### PR TITLE
Replace codenvy-dev.com SaaS server on a1.codenvy-dev.com

### DIFF
--- a/cdec/installation-manager-core/pom.xml
+++ b/cdec/installation-manager-core/pom.xml
@@ -397,7 +397,7 @@
                                         </replace>
                                         <replace file="${project.build.directory}/classes/codenvy/installation-manager.properties">
                                             <replacetoken>saas.api.endpoint=https://codenvy.com/api</replacetoken>
-                                            <replacevalue>saas.api.endpoint=http://codenvy-dev.com/api</replacevalue>
+                                            <replacevalue>saas.api.endpoint=http://a1.codenvy-dev.com/api</replacevalue>
                                         </replace>
                                         <tstamp>
                                             <format offset="1" pattern="MM/dd/yyyy hh:mm aa" property="touch.time" unit="minute" />

--- a/cdec/installation-manager-tests/src/main/resources/bin/config.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/config.sh
@@ -18,7 +18,7 @@
 
 UPDATE_SERVER="http://updater-nightly.codenvy-dev.com"
 UPDATE_SERVICE="${UPDATE_SERVER}/update"
-SAAS_SERVER="http://codenvy-dev.com"
+SAAS_SERVER="http://a1.codenvy-dev.com"
 TEST_LOG="installation-manager-test.log"
 HOST_URL="codenvy"
 NEW_HOST_URL="test.codenvy"

--- a/cdec/upload-installation-manager.sh
+++ b/cdec/upload-installation-manager.sh
@@ -101,7 +101,7 @@ uploadCodenvySingleServerInstallProperties() {
         doUpload
         [ "${SERVER}" == "stg" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/saas_api_endpoint=https:\/\/codenvy.com\/api/saas_api_endpoint=https:\/\/codenvy-stg.com\/api/g' ${DESTINATION}/${FILENAME}"
         [ "${SERVER}" == "stg" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/installation_manager_update_server_endpoint=https:\/\/codenvy.com\/update/installation_manager_update_server_endpoint=https:\/\/codenvy-stg.com\/update/g' ${DESTINATION}/${FILENAME}"
-        [ "${SERVER}" == "ngt" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/saas_api_endpoint=https:\/\/codenvy.com\/api/saas_api_endpoint=http:\/\/codenvy-dev.com\/api/g' ${DESTINATION}/${FILENAME}"
+        [ "${SERVER}" == "ngt" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/saas_api_endpoint=https:\/\/codenvy.com\/api/saas_api_endpoint=http:\/\/a1.codenvy-dev.com\/api/g' ${DESTINATION}/${FILENAME}"
         [ "${SERVER}" == "ngt" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/installation_manager_update_server_endpoint=https:\/\/codenvy.com\/update/installation_manager_update_server_endpoint=http:\/\/updater-nightly.codenvy-dev.com\/update/g' ${DESTINATION}/${FILENAME}"
     fi
 }
@@ -117,7 +117,7 @@ uploadCodenvyMultiServerInstallProperties() {
         doUpload
         [ "${SERVER}" == "stg" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/saas_api_endpoint=https:\/\/codenvy.com\/api/saas_api_endpoint=https:\/\/codenvy-stg.com\/api/g' ${DESTINATION}/${FILENAME}"
         [ "${SERVER}" == "stg" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/installation_manager_update_server_endpoint=https:\/\/codenvy.com\/update/installation_manager_update_server_endpoint=https:\/\/codenvy-stg.com\/update/g' ${DESTINATION}/${FILENAME}"
-        [ "${SERVER}" == "ngt" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/saas_api_endpoint=https:\/\/codenvy.com\/api/saas_api_endpoint=http:\/\/codenvy-dev.com\/api/g' ${DESTINATION}/${FILENAME}"
+        [ "${SERVER}" == "ngt" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/saas_api_endpoint=https:\/\/codenvy.com\/api/saas_api_endpoint=http:\/\/a1.codenvy-dev.com\/api/g' ${DESTINATION}/${FILENAME}"
         [ "${SERVER}" == "ngt" ] && ssh -i ${SSH_KEY_NAME} ${SSH_AS_USER_NAME}@${AS_IP} "sed -i 's/installation_manager_update_server_endpoint=https:\/\/codenvy.com\/update/installation_manager_update_server_endpoint=http:\/\/updater-nightly.codenvy-dev.com\/update/g' ${DESTINATION}/${FILENAME}"
     fi
 }


### PR DESCRIPTION
Replace codenvy-dev.com SaaS server on a1.codenvy-dev.com in integration tests.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>