### PR TITLE
CODENVY-349 Rename workspace agent packaged war name

### DIFF
--- a/assembly/onpremises-ide-packaging-tomcat-ext-server/src/assembly/assembly.xml
+++ b/assembly/onpremises-ide-packaging-tomcat-ext-server/src/assembly/assembly.xml
@@ -33,7 +33,7 @@
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>
             <outputDirectory>webapps</outputDirectory>
-            <outputFileNameMapping>api.war</outputFileNameMapping>
+            <outputFileNameMapping>wsagent.war</outputFileNameMapping>
             <includes>
                 <include>com.codenvy.onpremises:onpremises-ide-packaging-war-ext-server</include>
             </includes>

--- a/assembly/onpremises-ide-packaging-war-ext-server/src/main/java/com/codenvy/ext/java/server/MachineServletModule.java
+++ b/assembly/onpremises-ide-packaging-war-ext-server/src/main/java/com/codenvy/ext/java/server/MachineServletModule.java
@@ -49,6 +49,6 @@ public class MachineServletModule extends ServletModule {
         serve("/swaggerinit").with(io.swagger.jaxrs.config.DefaultJaxrsConfig.class, ImmutableMap
                 .of("api.version", "1.0",
                     "swagger.api.title", "Eclipse Che",
-                    "swagger.api.basepath", "/api/ext"));
+                    "swagger.api.basepath", "/wsagent/ext"));
     }
 }

--- a/assembly/onpremises-ide-packaging-war-ide-resources/src/main/webapp/initializer/init.js
+++ b/assembly/onpremises-ide-packaging-war-ide-resources/src/main/webapp/initializer/init.js
@@ -331,7 +331,7 @@ var Initializer = new function () {
         "hiddenFiles": ".*",
         "facebookLikeURL": "/ide-resources/_app/facebook-like.html",
         "googleLikeURL": "/ide-resources/_app/google-like.html",
-        "cheExtensionPath": "/api/ext"
+        "cheExtensionPath": "/wsagent/ext"
     };
 
     /**


### PR DESCRIPTION
Changed workspace agent war name from "api.war" to "wsagent.war"
@eivantsov We might need to update docs for Codenvy.