### PR TITLE
Fix maven groupid for wsagent artifact

### DIFF
--- a/assembly/onpremises-ide-packaging-war-ext-server/pom.xml
+++ b/assembly/onpremises-ide-packaging-war-ext-server/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>codenvy-hosted-workspace-activity-agent</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codenvy.hosted-infrastructure</groupId>
+            <groupId>com.codenvy.onpremises</groupId>
             <artifactId>wsagent-codenvy</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -277,11 +277,6 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.codenvy.hosted-infrastructure</groupId>
-                <artifactId>wsagent-codenvy</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.codenvy.im</groupId>
                 <artifactId>installation-manager-cli-bundle</artifactId>
                 <version>${project.version}</version>
@@ -424,6 +419,11 @@
                 <artifactId>onpremises-ide-packaging-war-website-codenvy</artifactId>
                 <version>${project.version}</version>
                 <type>war</type>
+            </dependency>
+            <dependency>
+                <groupId>com.codenvy.onpremises</groupId>
+                <artifactId>wsagent-codenvy</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.codenvy.platform-api-client-java</groupId>

--- a/wsagent/pom.xml
+++ b/wsagent/pom.xml
@@ -18,10 +18,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>codenvy-hosted-infrastructure-parent</artifactId>
-        <groupId>com.codenvy.hosted-infrastructure</groupId>
+        <artifactId>onpremises-assembly-parent</artifactId>
+        <groupId>com.codenvy.onpremises</groupId>
         <version>4.3.0-RC2-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>codenvy-agent-parent</artifactId>
     <version>4.3.0-RC2-SNAPSHOT</version>

--- a/wsagent/wsagent-codenvy/pom.xml
+++ b/wsagent/wsagent-codenvy/pom.xml
@@ -19,9 +19,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>codenvy-agent-parent</artifactId>
-        <groupId>com.codenvy.hosted-infrastructure</groupId>
+        <groupId>com.codenvy.onpremises</groupId>
         <version>4.3.0-RC2-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>wsagent-codenvy</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
During assembly wsagent artifact, warnings occurs, to avoid that we shoud use correct group id for ws agent parent and wsagent codenvy artifacts.
@skabashnyuk 