### PR TITLE
CODENVY-509: add user not found message in share workspace widget

### DIFF
--- a/dashboard/src/app/factories/create-factory/create-factory.html
+++ b/dashboard/src/app/factories/create-factory/create-factory.html
@@ -24,7 +24,7 @@
     <div class="create-factory-share-header-widget-icon"><i class="chefont cheico-rocket-chefont icon">&nbsp;</i></div>
     <div layout="row" layout-fill layout-align="center center">
       <div class="create-factory-share-header-widget-badge"><a target="_blank" href="{{createFactoryCtrl.factoryLink}}"><img
-        src="{{createFactoryCtrl.factoryBadgeUrl}}"></a></div>
+        ng-src="{{createFactoryCtrl.factoryBadgeUrl}}"></a></div>
       <div class="create-factory-share-header-widget-markdown">{{createFactoryCtrl.factoryLink}}</div>
       <a class="create-factory-share-header-small-button" tooltip="{{valueLinkCopy === createFactoryCtrl.factoryLink ? 'Copied' : 'Copy'}}"
          clip-copy="createFactoryCtrl.factoryLink" clip-click="valueLinkCopy=createFactoryCtrl.factoryLink">Copy URL</a>

--- a/dashboard/src/app/workspace/share-workspace/share-workspace.controller.js
+++ b/dashboard/src/app/workspace/share-workspace/share-workspace.controller.js
@@ -46,6 +46,8 @@ export class ShareWorkspaceController {
     this.emails = [];
     //Filtered entered emails - users that really are registered
     this.existingUsers = new Map();
+    //Filtered entered emails - users that are not registered
+    this.notExistingUsers = [];
 
     this.isLoading = false;
     //Temp solution with defined actions, better to provide list of available for user to choose:
@@ -130,12 +132,22 @@ export class ShareWorkspaceController {
       //Clear share input data:
       this.emails.length = 0;
       this.existingUsers.clear();
+      this.notExistingUsers.length = 0;
 
       this.refreshWorkspacePermissions();
     }, (error) => {
       this.isLoading = false;
       this.cheNotification.showError(error.data && error.data.message ? error.data.message : 'Failed to share workspace.');
     });
+  }
+
+  /**
+   * Returns the list of the not registered users emails as string.
+   *
+   * @returns {*} string with wrong emails coma separated
+   */
+  getNotExistingEmails() {
+    return this.notExistingUsers.join(', ');
   }
 
   /**
@@ -208,7 +220,7 @@ export class ShareWorkspaceController {
       let user = this.codenvyUser.getUserByAlias(email);
       this.existingUsers.set(email, user);
     }, (error) => {
-      //do nothing
+      this.notExistingUsers.push(email);
     });
 
     return email;
@@ -221,6 +233,10 @@ export class ShareWorkspaceController {
    */
   onRemoveEmail(email) {
     this.existingUsers.delete(email);
+
+    this.lodash.remove(this.notExistingUsers, (data) => {
+        return email === data;
+    });
   }
 
   /**

--- a/dashboard/src/app/workspace/share-workspace/share-workspace.html
+++ b/dashboard/src/app/workspace/share-workspace/share-workspace.html
@@ -34,6 +34,10 @@
             </div>
           </md-chip-template>
         </md-chips>
+        <div ng-show="shareWorkspaceController.notExistingUsers.length > 0" class="user-not-found">
+          User<span ng-if="shareWorkspaceController.notExistingUsers.length > 1">s</span> with email<span ng-if="shareWorkspaceController.notExistingUsers.length > 1">s</span>
+          <b>{{shareWorkspaceController.getNotExistingEmails()}}</b> not found. Workspaces can be shared with registered users only.
+        </div>
       </form>
       <div flex="none" flex-offset="5" layout="column" layout-align="end end">
         <che-button-primary

--- a/dashboard/src/app/workspace/share-workspace/share-workspace.styl
+++ b/dashboard/src/app/workspace/share-workspace/share-workspace.styl
@@ -20,6 +20,9 @@
 .user-exists
   background-color $valid-color
 
+.user-not-found
+  color $error-color
+
 .share-user-input
   .md-chips:not(.md-focused)
     box-shadow 0 1px $default-border-color !important


### PR DESCRIPTION
### What does this PR do?
Adds message "User with email [email] not found. Workspaces can be shared with registered users only." when unregistered email is passed.

### What issues does this PR fix or reference?
Issue - https://github.com/codenvy/codenvy/issues/509

### Previous Behavior
No message was shown

### New Behavior
A message show show up - User with email noname@codenvy.com not found. Workspaces can be shared with registered users only.