### PR TITLE
CODENVY-292 Escape factory DB query attributes

### DIFF
--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/MongoDBFactoryStore.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/MongoDBFactoryStore.java
@@ -191,7 +191,7 @@ public class MongoDBFactoryStore implements FactoryStore {
         final List<Factory> result = new ArrayList<>();
         Document query = new Document();
         for (Pair<String, String> one : attributes) {
-            query.append(format("factory.%s", one.first), one.second);
+            query.append(format("factory.%s", one.first), encode(one.second));
         }
         final FindIterable<Document> findIt = factories.find(query).skip(skipCount).limit(maxItems);
         for (Document one : findIt) {


### PR DESCRIPTION
Sometimes query attribute values can contain dots ("creator.userId" : "admin@codenvy.onprem").
It must be escaped, as it is stored in DB.