### PR TITLE
Fix workspace updating on stop by timeout

### DIFF
--- a/core/codenvy-hosted-workspace-activity/src/main/java/com/codenvy/activity/server/WorkspaceActivityManager.java
+++ b/core/codenvy-hosted-workspace-activity/src/main/java/com/codenvy/activity/server/WorkspaceActivityManager.java
@@ -116,10 +116,10 @@ public class WorkspaceActivityManager {
                 try {
                     String workspaceId = workspaceExpireEntry.getKey();
 
-                    workspaceManager.stopWorkspace(workspaceId);
                     Workspace workspace = workspaceManager.getWorkspace(workspaceId);
                     workspace.getAttributes().put(WORKSPACE_STOPPED_BY, ACTIVITY_CHECKER);
                     workspaceManager.updateWorkspace(workspaceId, workspace);
+                    workspaceManager.stopWorkspace(workspaceId);
                 } catch (NotFoundException e) {
                     LOG.info("Workspace already stopped");
                 } catch (Exception ex) {


### PR DESCRIPTION
Perform update, and then stop workspace.
Stopping will asynchronously update workspace, so make sure there will be our attribute.