### PR TITLE
CODENVY-706: check if there is subscription-manager command in RHEL OS

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -1366,6 +1366,11 @@ doCheckResourceAccess() {
 }
 
 doCheckRedhatSubscription() {
+    # check if subscription-manager exists in system
+    if ! sudo subscription-manager &> /dev/null; then
+        return
+    fi
+
     # check validity of subscription
     if ! sudo subscription-manager status &> /dev/null; then
         local reposToDisplay=$(printf "'%s', " "${RHEL_REPOS[@]}")


### PR DESCRIPTION
CODENVY-706: check if there is subscription-manager command in RHEL OS when checking subscription in Codenvy bootstrap script.

@riuvshin: please, review this request.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>