### PR TITLE
CODENVY-666: Fix accepting of the factories by the existing URLs

### DIFF
--- a/assembly/onpremises-ide-packaging-war-factory/src/main/java/com/codenvy/onpremises/factory/deploy/FactoryServletModule.java
+++ b/assembly/onpremises-ide-packaging-war-factory/src/main/java/com/codenvy/onpremises/factory/deploy/FactoryServletModule.java
@@ -14,6 +14,7 @@
  */
 package com.codenvy.onpremises.factory.deploy;
 
+import com.codenvy.onpremises.factory.filter.RemoveIllegalCharactersFactoryURLFilter;
 import com.google.inject.name.Names;
 import com.google.inject.servlet.ServletModule;
 
@@ -33,6 +34,7 @@ public class FactoryServletModule extends ServletModule {
     @Override
     protected void configureServlets() {
         filterRegex(PASS_RESOURCES_REGEXP).through(com.codenvy.onpremises.factory.filter.BrowserCheckerFilter.class);
+        filterRegex(PASS_RESOURCES_REGEXP).through(RemoveIllegalCharactersFactoryURLFilter.class);
         filterRegex(PASS_RESOURCES_REGEXP).through(com.codenvy.onpremises.factory.filter.FactoryParamsFilter.class);
         filterRegex(PASS_RESOURCES_REGEXP).through(com.codenvy.auth.sso.client.LoginFilter.class);
         filterRegex(PASS_RESOURCES_REGEXP).through(com.codenvy.onpremises.factory.filter.FactoryRetrieverFilter.class);

--- a/assembly/onpremises-ide-packaging-war-factory/src/main/java/com/codenvy/onpremises/factory/filter/RemoveIllegalCharactersFactoryURLFilter.java
+++ b/assembly/onpremises-ide-packaging-war-factory/src/main/java/com/codenvy/onpremises/factory/filter/RemoveIllegalCharactersFactoryURLFilter.java
@@ -1,0 +1,108 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.onpremises.factory.filter;
+
+import javax.inject.Singleton;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Allows to accept the factories by the URLs with old username.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class RemoveIllegalCharactersFactoryURLFilter implements Filter {
+
+    protected static final String USER_NAME = "user";
+
+    private static final Pattern ILLEGAL_USERNAME_CHARACTERS = Pattern.compile("[^a-zA-Z0-9]");
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+                                                                                                     ServletException {
+        chain.doFilter(new NormalizeFactoryUrlRequestWrapper(((HttpServletRequest)request)), response);
+    }
+
+    @Override
+    public void destroy() {}
+
+    /** Normalizes each username parameter in factory URLs by removing invalid characters. */
+    private class NormalizeFactoryUrlRequestWrapper extends HttpServletRequestWrapper {
+
+        public NormalizeFactoryUrlRequestWrapper(HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            final Map<String, String[]> params = super.getParameterMap();
+            final String[] users = params.get(USER_NAME);
+            if (users != null && users.length > 0) {
+                // normalize each parameter value that contains invalid username
+                for (int i = 0; i < users.length; i++) {
+                    users[i] = replaceInvalidCharacters(users[i]);
+                }
+                final HashMap<String, String[]> normalizeParams = new HashMap<>(params);
+                normalizeParams.put(USER_NAME, users);
+                return normalizeParams;
+            }
+            return params;
+        }
+
+        @Override
+        public String getParameter(String name) {
+            final String parameter = super.getParameter(name);
+            if (name.equals(USER_NAME) && parameter != null) {
+                return replaceInvalidCharacters(parameter);
+            }
+            return parameter;
+        }
+
+        @Override
+        public String getQueryString() {
+            String query = super.getQueryString();
+            if (query != null) {
+                // normalize each query value that contains invalid username
+                final String[] queryParams = query.split("&");
+                final String queryParamName = USER_NAME + '=';
+                for (String param : queryParams) {
+                    if (param.contains(queryParamName)) {
+                        final String user = param.substring(queryParamName.length(), param.length());
+                        query = query.replaceFirst(param, param.replace(user, replaceInvalidCharacters(user)));
+                    }
+                }
+            }
+            return query;
+        }
+
+        private String replaceInvalidCharacters(String username) {
+            return ILLEGAL_USERNAME_CHARACTERS.matcher(username).replaceAll("");
+        }
+    }
+}

--- a/assembly/onpremises-ide-packaging-war-factory/src/test/java/com/codenvy/onpremises/factory/filter/FactoryUrlFormatterFilterTest.java
+++ b/assembly/onpremises-ide-packaging-war-factory/src/test/java/com/codenvy/onpremises/factory/filter/FactoryUrlFormatterFilterTest.java
@@ -1,0 +1,138 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.onpremises.factory.filter;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+
+import static com.codenvy.onpremises.factory.filter.RemoveIllegalCharactersFactoryURLFilter.USER_NAME;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for {@link RemoveIllegalCharactersFactoryURLFilter}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(value = {MockitoTestNGListener.class})
+public class FactoryUrlFormatterFilterTest {
+
+    @Mock
+    private HttpServletRequest                  requestMock;
+    @Mock
+    private HttpServletResponse                 responseMock;
+    @Mock
+    private FilterChain                         chainMock;
+    @Captor
+    private ArgumentCaptor<HttpServletRequest>  requestCaptor;
+    @Captor
+    private ArgumentCaptor<HttpServletResponse> responseCaptor;
+
+    private RemoveIllegalCharactersFactoryURLFilter filter;
+
+    @BeforeMethod
+    public void setup() {
+        filter = new RemoveIllegalCharactersFactoryURLFilter();
+    }
+
+    @Test
+    public void shouldReplaceUsernameInRequestQueryString() throws Exception {
+        final String query = "name=test&user=user@codenvy.com";
+        when(requestMock.getQueryString()).thenReturn(query);
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getQueryString(), "name=test&user=usercodenvycom");
+    }
+
+    @Test
+    public void shouldReturnRequestQueryString() throws Exception {
+        final String query = "user=usercodenvycom&user=user2codenvycom";
+        when(requestMock.getQueryString()).thenReturn(query);
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getQueryString(), query);
+    }
+
+    @Test
+    public void shouldReplaceUsernameParameter() throws Exception {
+        final String username = "user@codenvy.com";
+        when(requestMock.getParameter(USER_NAME)).thenReturn(username);
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getParameter(USER_NAME), "usercodenvycom");
+    }
+
+    @Test
+    public void shouldReturnNotUsernameParameter() throws Exception {
+        final String param = "param";
+        when(requestMock.getParameter(param)).thenReturn(param);
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getParameter(param), param);
+    }
+
+    @Test
+    public void shouldReplaceUsernameInRequestParameterMap() throws Exception {
+        final String[] usernames = {"user@codenvy.com"};
+        when(requestMock.getParameterMap()).thenReturn(new HashMap<>(singletonMap(USER_NAME, usernames)));
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getParameterMap().get(USER_NAME)[0], "usercodenvycom");
+    }
+
+    @Test
+    public void shouldReplaceAllInvalidQueryParameters() throws Exception {
+        final String query = "user=qwe@mail.com&name=johny&user=username&user=wtf@gmail.com";
+        when(requestMock.getQueryString()).thenReturn(query);
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getQueryString(), "user=qwemailcom&name=johny&user=username&user=wtfgmailcom");
+    }
+
+    @Test
+    public void shouldReturnNullWhenQueryNull() throws Exception {
+        final String query = null;
+        when(requestMock.getQueryString()).thenReturn(query);
+
+        filter.doFilter(requestMock, responseMock, chainMock);
+
+        verify(chainMock).doFilter(requestCaptor.capture(), responseCaptor.capture());
+        assertEquals(requestCaptor.getValue().getQueryString(), query);
+    }
+}


### PR DESCRIPTION
After migration of user names all the factory URLs that contains the old names e.g("user@mail.com") became invalid, this pr should fix this problem.
@skabashnyuk, @garagatyi 