### PR TITLE
CODENVY-411: Fix bug machine with name ws-machine already exists

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/SwarmDockerConnector.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/SwarmDockerConnector.java
@@ -98,7 +98,7 @@ public class SwarmDockerConnector extends DockerConnector {
     }
 
     private DockerException decorateMessage(DockerException e) {
-        if (e.getOriginError().contains("no resources available to schedule container")) {
+        if (e.getOriginError() != null && e.getOriginError().contains("no resources available to schedule container")) {
             e = new DockerException("The system is out of resources. Please contact your system admin.",
                                     e.getOriginError(),
                                     e.getStatus());


### PR DESCRIPTION
### What does this PR do?
Fix NPE in `SwarmDockerConnector`, which broke catch chain on create machine error

### What issues does this PR fix or reference?
[Fix](https://github.com/codenvy/codenvy/issues/411) wrong "Machine with name _machine-name_ already exists" error message and fix the cause of next fails of this workspace to start

### Previous Behavior
Sometimes shows useless error message  if creation of a machine fails and breaks next workspace starts

### New Behavior
Displays actual error message instead of "Machine with name _machine-name_ already exists"

### Tests written?
No