### PR TITLE
CODENVY-348 Disable workspaceId Environment init filter for workspace service 

### DIFF
--- a/assembly/onpremises-ide-packaging-war-platform-api/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiServletModule.java
+++ b/assembly/onpremises-ide-packaging-war-platform-api/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiServletModule.java
@@ -44,8 +44,6 @@ public class OnPremisesIdeApiServletModule extends ServletModule {
                "/gae-validator/*",
                "/gae-parameters/*")
                 .through(com.codenvy.service.http.WorkspaceIdEnvironmentInitializationFilter.class);
-        filterRegex("^/workspace/(?!config$|runtime$|.*:.*$).+")
-                .through(com.codenvy.service.http.WorkspaceIdEnvironmentInitializationFilter.class);
         filter("/factory/*",
                "/activity/*",
                "/workspace/*",


### PR DESCRIPTION
We don't need this filter to be mapped for WorkspaceService and it conflicts with workspace getByKey method