### PR TITLE
corrected javadoc

### DIFF
--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/vcs/hosting/NoVcsHostingServiceImplementationException.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/vcs/hosting/NoVcsHostingServiceImplementationException.java
@@ -25,7 +25,7 @@ public class NoVcsHostingServiceImplementationException extends Exception {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs an instance of {@link VcsHostingService}.
+     * Constructs an instance of {@link NoVcsHostingServiceImplementationException}.
      */
     public NoVcsHostingServiceImplementationException() {
         super("No implementation of the VcsHostingService for the current project");


### PR DESCRIPTION
the constructor’s javadoc must have been copypasted (or whatever).