### PR TITLE
CHE-1061 Remove deprecations

### DIFF
--- a/analytics/analytics-application/src/main/webapp/WEB-INF/web.xml
+++ b/analytics/analytics-application/src/main/webapp/WEB-INF/web.xml
@@ -32,7 +32,7 @@
     </context-param>
 
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
 
     <listener>

--- a/analytics/analytics-tomcat-local-pkg/src/main/resources/analytics-application-basic-auth.web.xml
+++ b/analytics/analytics-tomcat-local-pkg/src/main/resources/analytics-application-basic-auth.web.xml
@@ -32,7 +32,7 @@
     </context-param>
 
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
 
     <listener>

--- a/assembly/onpremises-ide-packaging-war-ext-server/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/onpremises-ide-packaging-war-ext-server/src/main/webapp/WEB-INF/web.xml
@@ -26,7 +26,7 @@
         <param-value>/ext</param-value>
     </context-param>
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
     <listener>
         <listener-class>org.eclipse.che.everrest.ServerContainerInitializeListener</listener-class>

--- a/assembly/onpremises-ide-packaging-war-ide-resources/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/onpremises-ide-packaging-war-ide-resources/src/main/webapp/WEB-INF/web.xml
@@ -50,7 +50,7 @@
     </filter>
 
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
 
     <filter-mapping>

--- a/assembly/onpremises-ide-packaging-war-ide/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/onpremises-ide-packaging-war-ide/src/main/webapp/WEB-INF/web.xml
@@ -33,7 +33,7 @@
     </context-param>
 
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
     <filter>
         <filter-name>guiceFilter</filter-name>

--- a/assembly/onpremises-ide-packaging-war-platform-api/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/onpremises-ide-packaging-war-platform-api/src/main/webapp/WEB-INF/web.xml
@@ -36,7 +36,7 @@
     </resource-ref>
 
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
     <filter>
         <filter-name>guiceFilter</filter-name>

--- a/core/codenvy-hosted-mail-server/src/main/webapp/WEB-INF/web.xml
+++ b/core/codenvy-hosted-mail-server/src/main/webapp/WEB-INF/web.xml
@@ -24,7 +24,7 @@
     <display-name>eXo Cloud + IDE</display-name>
 
     <listener>
-        <listener-class>org.eclipse.che.inject.CodenvyBootstrap</listener-class>
+        <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>
     <filter>
         <filter-name>guiceFilter</filter-name>


### PR DESCRIPTION
1. CodenvyBootstrap
2. ExpirableCache
3. Deprecated methods in org.eclipse.che.commons.lang.IoUtil# modified: analytics/analytics-application/src/main/webapp/WEB-INF/web.xml
4. NamedThreadFactory
5. org.eclipse.che.commons.lang.cache.*