### PR TITLE
(#560) replace deprecated 'netstat' command by 'ss'

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -292,9 +292,6 @@ doConfigureSystem() {
 
     doEvalWaitReconnection installPackageIfNeed unzip
     validateExitCode $?
-
-    doEvalWaitReconnection installPackageIfNeed net-tools
-    validateExitCode $?
 }
 
 configureProxySettings() {
@@ -892,14 +889,14 @@ doCheckPortRemote() {
     local protocol=$1
     local port=$2
     local host=$3
-    OUTPUT=$(ssh -o LogLevel=quiet -o StrictHostKeyChecking=no -t ${host} "netstat -ano | egrep LISTEN | egrep ${protocol} | egrep ':${host}\s'")
+    OUTPUT=$(ssh -o LogLevel=quiet -o StrictHostKeyChecking=no -t ${host} "ss -ano | egrep LISTEN | egrep ${protocol} | egrep ':${host}\s'")
     echo ${OUTPUT}
 }
 
 doCheckPortLocal() {
     local protocol=$1
     local port=$2
-    OUTPUT=$(netstat -ano | egrep LISTEN | egrep ${protocol} | egrep ":${port}\s")
+    OUTPUT=$(ss -ano | egrep LISTEN | egrep ${protocol} | egrep ":${port}\s")
     echo ${OUTPUT}
 }
 

--- a/cdec/installation-manager-tests/src/main/resources/vagrant/single-codenvy4-with-additional-nodes/RHEL7/Vagrantfile
+++ b/cdec/installation-manager-tests/src/main/resources/vagrant/single-codenvy4-with-additional-nodes/RHEL7/Vagrantfile
@@ -9,8 +9,6 @@ $script = <<-SHELL
 sudo subscription-manager register --username riuvshin@codenvy.com --password codenvy --auto-attach
 sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
 sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
-
-sudo yum install net-tools -y
 SHELL
 
 Vagrant.configure("2") do |config|

--- a/cdec/installation-manager-tests/src/main/resources/vagrant/single/RHEL7/Vagrantfile
+++ b/cdec/installation-manager-tests/src/main/resources/vagrant/single/RHEL7/Vagrantfile
@@ -22,8 +22,6 @@ Vagrant.configure(2) do |config|
   sudo subscription-manager register --username riuvshin@codenvy.com --password codenvy --auto-attach
   sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
   sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
-
-  sudo yum install net-tools -y
   SHELL
 
   config.vm.provision "shell", inline: $script


### PR DESCRIPTION
### What does this PR do?
It replaces 'netstat' command by 'ss' so as first one is deprecated and not available on some CentOS 7.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>