### PR TITLE
Installation manager minor fixup

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -2169,13 +2169,14 @@ pauseTimer
 pauseInternetAccessChecker
 pauseFooterUpdater
 
-if [[ "${ARTIFACT}" == "codenvy" ]] && [[ "${VERSION}" =~ ^(4).* ]]; then
-    adminName=$(readProperty 'admin_ldap_user_name')
-    adminPassword=$(readProperty 'admin_ldap_password')
-    toolVersion=$(if [[ "${VERSION}" =~ .*SNAPSHOT$ ]]; then echo "nightly"; else echo ${VERSION}; fi)
-
-    postFlightCheckOfCodenvy "$adminName" "$adminPassword" "$toolVersion"
-    println
-fi
+## post-flight check was turned off because of issue https://github.com/eclipse/che/issues/2284
+#if [[ "${ARTIFACT}" == "codenvy" ]] && [[ "${VERSION}" =~ ^(4).* ]]; then
+#    adminName=$(readProperty 'admin_ldap_user_name')
+#    adminPassword=$(readProperty 'admin_ldap_password')
+#    toolVersion=$(if [[ "${VERSION}" =~ .*SNAPSHOT$ ]]; then echo "nightly"; else echo ${VERSION}; fi)
+#
+#    postFlightCheckOfCodenvy "$adminName" "$adminPassword" "$toolVersion"
+#    println
+#fi
 
 printPostInstallInfo_${ARTIFACT}

--- a/cdec/installation-manager-tests/src/main/resources/bin/lib.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/lib.sh
@@ -193,7 +193,7 @@ installCodenvy() {
 
     logStartCommand "installCodenvy $VERSION_OPTION $@"
 
-    ssh -o StrictHostKeyChecking=no -i ~/.vagrant.d/insecure_private_key vagrant@${INSTALL_ON_NODE} "export TERM='xterm' && bash <(curl -L -s ${UPDATE_SERVICE}/repository/public/download/install-codenvy) --suppress --license=accept ${MULTI_OPTION} ${VERSION_OPTION} $@" >> ${TEST_LOG}
+    ssh -o StrictHostKeyChecking=no -i ~/.vagrant.d/insecure_private_key vagrant@${INSTALL_ON_NODE} "export TERM='xterm' && . /etc/profile && bash <(curl -L -s ${UPDATE_SERVICE}/repository/public/download/install-codenvy) --suppress --license=accept ${MULTI_OPTION} ${VERSION_OPTION} $@" >> ${TEST_LOG}
     EXIT_CODE=$?
 
     OUTPUT=$(cat ${TEST_LOG})
@@ -220,7 +220,7 @@ installImCliClient() {
         shift
     fi
 
-    ssh -o StrictHostKeyChecking=no -i ~/.vagrant.d/insecure_private_key vagrant@${INSTALL_ON_NODE} "export TERM='xterm' && bash <(curl -L -s ${UPDATE_SERVICE}/repository/public/download/install-codenvy) --im-cli --suppress --license=accept ${VERSION_OPTION} $@" >> ${TEST_LOG}
+    ssh -o StrictHostKeyChecking=no -i ~/.vagrant.d/insecure_private_key vagrant@${INSTALL_ON_NODE} "export TERM='xterm' && . /etc/profile && bash <(curl -L -s ${UPDATE_SERVICE}/repository/public/download/install-codenvy) --im-cli --suppress --license=accept ${VERSION_OPTION} $@" >> ${TEST_LOG}
     EXIT_CODE=$?
 
     OUTPUT=$(cat ${TEST_LOG})


### PR DESCRIPTION
@riuvshin: please, review this request.

Request contains:
1) fixup of integration tests which produces error 'ss: command not found';
2) turning off post-flight codenvy installation check because of an issue https://github.com/eclipse/che/issues/2284 which causes an error:
![post-flight_check_failure](https://cloud.githubusercontent.com/assets/1197777/18133848/db81e37c-6fa4-11e6-8e14-d72d011837c9.png)
