### PR TITLE
CHE-2206: add stacks item to navbar menu and add codemirror plugins

### DIFF
--- a/dashboard/src/app/navbar/codenvy-navbar.html
+++ b/dashboard/src/app/navbar/codenvy-navbar.html
@@ -59,6 +59,15 @@
                 </div>
               </md-button>
             </md-list-item>
+            <md-list-item flex class="navbar-subsection-item">
+              <md-button nav-bar-selected flex che-reload-href
+                         ng-href="{{codenvyNavbarCtrl.menuItemUrl.stacks}}" layout-align="left">
+                <div class="navbar-item" layout="row" layout-align="start center">
+                  <md-icon md-font-icon="navbar-icon material-design icon-ic_inbox_24px"></md-icon>
+                  <span>Stacks</span>
+                </div>
+              </md-button>
+            </md-list-item>
             <md-list-item flex class="navbar-subsection-item" ng-if="codenvyNavbarCtrl.isFactoryServiceAvailable">
               <md-button nav-bar-selected flex che-reload-href
                          ng-href="{{codenvyNavbarCtrl.menuItemUrl.factories}}" layout-align="left">

--- a/dashboard/src/app/navbar/navbar.controller.js
+++ b/dashboard/src/app/navbar/navbar.controller.js
@@ -70,6 +70,7 @@ export class CodenvyNavBarCtrl {
       login: '/site/login',
       dashboard: '#/',
       workspaces: '#/workspaces',
+      stacks: '#/stacks',
       factories: '#/factories',
       administration: '#/onprem/administration',
       usermanagement: '#/admin/usermanagement',

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -82,13 +82,17 @@
 <script src="../bower_components/jsonlint/lib/jsonlint.js"></script>
 <script src="../bower_components/codemirror/addon/lint/lint.js"></script>
 <script src="../bower_components/codemirror/addon/lint/json-lint.js"></script>
+<script src="../bower_components/codemirror/addon/mode/simple.js"></script>
 <script src="../bower_components/codemirror/mode/javascript/javascript.js"></script>
+<script src="../bower_components/codemirror/mode/yaml/yaml.js"></script>
+<script src="../bower_components/codemirror/mode/dockerfile/dockerfile.js"></script>
 <script src="../bower_components/codemirror/addon/edit/matchbrackets.js"></script>
 <script src="../bower_components/codemirror/addon/edit/closebrackets.js"></script>
 <script src="../bower_components/codemirror/addon/fold/foldcode.js"></script>
 <script src="../bower_components/codemirror/addon/fold/foldgutter.js"></script>
 <script src="../bower_components/codemirror/addon/fold/brace-fold.js"></script>
 <script src="../bower_components/codemirror/addon/selection/active-line.js"></script>
+
 <!-- bower:js -->
 <!-- run `gulp inject` to automatically populate bower script dependencies -->
 <!-- endbower -->


### PR DESCRIPTION
### What does this PR do?
Adds stacks navbar menu item. Fixes codemirror used dependencies.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/2206


Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>