### PR TITLE
Add hosts into the /etc/hosts of Codenvy on-prem from the new line

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
@@ -104,10 +104,10 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
             case 1:
                 return new MacroCommand(new ArrayList<Command>() {{
                     add(createCommand("if ! sudo grep -Eq \"127.0.0.1.*puppet\" /etc/hosts; then\n" +
-                                      " echo '127.0.0.1 puppet' | sudo tee --append /etc/hosts > /dev/null\n" +
+                                      " echo '\n127.0.0.1 puppet' | sudo tee --append /etc/hosts > /dev/null\n" +
                                       "fi"));
                     add(createCommand(format("if ! sudo grep -Eq \" %1$s$\" /etc/hosts; then\n" +
-                                             "  echo \"127.0.0.1 %1$s\" | sudo tee --append /etc/hosts > /dev/null\n" +
+                                             "  echo \"\n127.0.0.1 %1$s\" | sudo tee --append /etc/hosts > /dev/null\n" +
                                              "fi", config.getHostUrl())));
 
                     // install puppet rpm


### PR DESCRIPTION
@tolusha: please, review my request. on-prem
This fix will allow to avoid situation when, after installing Codenvy, there will be next content of /etc/hosts initially without EOF at the end:

> 127.0.0.1 localhost127.0.0.1 puppet
