### PR TITLE
CODENVY-483; fix PR creation from own repo by sending name of origin

### DIFF
--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/steps/PushBranchOnOriginStep.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/steps/PushBranchOnOriginStep.java
@@ -29,6 +29,8 @@ import javax.inject.Inject;
 @Singleton
 public class PushBranchOnOriginStep implements Step {
 
+    private final static String ORIGIN_REMOTE_NAME = "origin";
+
     private final PushBranchStepFactory pushBranchStepFactory;
 
     @Inject
@@ -38,6 +40,7 @@ public class PushBranchOnOriginStep implements Step {
 
     @Override
     public void execute(final WorkflowExecutor executor, final Context context) {
+        context.setForkedRemoteName(ORIGIN_REMOTE_NAME);
         pushBranchStepFactory.create(this,
                                      context.getOriginRepositoryOwner(),
                                      context.getOriginRepositoryName())


### PR DESCRIPTION
### What does this PR do?
Fixes creation of pull requets into the own repo (when no forking performed)

### What issues does this PR fix or reference?
#483

### Previous Behavior
PR creation fails

### New Behavior
PR creation OK

### Tests written?
No

### Docs requirements?
Nope
