### PR TITLE
CODENVY-454: Remove error log when machine was stopped while its backup task was in executor queue

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/WorkspaceFsBackupScheduler.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/WorkspaceFsBackupScheduler.java
@@ -86,7 +86,9 @@ public class WorkspaceFsBackupScheduler {
                                 backupWorkspaceInMachine(machine);
 
                                 lastMachineSynchronizationTime.put(machine.getId(), System.currentTimeMillis());
-                            } catch (NotFoundException | ServerException e) {
+                            } catch (NotFoundException ignore) {
+                                // it is ok, machine was stopped while this backup task was in the executor queue
+                            } catch (ServerException e) {
                                 LOG.error(e.getLocalizedMessage(), e);
                             } finally {
                                 devMachinesBackupsInProgress.remove(machineId);


### PR DESCRIPTION
### What does this PR do?
Handle machine not found exception in backup scheduler
### What issues does this PR fix or reference?
#454
### Previous Behavior
Logged error about attempt to backup stooped machine 
### New Behavior
Just skip backup in such case, because it is normal behaviour
### Tests written?
Yes