### PR TITLE
CHE-1989 Fix permissions checking in according to new namespace concept

### DIFF
--- a/core/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/WorkspacePermissionsFilter.java
+++ b/core/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/WorkspacePermissionsFilter.java
@@ -14,11 +14,14 @@
  */
 package com.codenvy.api.workspace.server.filters;
 
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceService;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.everrest.CheMethodInvokerFilter;
@@ -33,7 +36,6 @@ import static com.codenvy.api.workspace.server.WorkspaceDomain.DELETE;
 import static com.codenvy.api.workspace.server.WorkspaceDomain.DOMAIN_ID;
 import static com.codenvy.api.workspace.server.WorkspaceDomain.READ;
 import static com.codenvy.api.workspace.server.WorkspaceDomain.RUN;
-import static com.google.api.client.repackaged.com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Restricts access to methods of {@link WorkspaceService} by users' permissions
@@ -61,39 +63,46 @@ public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
 
         final Subject currentSubject = EnvironmentContext.getCurrent().getSubject();
         String action;
-        String workspaceId;
+        String key;
 
         switch (methodName) {
-            case "create": {
-                final String accountId = ((String)arguments[3]);
-                checkPermissionsToCreateWorkspaces(currentSubject, accountId);
+            case "getWorkspaces": //method accessible to every user
+                return;
+
+            case "getByNamespace": {
+                checkNamespaceAccess(currentSubject, ((String)arguments[1]));
                 return;
             }
 
-            case "startFromConfig":
-                String accountId = ((String)arguments[2]);
-                checkPermissionsToCreateWorkspaces(currentSubject, accountId);
+            case "create": {
+                checkNamespaceAccess(currentSubject, ((String)arguments[3]));
                 return;
+            }
+
+            case "startFromConfig": {
+                checkNamespaceAccess(currentSubject, ((String)arguments[2]));
+                return;
+            }
 
             case "delete":
-                workspaceId = ((String)arguments[0]);
+                key = ((String)arguments[0]);
                 action = DELETE;
                 break;
             case "createMachine":
             case "stop":
             case "startById":
             case "createSnapshot":
-                workspaceId = ((String)arguments[0]);
+                key = ((String)arguments[0]);
                 action = RUN;
                 break;
 
             case "getSnapshot":
-                workspaceId = ((String)arguments[0]);
+                key = ((String)arguments[0]);
                 action = READ;
                 break;
 
             case "getByKey":
-                workspaceId = getWorkspaceIdFromKey(((String)arguments[0]));
+                key = ((String)arguments[0]);
                 action = READ;
                 break;
 
@@ -107,41 +116,36 @@ public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
             case "addCommand":
             case "deleteCommand":
             case "updateCommand":
-                workspaceId = ((String)arguments[0]);
+                key = ((String)arguments[0]);
                 action = CONFIGURE;
                 break;
-
-            case "getWorkspaces": //method accessible to every user
-                return;
 
             default:
                 throw new ForbiddenException("The user does not have permission to perform this operation");
         }
 
-        if (!currentSubject.hasPermission(DOMAIN_ID, workspaceId, action)) {
-            throw new ForbiddenException("The user does not have permission to " + action + " workspace with id '" + workspaceId + "'");
+        final WorkspaceImpl workspace = workspaceManager.getWorkspace(key);
+        final String namespace = workspace.getNamespace();
+
+        if (currentSubject.getUserName().equals(namespace)) {
+            // user is authorized to perform any operation if workspace belongs to his personal account
+            return;
+        }
+
+        if (!currentSubject.hasPermission(DOMAIN_ID, workspace.getId(), action)) {
+            throw new ForbiddenException("The user does not have permission to " + action + " workspace with id '" + workspace.getId() + "'");
         }
     }
 
-    private void checkPermissionsToCreateWorkspaces(Subject subject, String accountId) throws ForbiddenException {
-        if (!isNullOrEmpty(accountId)) {
-            if (!subject.hasPermission("account", accountId, "createWorkspaces")) {
-                throw new ForbiddenException("The user does not have permission to create workspace in given account");
-            }
+    @VisibleForTesting
+    void checkNamespaceAccess(Subject currentSubject, String namespace) throws ForbiddenException {
+        if (namespace == null) {
+            //namespace will be defined as username by default
+            return;
         }
-    }
 
-    /**
-     * Get workspace id from composite key.
-     */
-    private String getWorkspaceIdFromKey(String key) throws NotFoundException, ServerException {
-        String[] parts = key.split(":", -1); // -1 is to prevent skipping trailing part
-        if (parts.length == 1) {
-            return key;
+        if (!currentSubject.getUserName().equals(namespace)) {
+            throw new ForbiddenException("User is not authorized to use given namespace");
         }
-        final String userName = parts[0];
-        final String wsName = parts[1];
-        final String namespace = userName.isEmpty() ? EnvironmentContext.getCurrent().getSubject().getUserName() : userName;
-        return workspaceManager.getWorkspace(wsName, namespace).getId();
     }
 }

--- a/core/codenvy-hosted-api-workspace/src/test/java/com/codenvy/api/workspace/server/filters/WorkspacePermissionsFilterTest.java
+++ b/core/codenvy-hosted-api-workspace/src/test/java/com/codenvy/api/workspace/server/filters/WorkspacePermissionsFilterTest.java
@@ -34,7 +34,9 @@ import org.everrest.core.RequestFilter;
 import org.everrest.core.resource.GenericResourceMethod;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -52,7 +54,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -65,16 +70,17 @@ import static org.testng.Assert.assertEquals;
  */
 @Listeners(value = {EverrestJetty.class, MockitoTestNGListener.class})
 public class WorkspacePermissionsFilterTest {
+    private static final String             USERNAME = "userok";
     @SuppressWarnings("unused")
-    private static final ApiExceptionMapper MAPPER = new ApiExceptionMapper();
+    private static final ApiExceptionMapper MAPPER   = new ApiExceptionMapper();
     @SuppressWarnings("unused")
-    private static final EnvironmentFilter  FILTER = new EnvironmentFilter();
+    private static final EnvironmentFilter  FILTER   = new EnvironmentFilter();
 
     @Mock
     WorkspaceManager workspaceManager;
 
-    @SuppressWarnings("unused")
     @InjectMocks
+    @Spy
     WorkspacePermissionsFilter permissionsFilter;
 
     @Mock
@@ -83,34 +89,59 @@ public class WorkspacePermissionsFilterTest {
     @Mock
     WorkspaceService service;
 
-    @Test
-    public void shouldCheckPermissionsByAccountDomainOnStartingFromConfig() throws Exception {
-        when(subject.hasPermission("account", "account123", "createWorkspaces")).thenReturn(true);
+    @Mock
+    WorkspaceImpl workspace;
 
-        final Response response = given().auth()
-                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
-                                         .contentType("application/json")
-                                         .when()
-                                         .post(SECURE_PATH + "/workspace/runtime?account=account123");
+    @BeforeMethod
+    public void setUp() throws Exception {
+        doNothing().when(permissionsFilter).checkNamespaceAccess(any(), any());
 
-        assertEquals(response.getStatusCode(), 204);
-        verify(service).startFromConfig(any(), any(), eq("account123"));
-        verify(subject).hasPermission(eq("account"), eq("account123"), eq("createWorkspaces"));
+        when(subject.getUserName()).thenReturn(USERNAME);
+        when(workspaceManager.getWorkspace(any())).thenReturn(workspace);
+        when(workspace.getNamespace()).thenReturn("namespace");
+        when(workspace.getId()).thenReturn("workspace123");
     }
 
     @Test
-    public void shouldCheckPermissionsByAccountDomainOnWorkspaceCreating() throws Exception {
-        when(subject.hasPermission("account", "account123", "createWorkspaces")).thenReturn(true);
-
+    public void shouldCheckNamespaceAccessOnWorkspaceCreation() throws Exception {
         final Response response = given().auth()
                                          .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
                                          .contentType("application/json")
                                          .when()
-                                         .post(SECURE_PATH + "/workspace?account=account123");
+                                         .post(SECURE_PATH + "/workspace?namespace=userok");
 
         assertEquals(response.getStatusCode(), 204);
-        verify(service).create(any(), any(), any(), eq("account123"));
-        verify(subject).hasPermission(eq("account"), eq("account123"), eq("createWorkspaces"));
+        verify(service).create(any(), any(), any(), eq("userok"));
+        verify(permissionsFilter).checkNamespaceAccess(any(), eq("userok"));
+        verifyZeroInteractions(subject);
+    }
+
+    @Test
+    public void shouldCheckNamespaceAccessOnFetchingWorkspacesByNamespace() throws Exception {
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .contentType("application/json")
+                                         .when()
+                                         .get(SECURE_PATH + "/workspace/namespace/userok");
+
+        assertEquals(response.getStatusCode(), 200);
+        verify(service).getByNamespace(any(), eq("userok"));
+        verify(permissionsFilter).checkNamespaceAccess(any(), eq("userok"));
+        verifyZeroInteractions(subject);
+    }
+
+    @Test
+    public void shouldCheckNamespaceAccessOnStaringWorkspaceFromConfig() throws Exception {
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .contentType("application/json")
+                                         .when()
+                                         .post(SECURE_PATH + "/workspace/runtime?namespace=userok");
+
+        assertEquals(response.getStatusCode(), 204);
+        verify(service).startFromConfig(any(), any(), eq("userok"));
+        verify(permissionsFilter).checkNamespaceAccess(any(), eq("userok"));
+        verifyZeroInteractions(subject);
     }
 
     @Test
@@ -170,7 +201,7 @@ public class WorkspacePermissionsFilterTest {
                                          .post(SECURE_PATH + "/workspace/{id}/runtime");
 
         assertEquals(response.getStatusCode(), 204);
-        verify(service).startById(eq("workspace123"), anyString(), anyString(), any());
+        verify(service).startById(eq("workspace123"), anyString(), any());
         verify(subject).hasPermission(eq("workspace"), eq("workspace123"), eq("run"));
     }
 
@@ -395,8 +426,7 @@ public class WorkspacePermissionsFilterTest {
     @Test(dataProvider = "coveredPaths")
     public void shouldThrowForbiddenExceptionWhenUserDoesNotHavePermissionsForPerformOperation(String path,
                                                                                                String method,
-                                                                                               String action)
-            throws Exception {
+                                                                                               String action) throws Exception {
         when(subject.hasPermission(anyString(), anyString(), anyString())).thenReturn(false);
 
         Response response = request(given().auth()
@@ -407,30 +437,68 @@ public class WorkspacePermissionsFilterTest {
                                     method);
 
         assertEquals(response.getStatusCode(), 403);
-        assertEquals(unwrapError(response), "The user does not have permission to " + action + " workspace with id 'ws123'");
+        assertEquals(unwrapError(response), "The user does not have permission to " + action + " workspace with id 'workspace123'");
 
         verifyZeroInteractions(service);
+    }
+
+    @Test(dataProvider = "coveredPaths")
+    public void shouldNotCheckWorkspacePermissionsWhenWorkspaceBelongToHisPersonalAccount(String path,
+                                                                                          String method,
+                                                                                          String action) throws Exception {
+        when(workspace.getNamespace()).thenReturn(USERNAME);
+
+        Response response = request(given().auth()
+                                           .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                           .contentType("application/json")
+                                           .when(),
+                                    SECURE_PATH + path,
+                                    method);
+        //Successful 2xx
+        assertEquals(response.getStatusCode() / 100, 2);
+        verify(subject, never()).hasPermission(any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhenNamespaceIsNullOnNamespaceAccessChecking() throws Exception {
+        doCallRealMethod().when(permissionsFilter).checkNamespaceAccess(any(), any());
+
+        permissionsFilter.checkNamespaceAccess(subject, null);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhenNamespaceEqualsToUserNameIsNullOnNamespaceAccessChecking() throws Exception {
+        doCallRealMethod().when(permissionsFilter).checkNamespaceAccess(any(), any());
+
+        permissionsFilter.checkNamespaceAccess(subject, USERNAME);
+    }
+
+    @Test(expectedExceptions = ForbiddenException.class)
+    public void shouldThrowForbiddenExceptionWhenNamespaceIsNotNullAndDoesNotEqualToUserNameIsNullOnNamespaceAccessChecking() throws Exception {
+        doCallRealMethod().when(permissionsFilter).checkNamespaceAccess(any(), any());
+
+        permissionsFilter.checkNamespaceAccess(subject, "namespace");
     }
 
     @DataProvider(name = "coveredPaths")
     public Object[][] pathsProvider() {
         return new Object[][] {
-                {"/workspace/ws123", "get", READ},
-                {"/workspace/ws123", "put", CONFIGURE},
-                {"/workspace/ws123/runtime", "post", RUN},
-                {"/workspace/ws123/runtime", "delete", RUN},
-                {"/workspace/ws123/snapshot", "post", RUN},
-                {"/workspace/ws123/snapshot", "get", READ},
-                {"/workspace/ws123/command", "post", CONFIGURE},
-                {"/workspace/ws123/command/run-application", "put", CONFIGURE},
-                {"/workspace/ws123/command/run-application", "delete", CONFIGURE},
-                {"/workspace/ws123/environment", "post", CONFIGURE},
-                {"/workspace/ws123/environment/myEnvironment", "put", CONFIGURE},
-                {"/workspace/ws123/environment/myEnvironment", "delete", CONFIGURE},
-                {"/workspace/ws123/project", "post", CONFIGURE},
-                {"/workspace/ws123/project/spring", "put", CONFIGURE},
-                {"/workspace/ws123/project/spring", "delete", CONFIGURE},
-                {"/workspace/ws123/machine", "post", RUN},
+                {"/workspace/workspace123", "get", READ},
+                {"/workspace/workspace123", "put", CONFIGURE},
+                {"/workspace/workspace123/runtime", "post", RUN},
+                {"/workspace/workspace123/runtime", "delete", RUN},
+                {"/workspace/workspace123/snapshot", "post", RUN},
+                {"/workspace/workspace123/snapshot", "get", READ},
+                {"/workspace/workspace123/command", "post", CONFIGURE},
+                {"/workspace/workspace123/command/run-application", "put", CONFIGURE},
+                {"/workspace/workspace123/command/run-application", "delete", CONFIGURE},
+                {"/workspace/workspace123/environment", "post", CONFIGURE},
+                {"/workspace/workspace123/environment/myEnvironment", "put", CONFIGURE},
+                {"/workspace/workspace123/environment/myEnvironment", "delete", CONFIGURE},
+                {"/workspace/workspace123/project", "post", CONFIGURE},
+                {"/workspace/workspace123/project/spring", "put", CONFIGURE},
+                {"/workspace/workspace123/project/spring", "delete", CONFIGURE},
+                {"/workspace/workspace123/machine", "post", RUN},
         };
     }
 

--- a/core/codenvy-hosted-machine-authentication/src/test/java/com/codenvy/machine/authentication/server/interceptor/MachineTokenInterceptorTest.java
+++ b/core/codenvy-hosted-machine-authentication/src/test/java/com/codenvy/machine/authentication/server/interceptor/MachineTokenInterceptorTest.java
@@ -116,7 +116,7 @@ public class MachineTokenInterceptorTest {
         final String workspaceId = "testWs123";
         when(workspaceImpl.getId()).thenReturn(workspaceId);
 
-        workspaceManager.startWorkspace(workspaceId, null, null, null);
+        workspaceManager.startWorkspace(workspaceId, null, null);
 
         verify(tokenRegistry).generateToken(eq(USER_ID), eq(workspaceId));
     }

--- a/core/codenvy-hosted-platform-api-impl/pom.xml
+++ b/core/codenvy-hosted-platform-api-impl/pom.xml
@@ -59,6 +59,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-account</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-auth</artifactId>
         </dependency>
         <dependency>

--- a/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/core/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -87,33 +87,30 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
 
     @Override
     public WorkspaceImpl createWorkspace(WorkspaceConfig config,
-                                         String namespace,
-                                         @Nullable String accountId) throws ServerException,
-                                                                            ConflictException,
-                                                                            NotFoundException {
+                                         String namespace) throws ServerException,
+                                                                  ConflictException,
+                                                                  NotFoundException {
         checkMaxEnvironmentRam(config);
         checkNamespaceValidity(namespace, "Unable to create workspace because its namespace owner is " +
                                           "unavailable and it is impossible to check resources limit.");
-        return checkCountAndPropagateCreation(namespace, () -> super.createWorkspace(config, namespace, accountId));
+        return checkCountAndPropagateCreation(namespace, () -> super.createWorkspace(config, namespace));
     }
 
     @Override
     public WorkspaceImpl createWorkspace(WorkspaceConfig config,
                                          String namespace,
-                                         Map<String, String> attributes,
-                                         @Nullable String accountId) throws ServerException,
-                                                                            NotFoundException,
-                                                                            ConflictException {
+                                         Map<String, String> attributes) throws ServerException,
+                                                                                NotFoundException,
+                                                                                ConflictException {
         checkMaxEnvironmentRam(config);
         checkNamespaceValidity(namespace, "Unable to create workspace because its namespace owner is " +
                                           "unavailable and it is impossible to check resources limit.");
-        return checkCountAndPropagateCreation(namespace, () -> super.createWorkspace(config, namespace, attributes, accountId));
+        return checkCountAndPropagateCreation(namespace, () -> super.createWorkspace(config, namespace, attributes));
     }
 
     @Override
     public WorkspaceImpl startWorkspace(String workspaceId,
                                         @Nullable String envName,
-                                        @Nullable String accountId,
                                         @Nullable Boolean restore) throws NotFoundException,
                                                                           ServerException,
                                                                           ConflictException {
@@ -125,21 +122,20 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
         return checkRamAndPropagateStart(workspace.getConfig(),
                                          envName,
                                          workspace.getNamespace(),
-                                         () -> super.startWorkspace(workspaceId, envName, accountId, restore));
+                                         () -> super.startWorkspace(workspaceId, envName, restore));
     }
 
     @Override
     public WorkspaceImpl startWorkspace(WorkspaceConfig config,
                                         String namespace,
-                                        boolean isTemporary,
-                                        @Nullable String accountId) throws ServerException,
-                                                                           NotFoundException,
-                                                                           ConflictException {
+                                        boolean isTemporary) throws ServerException,
+                                                                    NotFoundException,
+                                                                    ConflictException {
         checkMaxEnvironmentRam(config);
         return checkRamAndPropagateStart(config,
                                          config.getDefaultEnv(),
                                          namespace,
-                                         () -> super.startWorkspace(config, namespace, isTemporary, accountId));
+                                         () -> super.startWorkspace(config, namespace, isTemporary));
     }
 
     @Override

--- a/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/core/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -271,11 +271,11 @@ public class LimitsCheckingWorkspaceManagerTest {
         doReturn(ws).when(manager).getWorkspace(anyString()); // <- currently running 2gb
         doReturn(ws).when(manager).checkRamAndPropagateStart(anyObject(), anyString(), anyString(), anyObject());
 
-        manager.startWorkspace(ws.getId(), "envName", "accountId", true);
+        manager.startWorkspace(ws.getId(), "envName", true);
 
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(manager).checkRamAndPropagateStart(anyObject(), anyString(), argument.capture(), anyObject());
-        verify((WorkspaceManager)manager).startWorkspace(ws.getId(), "envName", "accountId", true);
+        verify((WorkspaceManager)manager).startWorkspace(ws.getId(), "envName", true);
         Assert.assertEquals(argument.getValue(), ws.getNamespace());
     }
 
@@ -300,6 +300,6 @@ public class LimitsCheckingWorkspaceManagerTest {
                                                                                               false));
         doReturn(ws).when(manager).getWorkspace(anyString()); // <- currently running 2gb
 
-        manager.startWorkspace(ws.getId(), null, null, null);
+        manager.startWorkspace(ws.getId(), null, null);
     }
 }


### PR DESCRIPTION
### What does this PR do?
- Adapt source code to changes of [Account API](https://github.com/eclipse/che/pull/1990)
- Rework permissions checking in according to new namespace concept

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/1989

### Previous Behavior
Earlier filter checked permissions only by subject to wit by link workspace and user with worker.

### New Behavior
User will be able to do anythink with workspace if it has namespace that equals to user's name

### Tests written?
Yes