### PR TITLE
CODENVY-1938: Add error code & attributes for limit exception

### DIFF
--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/ErrorCodes.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/ErrorCodes.java
@@ -1,0 +1,29 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.api;
+
+/**
+ * Defines error codes, defined codes MUST NOT conflict with
+ * existing {@link org.eclipse.che.api.core.ErrorCodes}, error codes must
+ * be in range <b>10000-14999</b> inclusive.
+ *
+ * @author Yevhenii Voevodin
+ */
+public final class ErrorCodes {
+
+    public static final int LIMIT_EXCEEDED = 10000;
+
+    private ErrorCodes() {}
+}

--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitExceededException.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitExceededException.java
@@ -14,7 +14,13 @@
  */
 package com.codenvy.api.workspace;
 
+import com.codenvy.api.ErrorCodes;
+
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.rest.shared.dto.ExtendedError;
+import org.eclipse.che.dto.server.DtoFactory;
+
+import java.util.Map;
 
 /**
  * Should be thrown when limit of some resource is exceeded
@@ -27,5 +33,12 @@ public class LimitExceededException extends ServerException {
 
     public LimitExceededException(String message) {
         super(message);
+    }
+
+    public LimitExceededException(String message, Map<String, String> attributes) {
+        super(DtoFactory.newDto(ExtendedError.class)
+                        .withMessage(message)
+                        .withAttributes(attributes)
+                        .withErrorCode(ErrorCodes.LIMIT_EXCEEDED));
     }
 }


### PR DESCRIPTION
Server response example:

```json
{
   "attributes":{
      "workspaces_count":"1",
      "used_ram":"1",
      "used_ram_unit":"gb",
      "free_ram":"0",
      "free_ram_unit":"gb"
   },
   "errorCode":10000,
   "message":"There are 1 running workspaces consuming 1GB RAM. Your current RAM limit is 0GB. You can stop other workspaces to free resources."
}

{  
   "attributes":{  
      "environment_max_ram":"16384",
      "environment_max_ram_unit":"mb",
      "environment_ram":"32000",
      "environment_ram_unit":"mb"
   },
   "errorCode":10000,
   "message":"The maximum RAM per workspace is set to '16384mb' and you requested '32000mb'. This value is set by your admin with the 'limits.workspace.env.ram' property"
}

```


@skabashnyuk please review
