### PR TITLE
Add permissions filter for LdapSynchronizerService

### DIFF
--- a/assembly/onpremises-ide-packaging-war-platform-api/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiServletModule.java
+++ b/assembly/onpremises-ide-packaging-war-platform-api/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiServletModule.java
@@ -95,7 +95,9 @@ public class OnPremisesIdeApiServletModule extends ServletModule {
                "/preferences",
                "/preferences/*",
                "/license",
-               "/license/*")
+               "/license/*",
+               "/ldap/sync",
+               "/ldap/sync/*")
                 .through(com.codenvy.auth.sso.client.LoginFilter.class);
 
         final Map<String, String> corsFilterParams = new HashMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -362,11 +362,6 @@
             </dependency>
             <dependency>
                 <groupId>com.codenvy.onpremises.wsmaster</groupId>
-                <artifactId>codenvy-ldap</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.codenvy.onpremises.wsmaster</groupId>
                 <artifactId>codenvy-hosted-api-machine</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -512,6 +507,11 @@
             <dependency>
                 <groupId>com.codenvy.onpremises.wsmaster</groupId>
                 <artifactId>codenvy-hosted-workspace-activity</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.codenvy.onpremises.wsmaster</groupId>
+                <artifactId>codenvy-ldap</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/wsmaster/codenvy-ldap/pom.xml
+++ b/wsmaster/codenvy-ldap/pom.xml
@@ -31,6 +31,10 @@
     <dependencies>
         <dependency>
             <groupId>com.codenvy.onpremises.wsmaster</groupId>
+            <artifactId>codenvy-hosted-api-permission</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.codenvy.onpremises.wsmaster</groupId>
             <artifactId>codenvy-hosted-platform-api-impl</artifactId>
         </dependency>
         <dependency>
@@ -86,6 +90,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.ldaptive</groupId>
             <artifactId>ldaptive</artifactId>
         </dependency>
@@ -125,6 +133,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-all</artifactId>
             <scope>test</scope>
@@ -132,6 +145,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-jdbc-vendor-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-assured</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -160,4 +178,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <ignoredDependencies>
+                                <ignoredDependency>com.codenvy.onpremises.wsmaster:codenvy-hosted-api-permission</ignoredDependency>
+                            </ignoredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/LdapSynchronizerPermissionsFilter.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/LdapSynchronizerPermissionsFilter.java
@@ -1,0 +1,45 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ldap.sync;
+
+import com.codenvy.api.permission.server.SystemDomain;
+
+import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.everrest.CheMethodInvokerFilter;
+import org.everrest.core.Filter;
+import org.everrest.core.resource.GenericResourceMethod;
+
+import javax.ws.rs.Path;
+
+/**
+ * Rejects/allows access to the methods of {@link LdapSynchronizerService}.
+ *
+ * <p>All the service methods MUST be allowed only to those users who have
+ * {@link SystemDomain#MANAGE_CODENVY_ACTION} permission.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Filter
+@Path("/ldap/sync{path:.*}")
+public class LdapSynchronizerPermissionsFilter extends CheMethodInvokerFilter {
+
+    @Override
+    protected void filter(GenericResourceMethod resource, Object[] args) throws ApiException {
+        EnvironmentContext.getCurrent()
+                          .getSubject()
+                          .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_CODENVY_ACTION);
+    }
+}

--- a/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizerServiceTest.java
+++ b/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizerServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ldap.sync;
+
+import com.jayway.restassured.response.Response;
+
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.rest.ApiExceptionMapper;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.everrest.assured.EverrestJetty;
+import org.everrest.core.Filter;
+import org.everrest.core.GenericContainerRequest;
+import org.everrest.core.RequestFilter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
+import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests {@link LdapSynchronizerService} and {@link LdapSynchronizerPermissionsFilter}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Listeners({EverrestJetty.class, MockitoTestNGListener.class})
+public class LdapSynchronizerServiceTest {
+
+    @SuppressWarnings("unused")
+    private static LdapSynchronizerPermissionsFilter PERMISSIONS_FILTER = new LdapSynchronizerPermissionsFilter();
+    @SuppressWarnings("unused")
+    private static EnvironmentFilter                 ENVIRONMENT_FILTER = new EnvironmentFilter();
+    @SuppressWarnings("unused")
+    private static ApiExceptionMapper                EX_MAPPER          = new ApiExceptionMapper();
+
+    @Mock
+    private static SubjectImpl SUBJECT;
+
+    @Mock
+    private LdapSynchronizer synchronizer;
+
+    @InjectMocks
+    private LdapSynchronizerService syncService;
+
+    @Test
+    public void shouldCallSync() throws Exception {
+        given().auth()
+               .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+               .when()
+               .post(SECURE_PATH + "/ldap/sync");
+
+        verify(synchronizer).syncAllAsynchronously();
+    }
+
+    @Test
+    public void shouldReturn409WhenSyncCouldNotBePerformedDueToOngoingOne() throws Exception {
+        doThrow(new SyncException("test")).when(synchronizer).syncAllAsynchronously();
+
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .when()
+                                         .post(SECURE_PATH + "/ldap/sync");
+
+        assertEquals(response.getStatusCode(), 409);
+        verify(synchronizer).syncAllAsynchronously();
+    }
+
+    @Test
+    public void shouldRejectSynchronizationIfUserPermissionsCheckFails() throws Exception {
+        doThrow(new ForbiddenException("test")).when(SUBJECT).checkPermission(anyString(), anyString(), anyString());
+
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .when()
+                                         .post(SECURE_PATH + "/ldap/sync");
+
+        assertEquals(response.getStatusCode(), 403);
+        verify(synchronizer, never()).syncAllAsynchronously();
+    }
+
+    @Filter
+    public static class EnvironmentFilter implements RequestFilter {
+        public void doFilter(GenericContainerRequest request) {
+            EnvironmentContext.getCurrent().setSubject(SUBJECT);
+        }
+    }
+}


### PR DESCRIPTION
Allows/rejects synchronization based on `MANAGE_CODENVY_ACTION` existence.

@skabashnyuk, @sleshchenko please review