### PR TITLE
CODENVY-543: replace '&' on '\&' in right part of sed command

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/commands/CommandLibrary.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/commands/CommandLibrary.java
@@ -80,7 +80,7 @@ public class CommandLibrary {
     public static Command createReplaceCommand(String file, String replacingToken, String replacement, boolean withSudo) {
         String cmd = format("sudo cat %3$s | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|%1$s|%2$2s|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %3$s",
                             replacingToken,
-                            replacement.replace("\\$", "\\\\$").replace("\n", "\\n"),
+                            replacement.replace("\\$", "\\\\$").replace("\n", "\\n").replace("&", "\\&"), // http://sed.sourceforge.net/sedfaq3.html: "To enter a literal ampersand on the RHS, type '\&'."
                             file);
         return createCommand(withSudo ? cmd : cmd.replace("sudo ", ""));
     }

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/commands/TestCommandLibrary.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/commands/TestCommandLibrary.java
@@ -97,16 +97,16 @@ public class TestCommandLibrary extends BaseTest {
         Path testFile = Paths.get("target/testFile");
         write(testFile.toFile(), "old\n");
 
-        Command testCommand = createReplaceCommand(testFile.toString(), "old", "\\$new", false);
+        Command testCommand = createReplaceCommand(testFile.toString(), "old", "\\$new &&", false);
         assertEquals(testCommand.toString(), "{'command'='cat target/testFile " +
                                              "| sed ':a;N;$!ba;s/\\n/~n/g' " +
-                                             "| sed 's|old|\\\\$new|g' " +
+                                             "| sed 's|old|\\\\$new \\&\\&|g' " +
                                              "| sed 's|~n|\\n|g' > tmp.tmp " +
                                              "&& mv tmp.tmp target/testFile', 'agent'='LocalAgent'}");
         testCommand.execute();
 
         String content = readFileToString(testFile.toFile());
-        assertEquals(content, "\\$new\n");
+        assertEquals(content, "\\$new &&\n");
     }
 
     @Test

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy4/test-update-single-node-from-binary-with-codenvy4.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy4/test-update-single-node-from-binary-with-codenvy4.sh
@@ -27,7 +27,6 @@ authWithoutRealmAndServerDns "newadmin" "new-password"
 
 executeIMCommand "im-download" "codenvy" "${LATEST_CODENVY4_VERSION}"
 
-# put correct config into binaries
 BINARIES="/home/vagrant/codenvy-im-data/updates/codenvy/${LATEST_CODENVY4_VERSION}/codenvy-${LATEST_CODENVY4_VERSION}.zip"
 
 # install from local folder


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>