### PR TITLE
Installation manager fixup.

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
@@ -153,6 +153,7 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
                     Path file = propertiesFiles.next();
 
                     commands.add(createReplaceCommand(file, "YOUR_DNS_NAME", config.getHostUrl()));
+                    commands.add(createReplaceCommand(file, "codenvy.onprem", config.getHostUrl()));
                     for (Map.Entry<String, String> e : config.getProperties().entrySet()) {
                         String property = e.getKey();
                         String value = e.getValue();
@@ -245,6 +246,7 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
 
                     // set host url in the "machine instance" section of puppet manifest
                     commands.add(createReplaceCommand(propertiesFileOfCodenvyBinary, "YOUR_DNS_NAME", config.getHostUrl()));
+                    commands.add(createReplaceCommand(propertiesFileOfCodenvyBinary, "codenvy.onprem", config.getHostUrl()));
 
                     // replace propertiesFileOfCodenvyBinary on actual codenvy properties
                     for (Map.Entry<String, String> e : config.getProperties().entrySet()) {

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestCDECArtifact.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestCDECArtifact.java
@@ -391,13 +391,14 @@ public class TestCDECArtifact extends BaseTest {
                             TMP_CODENVY));
 
         List<Command> commands = ((MacroCommand) spyCdecArtifact.getUpdateCommand(versionToUpdate, pathToBinaries, options.setStep(1))).getCommands();
-        assertEquals(commands.size(), 8);
+        assertEquals(commands.size(), 10);
         k = 0;
 
         assertTrue(commands.get(k).toString().matches(format("\\{'command'='sudo cp %1$s/manifests/nodes/single_server/base_config.pp %1$s/manifests/nodes/single_server/base_config.pp.back ; sudo cp %1$s/manifests/nodes/single_server/base_config.pp %1$s/manifests/nodes/single_server/base_config.pp.back.\\d+ ; ', 'agent'='LocalAgent'\\}", ETC_PUPPET)),
                                                       "Actual command: " + commands.get(k++).toString());
 
         assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/base_config.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|YOUR_DNS_NAME|host_url|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/base_config.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
+        assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/base_config.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|codenvy.onprem|host_url|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/base_config.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
         assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/base_config.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|$host_url *= *\"[^\"]*\"|$host_url = \"host_url\"|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/base_config.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
         assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/base_config.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|$some property *= *\"[^\"]*\"|$some property = \"some value\"|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/base_config.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
 
@@ -405,6 +406,7 @@ public class TestCDECArtifact extends BaseTest {
                    "Actual command: " + commands.get(k++).toString());
 
         assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/single_server.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|YOUR_DNS_NAME|host_url|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/single_server.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
+        assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/single_server.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|codenvy.onprem|host_url|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/single_server.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
         assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/single_server.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|$host_url *= *\"[^\"]*\"|$host_url = \"host_url\"|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/single_server.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
         assertEquals(commands.get(k++).toString(), format("{'command'='sudo cat %1$s/manifests/nodes/single_server/single_server.pp | sed ':a;N;$!ba;s/\\n/~n/g' | sed 's|$some property *= *\"[^\"]*\"|$some property = \"some value\"|g' | sed 's|~n|\\n|g' > tmp.tmp && sudo mv tmp.tmp %1$s/manifests/nodes/single_server/single_server.pp', 'agent'='LocalAgent'}", TMP_CODENVY));
 

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/backup/test-backup-restore-single-node.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/backup/test-backup-restore-single-node.sh
@@ -44,8 +44,8 @@ BACKUP_AT_START=${OUTPUT}
 # modify data: add account, workspace, project, user
 authWithoutRealmAndServerDns "admin" "password"
 
-# create user "cdec.im.test@gmail.com"
-doPost "application/json" "{\"name\":\"cdec\",\"email\":\"cdec.im.test@gmail.com\",\"password\":\"pwd123ABC\"}" "http://${HOST_URL}/api/user" "${TOKEN}"
+# create user "cdec.im.test1@gmail.com"
+doPost "application/json" "{\"name\":\"cdec\",\"email\":\"cdec.im.test1@gmail.com\",\"password\":\"pwd123ABC\"}" "http://${HOST_URL}/api/user" "${TOKEN}"
 fetchJsonParameter "id"
 USER_ID=${OUTPUT}
 
@@ -124,9 +124,9 @@ executeIMCommand "restore" ${BACKUP_WITH_MODIFICATIONS}
 authWithoutRealmAndServerDns "admin" "password"
 
 doGet "http://${HOST_URL}/api/user/${USER_ID}?token=${TOKEN}"
-validateExpectedString ".*cdec.im.test@gmail.com.*"
+validateExpectedString ".*cdec.im.test1@gmail.com.*"
 
-authWithoutRealmAndServerDns "cdec.im.test@gmail.com" "pwd123ABC"
+authWithoutRealmAndServerDns "cdec.im.test1@gmail.com" "pwd123ABC"
 
 doGet "http://${HOST_URL}/api/workspace/${WORKSPACE_ID}?token=${TOKEN}"
 validateExpectedString ".*${PROJECT_NAME}.*${WORKSPACE_NAME}.*"

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
@@ -81,8 +81,8 @@ validateExpectedString ".*NO_PROXY=\"$NO_PROXY\".*"
 ## check creation of workspace
 authWithoutRealmAndServerDns "admin" "password"
 
-# create user "cdec.im.test@gmail.com"
-doPost "application/json" "{\"name\":\"cdec\",\"email\":\"cdec.im.test@gmail.com\",\"password\":\"pwd123ABC\"}" "http://${HOST_URL}/api/user" "${TOKEN}"
+# create user "cdec.im.test1@gmail.com"
+doPost "application/json" "{\"name\":\"cdec\",\"email\":\"cdec.im.test1@gmail.com\",\"password\":\"pwd123ABC\"}" "http://${HOST_URL}/api/user" "${TOKEN}"
 fetchJsonParameter "id"
 USER_ID=${OUTPUT}
 

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/update/test-update-single-node-from-binary.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/update/test-update-single-node-from-binary.sh
@@ -27,6 +27,9 @@ validateInstalledCodenvyVersion ${PREV_CODENVY_VERSION}
 executeSshCommand "cat codenvy/codenvy.properties | grep 'install_monitoring_tools=false'"
 authWithoutRealmAndServerDns "admin" "password"
 
+executeSshCommand "sudo sed -i 's/${HOST_URL}/${NEW_HOST_URL}/g' /etc/hosts"
+executeIMCommand "config" "--hostname" "${NEW_HOST_URL}"
+
 executeIMCommand "download" "codenvy" "${LATEST_CODENVY_VERSION}"
 
 BINARIES="/home/vagrant/codenvy/updates/codenvy/${LATEST_CODENVY_VERSION}/codenvy-${LATEST_CODENVY_VERSION}.zip"

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/update/test-update-single-node.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/update/test-update-single-node.sh
@@ -32,8 +32,8 @@ validateInstalledCodenvyVersion ${PREV_CODENVY_VERSION}
 # create data: add account, workspace, project, user, factory
 authWithoutRealmAndServerDns "admin" "password"
 
-# create user "cdec.im.test@gmail.com"
-doPost "application/json" "{\"name\":\"cdec\",\"email\":\"cdec.im.test@gmail.com\",\"password\":\"pwd123ABC\"}" "http://${HOST_URL}/api/user" "${TOKEN}"
+# create user "cdec.im.test1@gmail.com"
+doPost "application/json" "{\"name\":\"cdec\",\"email\":\"cdec.im.test1@gmail.com\",\"password\":\"pwd123ABC\"}" "http://${HOST_URL}/api/user" "${TOKEN}"
 fetchJsonParameter "id"
 USER_ID=${OUTPUT}
 
@@ -95,9 +95,9 @@ validateExpectedString ".*\"Version.of.backed.up.artifact.'${PREV_CODENVY_VERSIO
 authWithoutRealmAndServerDns "admin" "password"
 
 doGet "http://${HOST_URL}/api/user/${USER_ID}?token=${TOKEN}"
-validateExpectedString ".*cdec.im.test@gmail.com.*"
+validateExpectedString ".*cdec.im.test1@gmail.com.*"
 
-authWithoutRealmAndServerDns "cdec.im.test@gmail.com" "pwd123ABC"
+authWithoutRealmAndServerDns "cdec.im.test1@gmail.com" "pwd123ABC"
 
 doGet "http://${HOST_URL}/api/workspace/${WORKSPACE_ID}?token=${TOKEN}"
 validateExpectedString ".*${PROJECT_NAME}.*${WORKSPACE_NAME}.*"

--- a/cdec/installation-manager-tests/src/test/resources/MainSuite.xml
+++ b/cdec/installation-manager-tests/src/test/resources/MainSuite.xml
@@ -43,11 +43,11 @@
         </classes>
     </test>
 
-    <test name="im-cli-with-codenvy3">
+    <!--test name="im-cli-with-codenvy3">
         <classes>
             <class name="com.codenvy.im.TestInstallationManagerCliWithCodenvy3"/>
         </classes>
-    </test>
+    </test-->
 
     <test name="im-cli-with-codenvy">
         <classes>


### PR DESCRIPTION
### What does this PR do?
1. Switch off integration testing of Codenvy on-prem 3.x
2. Take into account replacement 'YOUR_DNS_NAME' on 'codenvy.onprem' in default manifest.
