### PR TITLE
CODENVY-449; fix VSTS project URL matching regexp

### DIFF
--- a/assembly/onpremises-ide-packaging-war-ext-server/src/main/webapp/WEB-INF/classes/codenvy/che-machine-configuration.properties
+++ b/assembly/onpremises-ide-packaging-war-ext-server/src/main/webapp/WEB-INF/classes/codenvy/che-machine-configuration.properties
@@ -43,7 +43,7 @@ che.maven.server.path=${catalina.base}/maven-server
 
 git.server.uri.prefix=git
 che.user.workspaces.storage=/projects
-oauth.microsoft.git.pattern=https://([0-9a-zA-Z-_.%]+)\\.visualstudio\\.com/.+/_git/.+
+oauth.microsoft.git.pattern=https://([0-9a-zA-Z-_.%]+)\\.visualstudio\\.com/.*/?_git/.+
 
 #this path is relative to user home directory
 che.workspace.metadata = che/.workspace


### PR DESCRIPTION
### What does this PR do?
Fixes cloning projects from VSTS

Now VSTS URL's may or may not contains the collection name, e.g.:
with collection:
https://che-1.visualstudio.com/DefaultCollection/test/_git/che-core

without collection:
https://iedexmain1.visualstudio.com/_git/MyFirstProject
### What issues does this PR fix or reference?
#449 

### Tests written?
No

### Docs requirements?
None