### PR TITLE
(#456) fix update of hostname of Codenvy on-prem with machine nodes

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/commands/CommandLibrary.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/commands/CommandLibrary.java
@@ -533,7 +533,7 @@ public class CommandLibrary {
      * @see "http://www.unix.com/302910488-post2.html?s=c351328813d6bc7a509c0a5dee5dc9e7"
      */
     private static String getCheckRemotePortOpenedCommand(String remoteHost, int remotePort) {
-        return format("2>/dev/null >/dev/tcp/%s/%s", remoteHost, remotePort);
+        return format("sleep 3 && echo >/dev/tcp/%s/%s", remoteHost, remotePort);
     }
 
     private static class EmptyCommand implements Command {

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
@@ -135,7 +135,7 @@ authWithoutRealmAndServerDns "cdec" "pwd123ABC"
 doPost "application/json" "{}" "http://${HOST_URL}/api/workspace/${WORKSPACE_ID}/runtime?token=${TOKEN}"
 
 # obtain network ports
-doSleep "10m"  "Wait until workspace starts to avoid 'java.lang.NullPointerException' error on verifying workspace state"
+doSleep "6m"  "Wait until workspace starts to avoid 'java.lang.NullPointerException' error on verifying workspace state"
 doGet "http://${HOST_URL}/api/workspace/${WORKSPACE_ID}?token=${TOKEN}"
 validateExpectedString ".*\"status\":\"RUNNING\".*"
 fetchJsonParameter "network.ports"

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/node/test-add-remove-codenvy-nodes.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/node/test-add-remove-codenvy-nodes.sh
@@ -51,7 +51,7 @@ executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${HOST_URL}:23750/info"
 validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${HOST_URL}:2375\"\].*"
 
-# throw error that node has been already used
+## throw error that node has been already used
 executeIMCommand "--valid-exit-code=1" "add-node" "node1.${HOST_URL}"
 validateExpectedString ".*Node..node1.${HOST_URL}..has.been.already.used.*"
 
@@ -64,22 +64,26 @@ executeIMCommand "--valid-exit-code=1" "add-node" "node3.${HOST_URL}"
 validateExpectedString ".*Can.t.connect.to.host..vagrant@node3.${HOST_URL}:22.*"
 
 ############# Start of change Codenvy hostname workflow
-# change '${HOST_URL}' hostname on '${NEW_HOST_URL}' on puppet master
-executeSshCommand "sudo sed -i 's/ ${HOST_URL}/ ${NEW_HOST_URL}/' /etc/hosts" "node1.${HOST_URL}"
-executeSshCommand "sudo sed -i 's/ ${HOST_URL}/ ${NEW_HOST_URL}/' /etc/hosts" "node2.${NEW_HOST_URL}"
+# throw error on changing Codenvy host_url from '${HOST_URL}' to '${NEW_HOST_URL}'
+executeIMCommand "--valid-exit-code=1" "config" "--hostname" "${NEW_HOST_URL}"
+validateExpectedString ".*There.is.a.problem.with.one.of.the.additional.nodes.with.new.hostname.*node1.${NEW_HOST_URL}.*"
+
+ change '${HOST_URL}' hostname on '${NEW_HOST_URL}'
+executeSshCommand "sudo sed -i 's/${HOST_URL}/${NEW_HOST_URL}/g' /etc/hosts" "node1.${HOST_URL}"
+executeSshCommand "sudo sed -i 's/${HOST_URL}/${NEW_HOST_URL}/g' /etc/hosts"
+executeSshCommand "sudo sed -i 's/${HOST_URL}/${NEW_HOST_URL}/g' /etc/hosts" "node2.${HOST_URL}"
+doSleep "1m"  "Wait until network settings are used"
 
 # change Codenvy host_url from '${HOST_URL}' to '${NEW_HOST_URL}'
 executeIMCommand "config" "--hostname" "${NEW_HOST_URL}"
 
-# change 'node1.${HOST_URL}' hostname on 'node1.test.${HOST_URL}' on node1
-executeSshCommand "sudo sed -i 's/192.168.56.15 node1.${HOST_URL}//' /etc/hosts" "node1.${HOST_URL}"
-executeSshCommand "sudo sed -i 's/ node1.${HOST_URL}/ node1.${NEW_HOST_URL}/' /etc/hosts" "node1.${HOST_URL}"
-executeSshCommand "sudo sed -i 's/ node1.${HOST_URL}/ node1.${NEW_HOST_URL}/' /etc/hosts"
-executeSshCommand "sudo sed -i 's/ node1.${HOST_URL}/ node1.${NEW_HOST_URL}/' /etc/hosts" "node2.${NEW_HOST_URL}"
+executeSshCommand "sudo systemctl stop iptables"  # open port 23750
+doGet "http://${NEW_HOST_URL}:23750/info"
+validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${NEW_HOST_URL}:2375\"\].*"
 
-# remove node1.${HOST_URL}
-executeIMCommand "remove-node" "node1.${HOST_URL}"
-validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node1.${HOST_URL}\".*"
+# remove node1.${NEW_HOST_URL}
+executeIMCommand "remove-node" "node1.${NEW_HOST_URL}"
+validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node1.${NEW_HOST_URL}\".*"
 doSleep "1m"  "Wait until Docker machine takes into account /usr/local/swarm/node_list config"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
@@ -98,7 +102,7 @@ executeIMCommand "add-node" "node2.${NEW_HOST_URL}"
 validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node2.${NEW_HOST_URL}\".*"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
-validateExpectedString ".*Nodes\",\"3\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${NEW_HOST_URL}:2375\"\].*\[\" node2.${NEW_HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
+validateExpectedString ".*Nodes\",\"3\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${NEW_HOST_URL}:2375\"\].*\[\" node2.${HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
 
 # remove node2
 executeIMCommand "remove-node" "node2.${NEW_HOST_URL}"
@@ -118,7 +122,7 @@ executeIMCommand "add-node" "node2.${NEW_HOST_URL}"
 validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node2.${NEW_HOST_URL}\".*"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
-validateExpectedString ".*Nodes\",\"3\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${NEW_HOST_URL}:2375\"\].*\[\" node2.${NEW_HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
+validateExpectedString ".*Nodes\",\"3\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${NEW_HOST_URL}:2375\"\].*\[\" node2.${HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
 
 # remove node1.${NEW_HOST_URL}
 executeIMCommand "remove-node" "node1.${NEW_HOST_URL}"
@@ -126,7 +130,7 @@ validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node1.${NE
 doSleep "1m"  "Wait until Docker machine takes into account /usr/local/swarm/node_list config"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
-validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node2.${NEW_HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
+validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node2.${HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
 
 # remove default node
 executeIMCommand "remove-node" "${NEW_HOST_URL}"
@@ -134,7 +138,7 @@ validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"${NEW_HOST
 doSleep "1m"  "Wait until Docker machine takes into account /usr/local/swarm/node_list config"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
-validateExpectedString ".*Nodes\",\"1\".*[\" node2.${NEW_HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
+validateExpectedString ".*Nodes\",\"1\".*[\" node2.${HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
 
 # try to remove default node again and throw error
 executeIMCommand "--valid-exit-code=1" "remove-node" "${NEW_HOST_URL}"
@@ -143,7 +147,7 @@ validateExpectedString ".*Node..${NEW_HOST_URL}..is.not.found.*"
 # remove node2
 executeIMCommand "remove-node" "node2.${NEW_HOST_URL}"
 validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node2.${NEW_HOST_URL}\".*"
-executeSshCommand "sudo find /var/lib/puppet/ssl -name node2.${NEW_HOST_URL}.pem -delete" "node2.${NEW_HOST_URL}"  # remove puppet agent certificate
+executeSshCommand "sudo find /var/lib/puppet/ssl -name node2.${HOST_URL}.pem -delete" "node2.${NEW_HOST_URL}"  # remove puppet agent certificate
 doSleep "1m"  "Wait until Docker machine takes into account /usr/local/swarm/node_list config"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
@@ -154,14 +158,14 @@ executeIMCommand "add-node" "node2.${NEW_HOST_URL}"
 validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node2.${NEW_HOST_URL}\".*"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
-validateExpectedString ".*Nodes\",\"1\".*\[\" node2.${NEW_HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
+validateExpectedString ".*Nodes\",\"1\".*\[\" node2.${HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
 
 # add default node
 executeIMCommand "add-node" "${NEW_HOST_URL}"
 validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"${NEW_HOST_URL}\".*"
 executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
-validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*[\" node2.${NEW_HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
+validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*[\" node2.${HOST_URL}\",\"node2.${NEW_HOST_URL}:2375\"].*"
 
 # add default node again and throw error
 executeIMCommand "--valid-exit-code=1" "add-node" "${NEW_HOST_URL}"

--- a/cdec/installation-manager-tests/src/main/resources/vagrant/single-with-additional-nodes/CentOS7/Vagrantfile
+++ b/cdec/installation-manager-tests/src/main/resources/vagrant/single-with-additional-nodes/CentOS7/Vagrantfile
@@ -53,7 +53,7 @@ end
 ###################
 config.vm.define :node2 do |node2_instance_config|
 hostname = 'node2'
-domain = 'test.codenvy.onprem'
+domain = 'codenvy.onprem'
 node2_instance_config.vm.host_name = hostname + '.' + domain
 node2_instance_config.vm.network :private_network, ip: "192.168.56.20"
 node2_instance_config.vm.provider :virtualbox do |vbox|
@@ -73,7 +73,7 @@ config.vm.provision "shell", inline: "echo -e \"nameserver 172.19.20.192\n\" >> 
 
 config.vm.provision :hosts do |config|
 config.add_host '192.168.56.15', ['node1.codenvy.onprem']
-config.add_host '192.168.56.20', ['node2.test.codenvy.onprem']
+config.add_host '192.168.56.20', ['node2.codenvy.onprem']
 config.add_host '192.168.56.110', ['codenvy.onprem']
 end
 


### PR DESCRIPTION
List of points:
1) fix absolute value of **certname** property in _/etc/puppet/puppet.conf_ on machine node;
2) update _/etc/puppet/autosign.conf_ with new machine node hostnames on master;
3) update *$swarm_node* variable in _/etc/puppet/manifests/nodes/codenvy/codenvy.pp_ on master  with new machine node hostnames;
4) check if existed nodes with new hostname are available before changing hostname.

@tolusha: please, review this request.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>