### PR TITLE
CODENVY-515: Add ability to save workspace snapshots in AWS ECR

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/pom.xml
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/pom.xml
@@ -26,6 +26,10 @@
     <name>Codenvy Plugin :: Hosted :: Machine</name>
     <dependencies>
         <dependency>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <exclusions>
@@ -66,6 +70,10 @@
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
@@ -100,6 +108,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/MachineHostedModule.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/MachineHostedModule.java
@@ -1,0 +1,72 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+
+import org.eclipse.che.api.agent.server.wsagent.WsAgentLauncher;
+import org.eclipse.che.api.machine.server.spi.InstanceProvider;
+
+public class MachineHostedModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(org.eclipse.che.plugin.docker.client.DockerConnector.class).to(com.codenvy.swarm.client.SwarmDockerConnector.class);
+        bind(org.eclipse.che.plugin.docker.client.DockerRegistryDynamicAuthResolver.class)
+                .to(com.codenvy.auth.aws.ecr.AwsEcrAuthResolver.class);
+
+        bind(String.class).annotatedWith(Names.named("machine.docker.machine_env"))
+                          .toProvider(com.codenvy.machine.MaintenanceConstraintProvider.class);
+
+        install(new org.eclipse.che.plugin.docker.machine.ext.DockerTerminalModule());
+        bind(org.eclipse.che.api.agent.server.terminal.MachineTerminalLauncher.class);
+
+        install(new org.eclipse.che.plugin.docker.machine.proxy.DockerProxyModule());
+
+        install(new FactoryModuleBuilder()
+                        .implement(org.eclipse.che.api.machine.server.spi.Instance.class,
+                                   org.eclipse.che.plugin.docker.machine.DockerInstance.class)
+                        .implement(org.eclipse.che.api.machine.server.spi.InstanceProcess.class,
+                                   org.eclipse.che.plugin.docker.machine.DockerProcess.class)
+                        .implement(org.eclipse.che.plugin.docker.machine.node.DockerNode.class,
+                                   com.codenvy.machine.RemoteDockerNode.class)
+                        .implement(org.eclipse.che.plugin.docker.machine.DockerInstanceRuntimeInfo.class,
+                                   com.codenvy.machine.HostedServersInstanceRuntimeInfo.class)
+                        .build(org.eclipse.che.plugin.docker.machine.DockerMachineFactory.class));
+
+        install(new org.eclipse.che.plugin.docker.machine.ext.DockerExtServerModule());
+
+        bind(String.class).annotatedWith(Names.named("machine.docker.che_api.endpoint"))
+                          .to(Key.get(String.class, Names.named("api.endpoint")));
+
+        // install(new com.codenvy.router.MachineRouterModule());
+
+        bind(org.eclipse.che.api.workspace.server.event.MachineStateListener.class).asEagerSingleton();
+
+        install(new org.eclipse.che.plugin.docker.machine.DockerMachineModule());
+        Multibinder<InstanceProvider> machineImageProviderMultibinder =
+                Multibinder.newSetBinder(binder(), org.eclipse.che.api.machine.server.spi.InstanceProvider.class);
+        machineImageProviderMultibinder.addBinding()
+                                       .to(com.codenvy.machine.HostedDockerInstanceProvider.class);
+        bind(WsAgentLauncher.class).to(com.codenvy.machine.launcher.WsAgentWithAuthLauncherImpl.class);
+
+        install(new com.codenvy.machine.interceptor.MachineHostedInterceptorModule());
+    }
+
+}

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/interceptor/MachineHostedInterceptorModule.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/interceptor/MachineHostedInterceptorModule.java
@@ -1,0 +1,40 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.machine.interceptor;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.plugin.docker.machine.DockerInstance;
+
+import static com.google.inject.matcher.Matchers.subclassesOf;
+import static org.eclipse.che.inject.Matchers.names;
+
+/**
+ * Bind interceptors related to machines.
+ *
+ * @author Mykola Morhun
+ */
+public class MachineHostedInterceptorModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        final SnapshottingToRegistryInterceptor snapshottingToRegistryInterceptor = new SnapshottingToRegistryInterceptor();
+        requestInjection(snapshottingToRegistryInterceptor);
+        bindInterceptor(subclassesOf(DockerInstance.class),
+                        names("createAndPushSnapshotToRemoteRegistry"),
+                        snapshottingToRegistryInterceptor);
+    }
+
+}

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/interceptor/SnapshottingToRegistryInterceptor.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/interceptor/SnapshottingToRegistryInterceptor.java
@@ -1,0 +1,78 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.machine.interceptor;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.ecr.AmazonECRClient;
+import com.amazonaws.services.ecr.model.CreateRepositoryRequest;
+import com.codenvy.auth.aws.ecr.AwsInitialAuthConfig;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+
+/**
+ * This interceptor creates repository in remote registry if it doesn't support repository creation on docker push command.
+ *
+ * @author Mykola Morhun
+ */
+@Singleton
+public class SnapshottingToRegistryInterceptor implements MethodInterceptor {
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshottingToRegistryInterceptor.class);
+
+    // https://aws_account_id.dkr.ecr.region.amazonaws.com
+    private static final String AMAZON_ECR_URL_REG_EXP = "^\\d{12}\\.dkr\\.ecr\\..+-\\d\\.amazonaws\\.com$";
+    private static final Pattern AMAZON_ECR_URL_PATTERN = Pattern.compile(AMAZON_ECR_URL_REG_EXP);
+
+    @Inject
+    private AwsInitialAuthConfig awsInitialAuthConfig;
+
+    @Override
+    public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+        Object[] arguments = methodInvocation.getArguments();
+        String repository = (String) arguments[0];
+        String registry = (String) arguments[1];
+
+        if (registry != null) {
+            try {
+                if (AMAZON_ECR_URL_PATTERN.matcher(registry).find()) {
+                    AmazonECRClient amazonECRClient = getAwsEcrClient();
+                    CreateRepositoryRequest createRepositoryForSnapshotRequest = new CreateRepositoryRequest();
+                    createRepositoryForSnapshotRequest.setRepositoryName(repository);
+                    amazonECRClient.createRepository(createRepositoryForSnapshotRequest);
+                }
+            } catch (Exception e) {
+                LOG.error("Unable to create {} repository for {} registry. Reason: {}", repository, registry, e);
+            }
+        }
+
+        return methodInvocation.proceed();
+    }
+
+    @VisibleForTesting
+    AmazonECRClient getAwsEcrClient() {
+        AWSCredentials credentials = new BasicAWSCredentials(awsInitialAuthConfig.getAccessKeyId(),
+                                                             awsInitialAuthConfig.getSecretAccessKey());
+        return new AmazonECRClient(credentials);
+    }
+
+}

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/interceptor/SnapshottingToRegistryInterceptorTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/interceptor/SnapshottingToRegistryInterceptorTest.java
@@ -1,0 +1,128 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.machine.interceptor;
+
+import com.amazonaws.services.ecr.AmazonECRClient;
+import com.codenvy.auth.aws.ecr.AwsInitialAuthConfig;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Mykola Morhun
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SnapshottingToRegistryInterceptorTest {
+
+    private static final String REPOSITORY = "repository1234";
+
+    @Mock
+    private MethodInvocation     methodInvocation;
+    @Mock
+    private AwsInitialAuthConfig awsInitialAuthConfig;
+    @Mock
+    private AmazonECRClient      amazonEcrClient;
+
+    @Spy
+    @InjectMocks
+    private SnapshottingToRegistryInterceptor interceptor;
+
+    @BeforeMethod
+    public void setup() throws Throwable {
+        doReturn(null).when(methodInvocation).proceed(); // do nothing on methodInvocation.proceed()
+        doReturn(amazonEcrClient).when(interceptor).getAwsEcrClient();
+        doReturn(null).when(amazonEcrClient).createRepository(anyObject()); // prevent real request to AWS
+
+        when(awsInitialAuthConfig.getAccessKeyId()).thenReturn("1234567890");
+        when(awsInitialAuthConfig.getSecretAccessKey()).thenReturn("secretValue");
+    }
+
+    @Test
+    public void shouldInvokeInterceptedMethod() throws Throwable {
+        addArgumentsToInvocation(REPOSITORY, "");
+
+        interceptor.invoke(methodInvocation);
+
+        verify(methodInvocation).proceed();
+    }
+
+    @Test(dataProvider = "nonAwsEcrHostnameProvider")
+    public void shouldNotCreateNewRepositoryInAwsEcr(String registry) throws Throwable {
+        addArgumentsToInvocation(REPOSITORY, registry);
+
+        interceptor.invoke(methodInvocation);
+
+        verify(amazonEcrClient, never()).createRepository(anyObject());
+    }
+
+    @Test(dataProvider = "awsEcrHostnameProvider")
+    public void shouldCreateNewRepositoryInAwsEcr(String registry) throws Throwable {
+        addArgumentsToInvocation(REPOSITORY, registry);
+
+        interceptor.invoke(methodInvocation);
+
+        verify(amazonEcrClient).createRepository(anyObject());
+    }
+
+    @DataProvider(name = "nonAwsEcrHostnameProvider")
+    private Object[][] nonAwsEcrHostnameProvider() {
+        return new Object[][] {
+                {null},
+                {""},
+                {"docker.io"},
+                {"https://index.docker.io/v2/"},
+                {"registry.com"},
+                {"some.registry.com:5000"},
+                {"1234567890123.dkr.ecr.us-east-1.amazonaws.com"},
+                {"12345678901.dkr.ecr.us-east-1.amazonaws.com"},
+                {"123456789012.dkr.ecr.us-east.amazonaws.com"},
+                {"123456789012.dkr.ecr.us-east-1.amazon.com"},
+                {"123456789012.dkr.us-east-1.amazonaws.com"},
+                {"123456789012.ecr.us-east-1.amazonaws.com"},
+                {"123456789012.dkr.ecr.us-east-1.amazonaws.com:5000"},
+                {"https://123456789012.dkr.ecr.us-east-1.amazonaws.com"}
+        };
+    }
+
+    @DataProvider(name = "awsEcrHostnameProvider")
+    private Object[][] awsEcrHostnameProvider() {
+        return new Object[][] {
+                {"123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+                {"123456789012.dkr.ecr.ua-north-5.amazonaws.com"}
+        };
+    }
+
+    private void addArgumentsToInvocation(String repositoryArg, String registryArg) {
+        String[] arguments = new String[2];
+        arguments[0] = repositoryArg;
+        arguments[1] = registryArg;
+
+        when(methodInvocation.getArguments()).thenReturn(arguments);
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?
Adds interceptor for snapshot pushing to docker registry which in case of AWS ECR creates repository for the snapshot before pushing.

### What issues does this PR fix or reference?
#515 

### Previous Behavior
No ability to save snapshots in AWS ECR.

### New Behavior
Added ability to save workspace snapshots in AWS ECR.

### Tests written?
Yes