### PR TITLE
codenvy-451: Fix clean up 'lastName' profile attribute.

### DIFF
--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/ldap/ProfileAttributesMapper.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/ldap/ProfileAttributesMapper.java
@@ -14,8 +14,6 @@
  */
 package com.codenvy.api.dao.ldap;
 
-import com.google.common.base.Strings;
-
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.commons.lang.Pair;
 
@@ -37,6 +35,7 @@ import java.util.Map;
 import static javax.naming.directory.DirContext.ADD_ATTRIBUTE;
 import static javax.naming.directory.DirContext.REMOVE_ATTRIBUTE;
 import static javax.naming.directory.DirContext.REPLACE_ATTRIBUTE;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Mapper is used for mapping LDAP Attributes to {@link ProfileImpl}.
@@ -128,7 +127,8 @@ public class ProfileAttributesMapper {
         }
 
         // LDAP's inetOrgPerson requires sn attribute to be not null or empty
-        if (Strings.isNullOrEmpty(update.get(allowedAttributes.get("sn")))) {
+        String snAttr = allowedAttributes.get("sn");
+        if (update.containsKey(snAttr) && isNullOrEmpty(update.get(snAttr))) {
             update.put(allowedAttributes.get("sn"), "<none>");
         }
 


### PR DESCRIPTION
### What does this PR do?
This pull request fix clean up 'lastName' profile attribute in case partial update by json which does not contains attribute 'lastName'

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/451

### Previous Behavior
If map with changes contains `lastName` attribute with empty value or null, we replace it to `<none>`. But if map does not contains `lastName` attribute we replace 'lastName' value to `<none>` too.

### New Behavior
We set `<none>` for lastName only if json with changes contains `lastName` attribute and it has null or empty value.

### Tests written?
No

### Docs requirements?
Include the content for all the docs changes required. 
1.  API changes: without changes.

@sleshchenko @evoevodin review please.

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>