### PR TITLE
Provide contribution mixin before resource has been loaded

### DIFF
--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionExtension.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionExtension.java
@@ -15,35 +15,26 @@
 package com.codenvy.plugin.pullrequest.client;
 
 import com.codenvy.plugin.pullrequest.client.parts.contribute.ContributePartPresenter;
-import com.codenvy.plugin.pullrequest.client.vcs.VcsService;
-import com.codenvy.plugin.pullrequest.client.vcs.VcsServiceProvider;
-import com.codenvy.plugin.pullrequest.client.vcs.hosting.NoVcsHostingServiceImplementationException;
 import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingService;
 import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingServiceProvider;
 import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
 import com.google.web.bindery.event.shared.EventBus;
 
-import org.eclipse.che.api.promises.client.Function;
-import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.PromiseError;
-import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.event.SelectionChangedEvent;
 import org.eclipse.che.ide.api.event.SelectionChangedHandler;
 import org.eclipse.che.ide.api.extension.Extension;
-import org.eclipse.che.ide.api.project.MutableProjectConfig;
+import org.eclipse.che.ide.api.parts.PartStackType;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.resources.Project;
-import org.eclipse.che.ide.util.loging.Log;
+import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import static com.codenvy.plugin.pullrequest.projecttype.shared.ContributionProjectTypeConstants.CONTRIBUTE_TO_BRANCH_VARIABLE_NAME;
 import static com.codenvy.plugin.pullrequest.projecttype.shared.ContributionProjectTypeConstants.CONTRIBUTION_PROJECT_TYPE_ID;
-import static java.util.Collections.singletonList;
 
 /**
  * Registers event handlers for adding/removing contribution part.
@@ -60,26 +51,19 @@ import static java.util.Collections.singletonList;
 @Extension(title = "Contributor", version = "1.0.0")
 public class ContributionExtension {
 
-    private final ContributePartPresenter   contributionPartPresenter;
     private final WorkflowExecutor          workflowExecutor;
-    private final VcsHostingServiceProvider hostingServiceProvider;
-    private final VcsServiceProvider        vcsServiceProvider;
 
-    private String  lastSelectedProjectName;
-    private boolean partWasOpened;
+    private Project lastSelectedProject;
 
     @Inject
     public ContributionExtension(final EventBus eventBus,
                                  final ContributeResources resources,
                                  final AppContext appContext,
-                                 final ContributePartPresenter contributionPartPresenter,
                                  final WorkflowExecutor workflow,
                                  final VcsHostingServiceProvider vcsHostingServiceProvider,
-                                 final VcsServiceProvider vcsServiceProvider) {
+                                 final ContributePartPresenter contributePart,
+                                 final WorkspaceAgent workspaceAgent) {
         this.workflowExecutor = workflow;
-        this.contributionPartPresenter = contributionPartPresenter;
-        this.hostingServiceProvider = vcsHostingServiceProvider;
-        this.vcsServiceProvider = vcsServiceProvider;
 
         eventBus.addHandler(SelectionChangedEvent.TYPE, new SelectionChangedHandler() {
             @Override
@@ -88,76 +72,31 @@ public class ContributionExtension {
                 if (rootProject == null) {
                     return;
                 }
-                if (!rootProject.getName().equals(lastSelectedProjectName) || !partWasOpened) {
-                    initializeContributorExtension(rootProject);
+
+                if (rootProject.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID) && !rootProject.equals(lastSelectedProject)) {
+                    vcsHostingServiceProvider.getVcsHostingService(rootProject).then(new Operation<VcsHostingService>() {
+                        @Override
+                        public void apply(VcsHostingService arg) throws OperationException {
+                            workflowExecutor.init(arg, rootProject);
+                        }
+                    });
+
                 }
-                lastSelectedProjectName = rootProject.getName();
+
+                lastSelectedProject = rootProject;
+            }
+        });
+
+        eventBus.addHandler(WorkspaceStoppedEvent.TYPE, new WorkspaceStoppedEvent.Handler() {
+            @Override
+            public void onWorkspaceStopped(WorkspaceStoppedEvent event) {
+                workflowExecutor.invalidateContext(lastSelectedProject);
+                contributePart.minimize();
             }
         });
 
         resources.contributeCss().ensureInjected();
-    }
 
-    private void initializeContributorExtension(final Project project) {
-        hostingServiceProvider.getVcsHostingService(project)
-                              .then(initContribution(project))
-                              .catchError(cancelInit(project));
-    }
-
-    private Operation<PromiseError> cancelInit(final Project project) {
-        return new Operation<PromiseError>() {
-            @Override
-            public void apply(final PromiseError error) throws OperationException {
-                Log.info(getClass(), "INIT ERROR :: " + project.getName() + " :: message => " + error.getMessage());
-                try {
-                    throw error.getCause();
-                } catch (NoVcsHostingServiceImplementationException noVcsEx) {
-                    contributionPartPresenter.remove();
-                    workflowExecutor.invalidateContext(project);
-                } catch (Throwable throwable) {
-                    lastSelectedProjectName = null;
-                    contributionPartPresenter.remove();
-                    workflowExecutor.invalidateContext(project);
-                }
-            }
-        };
-    }
-
-    private Promise<Project> addMixin(final Project project) {
-        if (!project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID)) {
-            final VcsService vcsService = vcsServiceProvider.getVcsService(project);
-            return vcsService.getBranchName(project)
-                             .thenPromise(new Function<String, Promise<Project>>() {
-                                 @Override
-                                 public Promise<Project> apply(String branchName) throws FunctionException {
-                                     MutableProjectConfig mutableConfig = new MutableProjectConfig(project);
-                                     mutableConfig.getMixins().add(CONTRIBUTION_PROJECT_TYPE_ID);
-                                     mutableConfig.getAttributes().put(CONTRIBUTE_TO_BRANCH_VARIABLE_NAME, singletonList(branchName));
-
-                                     return project.update().withBody(mutableConfig).send();
-                                 }
-                             });
-        } else {
-            return Promises.resolve(project);
-        }
-    }
-
-    private Operation<VcsHostingService> initContribution(final Project project) {
-        return new Operation<VcsHostingService>() {
-            @Override
-            public void apply(final VcsHostingService vcsHostingService) throws OperationException {
-                addMixin(project)
-                        .then(new Operation<Project>() {
-                            @Override
-                            public void apply(Project project) throws OperationException {
-                                Log.info(getClass(), "INIT SUCCESSFUL :: " + project.getName());
-                                contributionPartPresenter.open();
-                                partWasOpened = true;
-                                workflowExecutor.init(vcsHostingService, project);
-                            }
-                        })
-                        .catchError(cancelInit(project));
-            }
-        };
+        workspaceAgent.getPartStack(PartStackType.TOOLING).addPart(contributePart);
     }
 }

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProvider.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProvider.java
@@ -1,0 +1,148 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.plugin.pullrequest.client;
+
+import com.codenvy.plugin.pullrequest.client.parts.contribute.ContributePartPresenter;
+import com.codenvy.plugin.pullrequest.client.vcs.VcsService;
+import com.codenvy.plugin.pullrequest.client.vcs.VcsServiceProvider;
+import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingService;
+import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingServiceProvider;
+import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.promises.client.Function;
+import org.eclipse.che.api.promises.client.FunctionException;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.promises.client.js.Promises;
+import org.eclipse.che.ide.api.project.MutableProjectConfig;
+import org.eclipse.che.ide.api.resources.Project;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.api.resources.ResourceInterceptor;
+
+import static com.codenvy.plugin.pullrequest.projecttype.shared.ContributionProjectTypeConstants.CONTRIBUTE_TO_BRANCH_VARIABLE_NAME;
+import static com.codenvy.plugin.pullrequest.projecttype.shared.ContributionProjectTypeConstants.CONTRIBUTION_PROJECT_TYPE_ID;
+import static java.util.Collections.singletonList;
+
+/**
+ * Interceptor component, which pre-process resource at loading step.
+ * <p>
+ * Loading step means, that resource (file, folder or project) which is loaded from server should go through registered interceptors
+ * to register on the client side.
+ * <p>
+ * Current interceptor modifies resource (in our case resource - project) and set up contribution mixin.
+ *
+ * @author Vlad Zhukovskyi
+ * @see ResourceInterceptor
+ * @since 5.0.0
+ */
+@Singleton
+public class ContributionMixinProvider implements ResourceInterceptor {
+
+    private VcsServiceProvider        vcsServiceProvider;
+    private VcsHostingServiceProvider vcsHostingServiceProvider;
+    private WorkflowExecutor          workflowExecutor;
+    private ContributePartPresenter   contributionPartPresenter;
+
+    @Inject
+    public ContributionMixinProvider(VcsServiceProvider vcsServiceProvider,
+                                     VcsHostingServiceProvider vcsHostingServiceProvider,
+                                     WorkflowExecutor workflowExecutor,
+                                     ContributePartPresenter contributionPartPresenter) {
+        this.vcsServiceProvider = vcsServiceProvider;
+        this.vcsHostingServiceProvider = vcsHostingServiceProvider;
+        this.workflowExecutor = workflowExecutor;
+        this.contributionPartPresenter = contributionPartPresenter;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void intercept(Resource resource) {
+        if (!resource.isProject()) {
+            return;
+        }
+
+        final Project project = (Project)resource;
+
+        if (isNotRootProject(project) || hasContributionMixin(project) || hasNoVcsService(project)) {
+            return;
+        }
+
+        vcsHostingServiceProvider.getVcsHostingService(project)
+                                 .then(new Operation<VcsHostingService>() {
+                                     @Override
+                                     public void apply(final VcsHostingService vcsHostingService) throws OperationException {
+                                         addMixin(project)
+                                                 .then(new Operation<Project>() {
+                                                     @Override
+                                                     public void apply(Project project) throws OperationException {
+                                                         contributionPartPresenter.open();
+                                                         workflowExecutor.init(vcsHostingService, project);
+                                                     }
+                                                 })
+                                                 .catchError(new Operation<PromiseError>() {
+                                                     @Override
+                                                     public void apply(final PromiseError error) throws OperationException {
+                                                         workflowExecutor.invalidateContext(project);
+                                                     }
+                                                 });
+                                     }
+                                 })
+                                 .catchError(new Operation<PromiseError>() {
+                                     @Override
+                                     public void apply(final PromiseError error) throws OperationException {
+                                         workflowExecutor.invalidateContext(project);
+                                     }
+                                 });
+    }
+
+    private boolean isNotRootProject(Project project) {
+        return project.getLocation().segmentCount() != 1;
+    }
+
+    private boolean hasContributionMixin(Project project) {
+        return project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID);
+    }
+
+    private boolean hasNoVcsService(Project project) {
+        return vcsServiceProvider.getVcsService(project) == null;
+    }
+
+    private Promise<Project> addMixin(final Project project) {
+        final VcsService vcsService = vcsServiceProvider.getVcsService(project);
+
+        if (vcsService == null || project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID)) {
+            return Promises.resolve(project);
+        }
+
+        final Promise<Project> projectPromise = vcsService.getBranchName(project)
+                                                          .thenPromise(new Function<String, Promise<Project>>() {
+                                                              @Override
+                                                              public Promise<Project> apply(String branchName) throws FunctionException {
+                                                                  MutableProjectConfig mutableConfig = new MutableProjectConfig(project);
+                                                                  mutableConfig.getMixins().add(CONTRIBUTION_PROJECT_TYPE_ID);
+                                                                  mutableConfig.getAttributes().put(CONTRIBUTE_TO_BRANCH_VARIABLE_NAME,
+                                                                                                    singletonList(branchName));
+
+                                                                  return project.update().withBody(mutableConfig).send();
+                                                              }
+                                                          });
+
+        return projectPromise;
+    }
+}

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/inject/PullRequestGinModule.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/inject/PullRequestGinModule.java
@@ -14,6 +14,7 @@
  */
 package com.codenvy.plugin.pullrequest.client.inject;
 
+import com.codenvy.plugin.pullrequest.client.ContributionMixinProvider;
 import com.codenvy.plugin.pullrequest.client.steps.PushBranchStepFactory;
 import com.codenvy.plugin.pullrequest.client.steps.AddForkRemoteStepFactory;
 import com.codenvy.plugin.pullrequest.client.dialogs.commit.CommitView;
@@ -26,8 +27,10 @@ import com.codenvy.plugin.pullrequest.client.steps.WaitForkOnRemoteStepFactory;
 import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
+import com.google.gwt.inject.client.multibindings.GinMultibinder;
 
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
+import org.eclipse.che.ide.api.resources.ResourceInterceptor;
 
 import javax.inject.Singleton;
 
@@ -53,5 +56,7 @@ public class PullRequestGinModule extends AbstractGinModule {
         install(new GinFactoryModuleBuilder().build(WaitForkOnRemoteStepFactory.class));
         install(new GinFactoryModuleBuilder().build(PushBranchStepFactory.class));
         install(new GinFactoryModuleBuilder().build(AddForkRemoteStepFactory.class));
+
+        GinMultibinder.newSetBinder(binder(), ResourceInterceptor.class).addBinding().to(ContributionMixinProvider.class);
     }
 }


### PR DESCRIPTION
Instruct contribution extension to setup mixin before resource registration (in our case project resource).

Previous version of code base registered resource on selection change and in some case it failed due to project type resolving after import phase.

Related issue: https://github.com/codenvy/codenvy/issues/707

@vparfonov review it, plz.