### PR TITLE
Codenvy 473: fix IM according to TIAA CREF requests

### DIFF
--- a/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/AbstractIMCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/AbstractIMCommand.java
@@ -96,7 +96,7 @@ public abstract class AbstractIMCommand extends AbsCommand {
         try {
             // get latest update of IM CLI client
             Artifact imArtifact = createArtifact(InstallManagerArtifact.NAME);
-            List<UpdateArtifactInfo> updates = facade.getAllUpdates(imArtifact, true);
+            List<UpdateArtifactInfo> updates = facade.getAllUpdatesAfterInstalledVersion(imArtifact);
             if (updates.isEmpty()) {
                 return;
             }

--- a/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/AbstractIMCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/AbstractIMCommand.java
@@ -96,7 +96,7 @@ public abstract class AbstractIMCommand extends AbsCommand {
         try {
             // get latest update of IM CLI client
             Artifact imArtifact = createArtifact(InstallManagerArtifact.NAME);
-            List<UpdateArtifactInfo> updates = facade.getAllUpdates(imArtifact);
+            List<UpdateArtifactInfo> updates = facade.getAllUpdates(imArtifact, true);
             if (updates.isEmpty()) {
                 return;
             }

--- a/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/DownloadCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/DownloadCommand.java
@@ -138,7 +138,7 @@ public class DownloadCommand extends AbstractIMCommand {
             artifact = ArtifactFactory.createArtifact(CDECArtifact.NAME);
         }
 
-        List<UpdateArtifactInfo> versions = facade.getAllUpdates(artifact, false);
+        List<UpdateArtifactInfo> versions = facade.getAllUpdates(artifact);
         List<UpdateArtifactInfo> versionsInReverseOrder = versions.stream().sorted((v1, v2) -> v1.compareTo(v2)).collect(Collectors.toList());
 
         console.println(toJson(versionsInReverseOrder));

--- a/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/DownloadCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/DownloadCommand.java
@@ -34,7 +34,9 @@ import org.eclipse.che.commons.json.JsonParseException;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.codenvy.im.utils.Commons.createArtifactOrNull;
 import static com.codenvy.im.utils.Commons.createVersionOrNull;
@@ -136,7 +138,9 @@ public class DownloadCommand extends AbstractIMCommand {
             artifact = ArtifactFactory.createArtifact(CDECArtifact.NAME);
         }
 
-        Collection<UpdateArtifactInfo> versions = facade.getAllUpdates(artifact, false);
-        console.println(toJson(versions));
+        List<UpdateArtifactInfo> versions = facade.getAllUpdates(artifact, false);
+        List<UpdateArtifactInfo> versionsInReverseOrder = versions.stream().sorted((v1, v2) -> v1.compareTo(v2)).collect(Collectors.toList());
+
+        console.println(toJson(versionsInReverseOrder));
     }
 }

--- a/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/VersionCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/VersionCommand.java
@@ -52,7 +52,7 @@ public class VersionCommand extends AbstractIMCommand {
             info.setLabel(installedCDEC.getLabel());
         }
 
-        List<UpdateArtifactInfo> updatesCodenvy = facade.getAllUpdates(ArtifactFactory.createArtifact(CDECArtifact.NAME));
+        List<UpdateArtifactInfo> updatesCodenvy = facade.getAllUpdates(ArtifactFactory.createArtifact(CDECArtifact.NAME), true);
         UpdateArtifactInfo latestStableVersionInfo = getLatestStableVersionInfo(updatesCodenvy);
 
         AvailableVersionInfo availableVersion = new AvailableVersionInfo();

--- a/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/VersionCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/main/java/com/codenvy/im/cli/command/VersionCommand.java
@@ -52,7 +52,7 @@ public class VersionCommand extends AbstractIMCommand {
             info.setLabel(installedCDEC.getLabel());
         }
 
-        List<UpdateArtifactInfo> updatesCodenvy = facade.getAllUpdates(ArtifactFactory.createArtifact(CDECArtifact.NAME), true);
+        List<UpdateArtifactInfo> updatesCodenvy = facade.getAllUpdatesAfterInstalledVersion(ArtifactFactory.createArtifact(CDECArtifact.NAME));
         UpdateArtifactInfo latestStableVersionInfo = getLatestStableVersionInfo(updatesCodenvy);
 
         AvailableVersionInfo availableVersion = new AvailableVersionInfo();

--- a/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestDownloadCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestDownloadCommand.java
@@ -147,7 +147,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
                                   UpdateArtifactInfo.createInstance(codenvy.getName(),
                                                                     "1.0.2",
                                                                     UpdateArtifactInfo.Status.AVAILABLE_TO_DOWNLOAD)))
-            .when(service).getAllUpdates(codenvy, false);
+            .when(service).getAllUpdates(codenvy);
 
         CommandInvoker commandInvoker = new CommandInvoker(spyCommand, commandSession);
         commandInvoker.option("--list-remote", Boolean.TRUE);
@@ -177,7 +177,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
         UpdateArtifactInfo updateInfo = UpdateArtifactInfo.createInstance(imArtifact.getName(),
                                                                           versionToUpdate.toString(),
                                                                           UpdateArtifactInfo.Status.AVAILABLE_TO_DOWNLOAD);
-        doReturn(Collections.singletonList(updateInfo)).when(spyCommand.facade).getAllUpdates(imArtifact, true);
+        doReturn(Collections.singletonList(updateInfo)).when(spyCommand.facade).getAllUpdatesAfterInstalledVersion(imArtifact);
 
         doReturn(new DownloadProgressResponse(DownloadArtifactInfo.Status.DOWNLOADED, null, 100, Collections.EMPTY_LIST))
             .when(spyCommand.facade).getDownloadProgress();
@@ -210,7 +210,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
     public void testAutomaticUpdateCliWhenException() throws Exception {
         final Artifact imArtifact = createArtifact(InstallManagerArtifact.NAME);
 
-        doThrow(new RuntimeException("Error")).when(spyCommand.facade).getAllUpdates(imArtifact, true);
+        doThrow(new RuntimeException("Error")).when(spyCommand.facade).getAllUpdatesAfterInstalledVersion(imArtifact);
 
         CommandInvoker commandInvoker = new CommandInvoker(spyCommand, commandSession);
         commandInvoker.option("--list-local", Boolean.TRUE);
@@ -233,7 +233,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
         UpdateArtifactInfo updateInfo = UpdateArtifactInfo.createInstance(imArtifact.getName(),
                                                                           versionToUpdate.toString(),
                                                                           UpdateArtifactInfo.Status.AVAILABLE_TO_DOWNLOAD);
-        doReturn(Collections.singletonList(updateInfo)).when(spyCommand.facade).getAllUpdates(imArtifact, true);
+        doReturn(Collections.singletonList(updateInfo)).when(spyCommand.facade).getAllUpdatesAfterInstalledVersion(imArtifact);
 
         doReturn(new DownloadProgressResponse(DownloadArtifactInfo.Status.FAILED, "Download error.", 100, Collections.EMPTY_LIST))
             .when(spyCommand.facade).getDownloadProgress();
@@ -261,7 +261,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
         UpdateArtifactInfo updateInfo = UpdateArtifactInfo.createInstance(imArtifact.getName(),
                                                                           versionToUpdate.toString(),
                                                                           UpdateArtifactInfo.Status.AVAILABLE_TO_DOWNLOAD);
-        doReturn(Collections.singletonList(updateInfo)).when(spyCommand.facade).getAllUpdates(imArtifact, true);
+        doReturn(Collections.singletonList(updateInfo)).when(spyCommand.facade).getAllUpdatesAfterInstalledVersion(imArtifact);
 
         doReturn(new DownloadProgressResponse(DownloadArtifactInfo.Status.DOWNLOADED, null, 100, Collections.EMPTY_LIST))
             .when(spyCommand.facade).getDownloadProgress();

--- a/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestDownloadCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestDownloadCommand.java
@@ -156,7 +156,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
         String output = result.getOutputStream();
         assertEquals(output, "[ {\n"
                              + "  \"artifact\" : \"codenvy\",\n"
-                             + "  \"version\" : \"1.0.0\",\n"
+                             + "  \"version\" : \"1.0.2\",\n"
                              + "  \"status\" : \"AVAILABLE_TO_DOWNLOAD\"\n"
                              + "}, {\n"
                              + "  \"artifact\" : \"codenvy\",\n"
@@ -164,7 +164,7 @@ public class TestDownloadCommand extends AbstractTestCommand {
                              + "  \"status\" : \"DOWNLOADED\"\n"
                              + "}, {\n"
                              + "  \"artifact\" : \"codenvy\",\n"
-                             + "  \"version\" : \"1.0.2\",\n"
+                             + "  \"version\" : \"1.0.0\",\n"
                              + "  \"status\" : \"AVAILABLE_TO_DOWNLOAD\"\n"
                              + "} ]\n");
     }

--- a/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestVersionCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestVersionCommand.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -120,7 +121,7 @@ public class TestVersionCommand extends AbstractTestCommand {
     @Test(dataProvider="getTestVersionData")
     public void testCodenvyVersion(List<InstallArtifactInfo> installed, List<UpdateArtifactInfo> updates, String expectedOutput) throws Exception {
         doReturn(installed).when(facade).getInstalledVersions();
-        doReturn(updates).when(facade).getAllUpdates(any(Artifact.class));
+        doReturn(updates).when(facade).getAllUpdates(any(Artifact.class), eq(true));
 
         CommandInvoker commandInvoker = new CommandInvoker(spyCommand, commandSession);
 

--- a/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestVersionCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestVersionCommand.java
@@ -121,7 +121,7 @@ public class TestVersionCommand extends AbstractTestCommand {
     @Test(dataProvider="getTestVersionData")
     public void testCodenvyVersion(List<InstallArtifactInfo> installed, List<UpdateArtifactInfo> updates, String expectedOutput) throws Exception {
         doReturn(installed).when(facade).getInstalledVersions();
-        doReturn(updates).when(facade).getAllUpdates(any(Artifact.class), eq(true));
+        doReturn(updates).when(facade).getAllUpdatesAfterInstalledVersion(any(Artifact.class));
 
         CommandInvoker commandInvoker = new CommandInvoker(spyCommand, commandSession);
 

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/AbstractArtifact.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/AbstractArtifact.java
@@ -155,7 +155,7 @@ public abstract class AbstractArtifact implements Artifact {
      */
     protected List<Map.Entry<Artifact, Version>> getAllUpdates() throws IOException {
         DownloadManager downloadManager = getDownloadManager();
-        return downloadManager.getAllUpdates(this)
+        return downloadManager.getAllUpdates(this, true)
                               .stream()
                               .filter((Map.Entry<Artifact, Version> update) -> {
                                   Artifact artifact = update.getKey();

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMArtifactLabeledFacade.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMArtifactLabeledFacade.java
@@ -120,8 +120,8 @@ public class IMArtifactLabeledFacade extends InstallationManagerFacade {
 
     /** {@inheritDoc} */
     @Override
-    public List<UpdateArtifactInfo> getAllUpdates(@Nullable Artifact artifact) throws IOException, JsonParseException {
-        List<UpdateArtifactInfo> updates = super.getAllUpdates(artifact);
+    public List<UpdateArtifactInfo> getAllUpdates(@Nullable Artifact artifact, boolean fromInstalledVersion) throws IOException, JsonParseException {
+        List<UpdateArtifactInfo> updates = super.getAllUpdates(artifact, fromInstalledVersion);
         setVersionLabel(updates);
         return updates;
     }

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMArtifactLabeledFacade.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMArtifactLabeledFacade.java
@@ -120,8 +120,8 @@ public class IMArtifactLabeledFacade extends InstallationManagerFacade {
 
     /** {@inheritDoc} */
     @Override
-    public List<UpdateArtifactInfo> getAllUpdates(@Nullable Artifact artifact, boolean fromInstalledVersion) throws IOException, JsonParseException {
-        List<UpdateArtifactInfo> updates = super.getAllUpdates(artifact, fromInstalledVersion);
+    public List<UpdateArtifactInfo> getAllUpdatesAfterInstalledVersion(@Nullable Artifact artifact) throws IOException, JsonParseException {
+        List<UpdateArtifactInfo> updates = super.getAllUpdatesAfterInstalledVersion(artifact);
         setVersionLabel(updates);
         return updates;
     }

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMCliFilteredFacade.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMCliFilteredFacade.java
@@ -118,8 +118,8 @@ public class IMCliFilteredFacade extends IMArtifactLabeledFacade {
 
     /** {@inheritDoc} */
     @Override
-    public List<UpdateArtifactInfo> getAllUpdates(@Nullable Artifact artifact) throws IOException, JsonParseException {
-        List<UpdateArtifactInfo> updates = new ArrayList<>(super.getAllUpdates(artifact));
+    public List<UpdateArtifactInfo> getAllUpdates(@Nullable Artifact artifact, boolean fromInstalledVersion) throws IOException, JsonParseException {
+        List<UpdateArtifactInfo> updates = new ArrayList<>(super.getAllUpdates(artifact, fromInstalledVersion));
         removeImCliArtifact(updates);
         return updates;
     }

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMCliFilteredFacade.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/IMCliFilteredFacade.java
@@ -118,8 +118,8 @@ public class IMCliFilteredFacade extends IMArtifactLabeledFacade {
 
     /** {@inheritDoc} */
     @Override
-    public List<UpdateArtifactInfo> getAllUpdates(@Nullable Artifact artifact, boolean fromInstalledVersion) throws IOException, JsonParseException {
-        List<UpdateArtifactInfo> updates = new ArrayList<>(super.getAllUpdates(artifact, fromInstalledVersion));
+    public List<UpdateArtifactInfo> getAllUpdatesAfterInstalledVersion(@Nullable Artifact artifact) throws IOException, JsonParseException {
+        List<UpdateArtifactInfo> updates = new ArrayList<>(super.getAllUpdatesAfterInstalledVersion(artifact));
         removeImCliArtifact(updates);
         return updates;
     }

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/InstallationManagerFacade.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/InstallationManagerFacade.java
@@ -229,8 +229,8 @@ public class InstallationManagerFacade {
     /**
      * @see com.codenvy.im.managers.DownloadManager#getAllUpdates
      */
-    public List<UpdateArtifactInfo> getAllUpdates(Artifact artifact) throws IOException, JsonParseException {
-        Collection<Map.Entry<Artifact, Version>> allUpdates = downloadManager.getAllUpdates(artifact);
+    public List<UpdateArtifactInfo> getAllUpdates(Artifact artifact, boolean fromInstalledVersion) throws IOException, JsonParseException {
+        Collection<Map.Entry<Artifact, Version>> allUpdates = downloadManager.getAllUpdates(artifact, fromInstalledVersion);
 
         List<UpdateArtifactInfo> infos = new ArrayList<>();
 

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/InstallationManagerFacade.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/facade/InstallationManagerFacade.java
@@ -229,8 +229,22 @@ public class InstallationManagerFacade {
     /**
      * @see com.codenvy.im.managers.DownloadManager#getAllUpdates
      */
-    public List<UpdateArtifactInfo> getAllUpdates(Artifact artifact, boolean fromInstalledVersion) throws IOException, JsonParseException {
-        Collection<Map.Entry<Artifact, Version>> allUpdates = downloadManager.getAllUpdates(artifact, fromInstalledVersion);
+    public List<UpdateArtifactInfo> getAllUpdates(Artifact artifact) throws IOException, JsonParseException {
+        return getAllUpdates(artifact, false);
+    }
+
+    /**
+     * @see com.codenvy.im.managers.DownloadManager#getAllUpdates
+     */
+    public List<UpdateArtifactInfo> getAllUpdatesAfterInstalledVersion(Artifact artifact) throws IOException, JsonParseException {
+        return getAllUpdates(artifact, true);
+    }
+
+    /**
+     * @see com.codenvy.im.managers.DownloadManager#getAllUpdates
+     */
+    private List<UpdateArtifactInfo> getAllUpdates(Artifact artifact, boolean afterInstalledVersion) throws IOException, JsonParseException {
+        Collection<Map.Entry<Artifact, Version>> allUpdates = downloadManager.getAllUpdates(artifact, afterInstalledVersion);
 
         List<UpdateArtifactInfo> infos = new ArrayList<>();
 

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/ConfigManager.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/ConfigManager.java
@@ -456,13 +456,13 @@ public class ConfigManager {
 
         if (! StringUtils.isEmpty(httpProxyForCodenvy)) {
             codenvyProperties.put(Config.HTTP_PROXY, codenvyProperties.get(Config.HTTP_PROXY_FOR_CODENVY));
-        } else {
+        } else if (! StringUtils.isEmpty(systemProperties.get(Config.HTTP_PROXY))) {
             codenvyProperties.put(Config.HTTP_PROXY, systemProperties.get(Config.HTTP_PROXY));
         }
 
         if (! StringUtils.isEmpty(httpsProxyForCodenvy)) {
             codenvyProperties.put(Config.HTTPS_PROXY, codenvyProperties.get(Config.HTTPS_PROXY_FOR_CODENVY));
-        } else {
+        } else if (! StringUtils.isEmpty(systemProperties.get(Config.HTTPS_PROXY))) {
             codenvyProperties.put(Config.HTTPS_PROXY, systemProperties.get(Config.HTTPS_PROXY));
         }
     }

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/DownloadManager.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/DownloadManager.java
@@ -378,11 +378,11 @@ public class DownloadManager {
      * Gets all updates for given artifact.
      *
      * @param artifact artifact which versions should be returned;
-     * @param fromInstalledVersion <b>true</b> to return versions starting from installed one; <b>false</b> - to return all versions.
+     * @param afterInstalledVersion <b>true</b> to return versions newer than installed one; <b>false</b> - to return all versions.
      * @throws java.io.IOException
      *         if an I/O error occurred
      */
-    public Collection<Map.Entry<Artifact, Version>> getAllUpdates(@Nullable final Artifact artifact, boolean fromInstalledVersion) throws IOException {
+    public Collection<Map.Entry<Artifact, Version>> getAllUpdates(@Nullable final Artifact artifact, boolean afterInstalledVersion) throws IOException {
         ArrayList<Map.Entry<Artifact, Version>> allUpdates = new ArrayList<>();
 
         Set<Artifact> artifacts2Check;
@@ -394,7 +394,7 @@ public class DownloadManager {
 
         for (final Artifact art2Check : artifacts2Check) {
             Optional<Version> installedVersion = art2Check.getInstalledVersion();
-            boolean fromVersion = fromInstalledVersion && installedVersion.isPresent();
+            boolean fromVersion = afterInstalledVersion && installedVersion.isPresent();
             String requestUrl = combinePaths(updateEndpoint,
                                              "repository/updates",
                                              art2Check + (fromVersion ? "?fromVersion=" + installedVersion.get().toString() : ""));

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/DownloadManager.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/DownloadManager.java
@@ -377,10 +377,12 @@ public class DownloadManager {
     /**
      * Gets all updates for given artifact.
      *
+     * @param artifact artifact which versions should be returned;
+     * @param fromInstalledVersion <b>true</b> to return versions starting from installed one; <b>false</b> - to return all versions.
      * @throws java.io.IOException
      *         if an I/O error occurred
      */
-    public Collection<Map.Entry<Artifact, Version>> getAllUpdates(@Nullable final Artifact artifact) throws IOException {
+    public Collection<Map.Entry<Artifact, Version>> getAllUpdates(@Nullable final Artifact artifact, boolean fromInstalledVersion) throws IOException {
         ArrayList<Map.Entry<Artifact, Version>> allUpdates = new ArrayList<>();
 
         Set<Artifact> artifacts2Check;
@@ -392,9 +394,10 @@ public class DownloadManager {
 
         for (final Artifact art2Check : artifacts2Check) {
             Optional<Version> installedVersion = art2Check.getInstalledVersion();
+            boolean fromVersion = fromInstalledVersion && installedVersion.isPresent();
             String requestUrl = combinePaths(updateEndpoint,
                                              "repository/updates",
-                                             art2Check + (installedVersion.isPresent() ? "?fromVersion=" + installedVersion.get().toString() : ""));
+                                             art2Check + (fromVersion ? "?fromVersion=" + installedVersion.get().toString() : ""));
             try {
                 List<String> l = fromJson(transport.doGet(requestUrl), List.class);
                 allUpdates.addAll(FluentIterable.from(l).transform(new Function<String, Map.Entry<Artifact, Version>>() {

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestAbstractArtifact.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestAbstractArtifact.java
@@ -159,7 +159,7 @@ public class TestAbstractArtifact extends BaseTest {
             add(new AbstractMap.SimpleEntry<>(spyTestArtifact, Version.valueOf("1.0.2")));
             add(new AbstractMap.SimpleEntry<>(spyTestArtifact, Version.valueOf("1.0.3")));
             add(new AbstractMap.SimpleEntry<>(spyTestArtifact, Version.valueOf("1.0.4")));
-        }}).when(mockDownloadManager).getAllUpdates(spyTestArtifact);
+        }}).when(mockDownloadManager).getAllUpdates(spyTestArtifact, true);
 
         doReturn("1\\.0\\.(.*)").when(spyTestArtifact).getProperty(Version.valueOf("0.0.9"), PREVIOUS_VERSION_PROPERTY);
         doReturn("1\\.0\\.(.*)").when(spyTestArtifact).getProperty(Version.valueOf("1.0.0"), PREVIOUS_VERSION_PROPERTY);
@@ -187,7 +187,7 @@ public class TestAbstractArtifact extends BaseTest {
         doReturn(new ArrayList<Map.Entry<Artifact, Version>>() {{
             add(new AbstractMap.SimpleEntry<>(spyTestArtifact, Version.valueOf("1.0.0")));
             add(new AbstractMap.SimpleEntry<>(spyTestArtifact, Version.valueOf("1.0.1")));
-        }}).when(mockDownloadManager).getAllUpdates(spyTestArtifact);
+        }}).when(mockDownloadManager).getAllUpdates(spyTestArtifact, true);
 
         doReturn("1\\.0\\.(.*)").when(spyTestArtifact).getProperty(Version.valueOf("1.0.0"), PREVIOUS_VERSION_PROPERTY);
         doReturn("1\\.0\\.(.*)").when(spyTestArtifact).getProperty(Version.valueOf("1.0.1"), PREVIOUS_VERSION_PROPERTY);
@@ -207,7 +207,7 @@ public class TestAbstractArtifact extends BaseTest {
 
         doReturn(new ArrayList<Map.Entry<Artifact, Version>>() {{
             add(new AbstractMap.SimpleEntry<>(spyTestArtifact, Version.valueOf("1.0.3")));
-        }}).when(mockDownloadManager).getAllUpdates(spyTestArtifact);
+        }}).when(mockDownloadManager).getAllUpdates(spyTestArtifact, true);
 
         doReturn("1\\.0\\.2").when(spyTestArtifact).getProperty(Version.valueOf("1.0.3"), PREVIOUS_VERSION_PROPERTY);
         doReturn(VersionLabel.STABLE.toString()).when(spyTestArtifact).getProperty(Version.valueOf("1.0.3"), LABEL_PROPERTY);

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/IMArtifactLabeledFacadeTest.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/IMArtifactLabeledFacadeTest.java
@@ -154,7 +154,7 @@ public class IMArtifactLabeledFacadeTest extends BaseTest {
         }}).when(downloadManager).getDownloadedVersions(artifact);
         doReturn(VersionLabel.UNSTABLE).when(facade).fetchVersionLabel("codenvy", "1.0.1");
 
-        Collection<UpdateArtifactInfo> updates = facade.getAllUpdates(artifact, true);
+        Collection<UpdateArtifactInfo> updates = facade.getAllUpdatesAfterInstalledVersion(artifact);
 
         assertEquals(updates.size(), 1);
 

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/IMArtifactLabeledFacadeTest.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/IMArtifactLabeledFacadeTest.java
@@ -148,13 +148,13 @@ public class IMArtifactLabeledFacadeTest extends BaseTest {
     public void testGetAllUpdates() throws Exception {
         doReturn(new ArrayList<Map.Entry<Artifact, Version>>() {{
             add(new AbstractMap.SimpleEntry<>(artifact, version));
-        }}).when(downloadManager).getAllUpdates(artifact);
+        }}).when(downloadManager).getAllUpdates(artifact, true);
         doReturn(new TreeMap<Version, Path>() {{
             put(version, Paths.get("path"));
         }}).when(downloadManager).getDownloadedVersions(artifact);
         doReturn(VersionLabel.UNSTABLE).when(facade).fetchVersionLabel("codenvy", "1.0.1");
 
-        Collection<UpdateArtifactInfo> updates = facade.getAllUpdates(artifact);
+        Collection<UpdateArtifactInfo> updates = facade.getAllUpdates(artifact, true);
 
         assertEquals(updates.size(), 1);
 

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/TestInstallationManagerFacade.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/TestInstallationManagerFacade.java
@@ -490,7 +490,7 @@ public class TestInstallationManagerFacade extends BaseTest {
             put(Version.valueOf("1.0.1"), Paths.get("file1"));
         }}).when(downloadManager).getDownloadedVersions(cdecArtifact);
 
-        Collection<UpdateArtifactInfo> updates = installationManagerFacade.getAllUpdates(cdecArtifact, true);
+        Collection<UpdateArtifactInfo> updates = installationManagerFacade.getAllUpdatesAfterInstalledVersion(cdecArtifact);
         assertEquals(updates.size(), 2);
 
         Iterator<UpdateArtifactInfo> iter = updates.iterator();

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/TestInstallationManagerFacade.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/facade/TestInstallationManagerFacade.java
@@ -222,8 +222,8 @@ public class TestInstallationManagerFacade extends BaseTest {
         installationManagerFacade.addNode("builder.node.com");
     }
 
-//    @Test(expectedExceptions = IllegalStateException.class,
-//          expectedExceptionsMessageRegExp = "Codenvy License is invalid or has unappropriated format.")
+    @Test(expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = "Codenvy License is invalid or has unappropriated format.")
     public void testAddNodeShouldFailedWhenLicenseInvalid() throws IOException {
         doReturn(ImmutableMap.of(cdecArtifact, Version.valueOf("4.0.0"))).when(installManager).getInstalledArtifacts();
         doThrow(new InvalidLicenseException("error")).when(codenvyLicenseManager).load();
@@ -233,8 +233,8 @@ public class TestInstallationManagerFacade extends BaseTest {
         verify(nodeManager, never()).add(anyString());
     }
 
-//    @Test(expectedExceptions = IllegalStateException.class,
-//          expectedExceptionsMessageRegExp = "Your Codenvy subscription only allows a single server.")
+    @Test(expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = "Your Codenvy subscription only allows a single server.")
     public void testAddNodeShouldFailedWhenLicenseNotFound() throws IOException {
         doReturn(ImmutableMap.of(cdecArtifact, Version.valueOf("4.0.0"))).when(installManager).getInstalledArtifacts();
         doThrow(new LicenseNotFoundException("error")).when(codenvyLicenseManager).load();
@@ -244,7 +244,7 @@ public class TestInstallationManagerFacade extends BaseTest {
         verify(nodeManager, never()).add(anyString());
     }
 
-//    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testAddNodeShouldFailedWhenEvaluationKeyExpired() throws IOException {
         doReturn(ImmutableMap.of(cdecArtifact, Version.valueOf("4.0.0"))).when(installManager).getInstalledArtifacts();
         doReturn(codenvyLicense).when(codenvyLicenseManager).load();
@@ -484,13 +484,13 @@ public class TestInstallationManagerFacade extends BaseTest {
         doReturn(new ArrayList<Map.Entry<Artifact, Version>>() {{
             add(new AbstractMap.SimpleEntry<>(cdecArtifact, Version.valueOf("1.0.1")));
             add(new AbstractMap.SimpleEntry<>(cdecArtifact, Version.valueOf("1.0.2")));
-        }}).when(downloadManager).getAllUpdates(cdecArtifact);
+        }}).when(downloadManager).getAllUpdates(cdecArtifact, true);
 
         doReturn(new TreeMap<Version, Path>() {{
             put(Version.valueOf("1.0.1"), Paths.get("file1"));
         }}).when(downloadManager).getDownloadedVersions(cdecArtifact);
 
-        Collection<UpdateArtifactInfo> updates = installationManagerFacade.getAllUpdates(cdecArtifact);
+        Collection<UpdateArtifactInfo> updates = installationManagerFacade.getAllUpdates(cdecArtifact, true);
         assertEquals(updates.size(), 2);
 
         Iterator<UpdateArtifactInfo> iter = updates.iterator();

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/managers/DownloadManagerTest.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/managers/DownloadManagerTest.java
@@ -539,7 +539,7 @@ public class DownloadManagerTest extends BaseTest {
         doReturn("[\"2.0.1\", \"2.0.2\"]").when(transport).doGet(endsWith("updates/codenvy?fromVersion=2.0.0"));
         doReturn(Optional.of(cdecVersion)).when(cdecArtifact).getInstalledVersion();
 
-        Collection<Map.Entry<Artifact, Version>> updates = downloadManager.getAllUpdates(cdecArtifact);
+        Collection<Map.Entry<Artifact, Version>> updates = downloadManager.getAllUpdates(cdecArtifact, true);
 
         assertEquals(updates.size(), 2);
     }
@@ -549,7 +549,7 @@ public class DownloadManagerTest extends BaseTest {
         doReturn("[\"2.0.1\"]").when(transport).doGet(endsWith("updates/codenvy"));
         doReturn(Optional.empty()).when(cdecArtifact).getInstalledVersion();
 
-        Collection<Map.Entry<Artifact, Version>> updates = downloadManager.getAllUpdates(cdecArtifact);
+        Collection<Map.Entry<Artifact, Version>> updates = downloadManager.getAllUpdates(cdecArtifact, true);
         assertEquals(updates.size(), 1);
     }
 

--- a/cdec/installation-manager-server-war/src/main/java/com/codenvy/im/service/InstallationManagerService.java
+++ b/cdec/installation-manager-server-war/src/main/java/com/codenvy/im/service/InstallationManagerService.java
@@ -238,7 +238,7 @@ public class InstallationManagerService {
                            @ApiResponse(code = 500, message = "Server error")})
     public Response getUpdates() {
         try {
-            Collection<UpdateArtifactInfo> updates = delegate.getAllUpdates(createArtifact(CDECArtifact.NAME));
+            Collection<UpdateArtifactInfo> updates = delegate.getAllUpdates(createArtifact(CDECArtifact.NAME), true);
             return Response.ok(updates).build();
         } catch (Exception e) {
             return handleException(e);

--- a/cdec/installation-manager-server-war/src/main/java/com/codenvy/im/service/InstallationManagerService.java
+++ b/cdec/installation-manager-server-war/src/main/java/com/codenvy/im/service/InstallationManagerService.java
@@ -238,7 +238,7 @@ public class InstallationManagerService {
                            @ApiResponse(code = 500, message = "Server error")})
     public Response getUpdates() {
         try {
-            Collection<UpdateArtifactInfo> updates = delegate.getAllUpdates(createArtifact(CDECArtifact.NAME), true);
+            Collection<UpdateArtifactInfo> updates = delegate.getAllUpdatesAfterInstalledVersion(createArtifact(CDECArtifact.NAME));
             return Response.ok(updates).build();
         } catch (Exception e) {
             return handleException(e);

--- a/cdec/installation-manager-server-war/src/test/java/com/codenvy/im/service/InstallationManagerServiceTest.java
+++ b/cdec/installation-manager-server-war/src/test/java/com/codenvy/im/service/InstallationManagerServiceTest.java
@@ -74,6 +74,7 @@ import static java.lang.String.format;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -210,7 +211,7 @@ public class InstallationManagerServiceTest {
 
     @Test
     public void testGetUpdatesShouldReturnOkStatus() throws Exception {
-        doReturn(Collections.emptyList()).when(mockFacade).getAllUpdates(any(Artifact.class));
+        doReturn(Collections.emptyList()).when(mockFacade).getAllUpdates(any(Artifact.class), eq(true));
 
         Response result = service.getUpdates();
         assertEquals(result.getStatus(), Response.Status.OK.getStatusCode());
@@ -218,7 +219,7 @@ public class InstallationManagerServiceTest {
 
     @Test
     public void testGetUpdatesShouldReturnErrorStatus() throws Exception {
-        doThrow(new IOException("error")).when(mockFacade).getAllUpdates(any(Artifact.class));
+        doThrow(new IOException("error")).when(mockFacade).getAllUpdates(any(Artifact.class), eq(true));
 
         Response result = service.getUpdates();
         assertEquals(result.getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/cdec/installation-manager-server-war/src/test/java/com/codenvy/im/service/InstallationManagerServiceTest.java
+++ b/cdec/installation-manager-server-war/src/test/java/com/codenvy/im/service/InstallationManagerServiceTest.java
@@ -74,7 +74,6 @@ import static java.lang.String.format;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -211,7 +210,7 @@ public class InstallationManagerServiceTest {
 
     @Test
     public void testGetUpdatesShouldReturnOkStatus() throws Exception {
-        doReturn(Collections.emptyList()).when(mockFacade).getAllUpdates(any(Artifact.class), eq(true));
+        doReturn(Collections.emptyList()).when(mockFacade).getAllUpdatesAfterInstalledVersion(any(Artifact.class));
 
         Response result = service.getUpdates();
         assertEquals(result.getStatus(), Response.Status.OK.getStatusCode());
@@ -219,7 +218,7 @@ public class InstallationManagerServiceTest {
 
     @Test
     public void testGetUpdatesShouldReturnErrorStatus() throws Exception {
-        doThrow(new IOException("error")).when(mockFacade).getAllUpdates(any(Artifact.class), eq(true));
+        doThrow(new IOException("error")).when(mockFacade).getAllUpdatesAfterInstalledVersion(any(Artifact.class));
 
         Response result = service.getUpdates();
         assertEquals(result.getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/cdec/installation-manager-tests/src/main/resources/bin/im-download/test-download-all-updates.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/im-download/test-download-all-updates.sh
@@ -31,6 +31,9 @@ validateExpectedString ".*\"artifact\".\:.\"codenvy\".*\"version\".\:.\"${LATEST
 executeIMCommand "im-download" "--list-local"
 validateExpectedString ".*\"artifact\".\:.\"codenvy\".*\"version\".\:.\"${LATEST_STABLE_CODENVY_VERSION}\".*\"file\".\:.\".*codenvy-${LATEST_STABLE_CODENVY_VERSION}.zip\".*\"status\".\:.\"READY_TO_INSTALL\".*"
 
+executeIMCommand "im-download" "--list-remote"
+validateExpectedString ".*\"artifact\".\:.\"codenvy\".*\"version\".\:.\"${PREV_CODENVY3_VERSION}\".*\"file\".\:.\".*codenvy-${PREV_CODENVY3_VERSION}.zip\".*\"status\".\:.\"AVAILABLE_TO_DOWNLOAD\".*"
+
 executeIMCommand "--valid-exit-code=1" "im-download" "unknown"
 executeIMCommand "--valid-exit-code=1" "im-download" "codenvy" "1.0.0"
 


### PR DESCRIPTION
Issues:
1) add '--list-remote' option of 'im-download' command to display all available versions in reverse order
2) fix setting proxy settings in codenvy properties when there is no http(s)_proxy environment variables.

@tolusha: please, review this request.