### PR TITLE
Turn on post-flight installation check

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -2169,14 +2169,13 @@ pauseTimer
 pauseInternetAccessChecker
 pauseFooterUpdater
 
-## post-flight check was turned off because of issue https://github.com/eclipse/che/issues/2284
-#if [[ "${ARTIFACT}" == "codenvy" ]] && [[ "${VERSION}" =~ ^(4).* ]]; then
-#    adminName=$(readProperty 'admin_ldap_user_name')
-#    adminPassword=$(readProperty 'admin_ldap_password')
-#    toolVersion=$(if [[ "${VERSION}" =~ .*SNAPSHOT$ ]]; then echo "nightly"; else echo ${VERSION}; fi)
-#
-#    postFlightCheckOfCodenvy "$adminName" "$adminPassword" "$toolVersion"
-#    println
-#fi
+if [[ "${ARTIFACT}" == "codenvy" ]] && [[ "${VERSION}" =~ ^(4).* ]]; then
+    adminName=$(readProperty 'admin_ldap_user_name')
+    adminPassword=$(readProperty 'admin_ldap_password')
+    toolVersion=$(if [[ "${VERSION}" =~ .*SNAPSHOT$ ]]; then echo "nightly"; else echo ${VERSION}; fi)
+
+    postFlightCheckOfCodenvy "$adminName" "$adminPassword" "$toolVersion"
+    println
+fi
 
 printPostInstallInfo_${ARTIFACT}


### PR DESCRIPTION
Turn on post-flight installation check after the issue https://github.com/eclipse/che/issues/2284 was done.
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>