### PR TITLE
CODENVY-651 Use 'dev' instead 'isDev' for machine configs in Mongo

### DIFF
--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/SnapshotImplCodec.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/SnapshotImplCodec.java
@@ -59,7 +59,7 @@ public class SnapshotImplCodec implements Codec<SnapshotImpl> {
                                                 .append("envName", snapshot.getEnvName())
                                                 .append("type", snapshot.getType())
                                                 .append("namespace", snapshot.getNamespace())
-                                                .append("isDev", snapshot.isDev())
+                                                .append("dev", snapshot.isDev())
                                                 .append("creationDate", snapshot.getCreationDate())
                                                 .append("description", snapshot.getDescription())
                                                 .append(MACHINE_SOURCE, machineSourceDocument);
@@ -89,7 +89,7 @@ public class SnapshotImplCodec implements Codec<SnapshotImpl> {
                                          .setEnvName(document.getString("envName"))
                                          .setType(document.getString("type"))
                                          .setNamespace(document.getString("namespace"))
-                                         .setDev(document.getBoolean("isDev"))
+                                         .setDev(document.getBoolean("dev"))
                                          .setCreationDate(document.getLong("creationDate"))
                                          .setDescription(document.getString("description"))
                                          .setMachineSource(machineSource)

--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/WorkspaceDaoImpl.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/WorkspaceDaoImpl.java
@@ -105,7 +105,7 @@ import static java.util.Objects.requireNonNull;
  *                  },
  *                  "machineConfigs" : [
  *                      {
- *                          "isDev" : true,
+ *                          "dev" : true,
  *                          "name" : "dev",
  *                          "type" : "machine-type",
  *                          "limits" : {

--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/WorkspaceImplCodec.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/WorkspaceImplCodec.java
@@ -239,7 +239,7 @@ public class WorkspaceImplCodec implements Codec<WorkspaceImpl> {
 
     private static MachineConfigImpl asMachineConfig(Document document) {
         final MachineConfigImplBuilder builder = MachineConfigImpl.builder()
-                                                                  .setDev(document.getBoolean("isDev"))
+                                                                  .setDev(document.getBoolean("dev"))
                                                                   .setName(document.getString("name"))
                                                                   .setType(document.getString("type"));
         final Document sourceDocument = document.get("source", Document.class);
@@ -270,7 +270,7 @@ public class WorkspaceImplCodec implements Codec<WorkspaceImpl> {
     }
 
     private static Document asDocument(MachineConfigImpl config) {
-        final Document document = new Document().append("isDev", config.isDev())
+        final Document document = new Document().append("dev", config.isDev())
                                                 .append("name", config.getName())
                                                 .append("type", config.getType())
                                                 .append("envVariables", mapAsDocumentsList(config.getEnvVariables()));

--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/stack/StackDaoImpl.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/mongo/stack/StackDaoImpl.java
@@ -133,7 +133,7 @@ import static java.util.Objects.requireNonNull;
  *              },
  *              "machineConfigs" : [
  *                  {
- *                      "isDev" : true,
+ *                      "dev" : true,
  *                      "name" : "dev",
  *                      "type" : "machine-type",
  *                      "limits" : {

--- a/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/mongo/SnapshotDaoImplTest.java
+++ b/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/mongo/SnapshotDaoImplTest.java
@@ -253,7 +253,7 @@ public class SnapshotDaoImplTest {
         assertEquals(result.getString("envName"), snapshot.getEnvName(), "Environment name");
         assertEquals(result.getString("type"), snapshot.getType(), "Snapshot type");
         assertEquals(result.getString("namespace"), snapshot.getNamespace(), "Snapshot owner");
-        assertEquals(result.getBoolean("isDev").booleanValue(), snapshot.isDev(), "Snapshot isdev");
+        assertEquals(result.getBoolean("dev").booleanValue(), snapshot.isDev(), "Snapshot isdev");
         assertEquals(result.getLong("creationDate").longValue(), snapshot.getCreationDate(), "Snapshot creation date");
         assertEquals(result.getString("type"), snapshot.getType(), "Snapshot defaultEnvName");
 

--- a/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/mongo/StackDaoImplTest.java
+++ b/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/mongo/StackDaoImplTest.java
@@ -372,7 +372,7 @@ public class StackDaoImplTest extends BaseDaoTest {
                 final Document machineDoc = machineConfigs.get(i);
                 final MachineConfigImpl machine = environment.getMachineConfigs().get(i);
 
-                assertEquals(machineDoc.getBoolean("isDev"), Boolean.valueOf(machine.isDev()));
+                assertEquals(machineDoc.getBoolean("dev"), Boolean.valueOf(machine.isDev()));
                 assertEquals(machineDoc.getString("name"), machine.getName(), "Machine name");
                 assertEquals(machineDoc.getString("type"), machine.getType(), "Machine type");
                 if (machine.getSource() != null) {

--- a/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/mongo/WorkspaceDaoImplTest.java
+++ b/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/mongo/WorkspaceDaoImplTest.java
@@ -371,7 +371,7 @@ public class WorkspaceDaoImplTest {
                 final Document machineDoc = machineConfigs.get(i);
                 final MachineConfigImpl machine = environment.getMachineConfigs().get(i);
 
-                assertEquals(machineDoc.getBoolean("isDev"), Boolean.valueOf(machine.isDev()));
+                assertEquals(machineDoc.getBoolean("dev"), Boolean.valueOf(machine.isDev()));
                 assertEquals(machineDoc.getString("name"), machine.getName(), "Machine name");
                 assertEquals(machineDoc.getString("type"), machine.getType(), "Machine type");
                 if (machine.getSource() != null) {


### PR DESCRIPTION
change MachineConfigImpl field 'isDev' to 'dev', as it is done in MachineConfigDto.
It should fix consitensy problems.

Also it needs to make migrations of existing workspaces.