### PR TITLE
(#404) validate options of Codenvy bootstrap script

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -107,6 +107,8 @@ URL_REGEX="^https?:\/\/[\da-zA-Z_\-\.\/?&#+]+"
 
 MIN_OS_VERSION=7.1
 
+UNRECOGNIZED_PARAMETERS=
+
 cleanUp() {
     setterm -cursor on
     killTimer
@@ -138,6 +140,8 @@ setRunOptions() {
     LICENSE_ACCEPTED=false
     INSTALL_DIR=./codenvy
     DISABLE_MONITORING_TOOLS=false
+
+    local i=0
 
     for var in "$@"; do
         if [[ "$var" == "--multi" ]]; then
@@ -208,6 +212,9 @@ setRunOptions() {
 
         elif [[ "$var" == "--disable-monitoring-tools" ]]; then
             DISABLE_MONITORING_TOOLS=true
+
+        else
+            UNRECOGNIZED_PARAMETERS[$((i++))]="$var"
 
         fi
     done
@@ -1028,11 +1035,6 @@ doCheckAvailablePorts_multi() {
 }
 
 printPreInstallInfo_single() {
-    clear
-
-    println "Welcome. This program installs ${ARTIFACT_DISPLAY} ${VERSION}."
-    println
-
     doEnsureLicenseAgreement
 
     println "Checking system pre-requisites..."
@@ -1406,11 +1408,6 @@ doCheckRedhatSubscription() {
 }
 
 printPreInstallInfo_multi() {
-    clear
-
-    println "Welcome. This program installs ${ARTIFACT_DISPLAY} ${VERSION}."
-    println
-
     doEnsureLicenseAgreement
 
     println "Checking system pre-requisites..."
@@ -1925,7 +1922,27 @@ printPostInstallInfo_installation-manager-cli() {
     println "Codenvy Installation Manager is installed into ${INSTALL_DIR}/cli directory"
 }
 
+
+clear
+
 setRunOptions "$@"
+
+println "Welcome. This program installs ${ARTIFACT_DISPLAY} ${VERSION}."
+println
+
+if [[ ${#UNRECOGNIZED_PARAMETERS[@]} != 0 ]]; then
+    println $(printWarning "!!! You passed next unrecognized parameters:")
+    for var in "${UNRECOGNIZED_PARAMETERS[@]}"; do
+        println $(printWarning "'$var'")
+    done
+
+    if [[ ${SUPPRESS} == false ]]; then
+        pressYKeyToContinue "Proceed?"
+    fi
+
+    println
+fi
+
 printPreInstallInfo_${CODENVY_TYPE}
 
 setterm -cursor off

--- a/cdec/installation-manager-tests/src/main/resources/bin/install/test-install-im-cli.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/install/test-install-im-cli.sh
@@ -22,8 +22,10 @@
 printAndLog "TEST CASE: Install IM CLI"
 vagrantUp ${SINGLE_NODE_VAGRANT_FILE}
 
-installImCliClient ${LATEST_IM_CLI_CLIENT_VERSION}
+installImCliClient ${LATEST_IM_CLI_CLIENT_VERSION} --unknown-parameter=value --unknown-flag typo
+validateExpectedString ".*You.passed.next.unrecognized.parameters\:.*'--unknown-parameter=value'.*'--unknown-flag'.*'typo'.*"
 validateInstalledImCliClientVersion
+
 executeSshCommand "test -d /home/vagrant/codenvy/cli"
 executeSshCommand --valid-exit-code=1 "test -d /home/vagrant/codenvy-im"
 

--- a/cdec/installation-manager-tests/src/main/resources/bin/lib.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/lib.sh
@@ -200,8 +200,7 @@ installCodenvy() {
     ssh -o StrictHostKeyChecking=no -i ~/.vagrant.d/insecure_private_key vagrant@${INSTALL_ON_NODE} "export TERM='xterm' && bash <(curl -L -s ${UPDATE_SERVICE}/repository/public/download/install-codenvy) --suppress --license=accept ${MULTI_OPTION} ${VERSION_OPTION} $@" >> ${TEST_LOG}
     EXIT_CODE=$?
 
-    # to get last several rows from test log file
-    OUTPUT=$(tail ${TEST_LOG})
+    OUTPUT=$(cat ${TEST_LOG})
 
     validateExitCode ${EXIT_CODE} ${validCode} --installCodenvy
 
@@ -228,8 +227,7 @@ installImCliClient() {
     ssh -o StrictHostKeyChecking=no -i ~/.vagrant.d/insecure_private_key vagrant@${INSTALL_ON_NODE} "export TERM='xterm' && bash <(curl -L -s ${UPDATE_SERVICE}/repository/public/download/install-im-cli) --license=accept ${VERSION_OPTION} $@" >> ${TEST_LOG}
     EXIT_CODE=$?
 
-    # to get last several rows from test log file
-    OUTPUT=$(tail ${TEST_LOG})
+    OUTPUT=$(cat ${TEST_LOG})
 
     validateExitCode ${EXIT_CODE} ${validCode}
 


### PR DESCRIPTION
@TylerJewell, @riuvshin: please. review this request.
Please, take into account that warning message in output was slightly changed to handle parameters with value, flags and typos, for example:
> [vagrant@dev ~]$ ./install-codenvy.sh --http-proxy=http://test --unknown typo
![parameter_validation_output](https://cloud.githubusercontent.com/assets/1197777/17294818/afb64ad6-5801-11e6-9683-c1dfe590b271.png)
