### PR TITLE
Fix unit tests of IM CLI

### DIFF
--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/commands/decorators/BaseTestPuppetErrorInterrupter.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/commands/decorators/BaseTestPuppetErrorInterrupter.java
@@ -91,7 +91,7 @@ public abstract class BaseTestPuppetErrorInterrupter {
     public void setup() throws IOException {
         MockitoAnnotations.initMocks(this);
 
-        deleteIfExists(BASE_TMP_DIRECTORY);
+        FileUtils.deleteDirectory(BASE_TMP_DIRECTORY.toFile());
 
         createDirectory(BASE_TMP_DIRECTORY);
         createDirectory(REPORT_TMP_DIRECTORY);

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/testhelper/ssh/SshServerFactory.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/testhelper/ssh/SshServerFactory.java
@@ -62,9 +62,9 @@ public class SshServerFactory {
     public static SshServer createSshd() {
         // it is needed to fix test execution on Jenkins so as it registers own JCE Provider when use 'Ssh Plugin'
         // before running tests, and it leads to error 'Algorithm negotiation fail' (issue CDEC-469).
-        if (java.security.Security.getProvider(SecurityUtils.BOUNCY_CASTLE) != null) {
-            java.security.Security.removeProvider(SecurityUtils.BOUNCY_CASTLE);
-        }
+//        if (java.security.Security.getProvider(SecurityUtils.BOUNCY_CASTLE) != null) {
+//            java.security.Security.removeProvider(SecurityUtils.BOUNCY_CASTLE);
+//        }
 
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(TEST_SSH_PORT);

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/utils/TestHttpTransport.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/utils/TestHttpTransport.java
@@ -26,6 +26,7 @@ import org.mockito.testng.MockitoTestNGListener;
 import org.testng.ITestContext;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -183,7 +184,7 @@ public class TestHttpTransport {
     }
 
     @Test(dataProvider = "testConsideringAuthenticatedProxyData")
-    public void testConsideringAuthenticatedHttpProxy(String username, String password, Runnable verification) throws IOException {
+    public void testConsideringAuthenticatedHttpProxy(String username, String password) throws IOException {
         String httpPath = "http://localhost";
 
         if (username != null) {
@@ -195,12 +196,25 @@ public class TestHttpTransport {
         }
 
         HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        doReturn(new URL(httpPath)).when(mockConnection).getURL();
         doReturn(200).when(mockConnection).getResponseCode();
 
         doReturn(mockConnection).when(spyHttpTransport).openConnection(httpPath, null, false);
 
         spyHttpTransport.doGet(httpPath);
-        verification.run();
+    }
+
+    @DataProvider
+    public Object[][] testConsideringAuthenticatedProxyData() {
+        return new Object[][]{
+            {null, null},
+            {"", null},
+            {null, ""},
+            {null, "pass"},
+            {"test", null},
+            {"test", ""},
+            {"test", "pass"}
+        };
     }
 
     @Test

--- a/cdec/installation-manager-core/src/test/resources/logback-test.xml
+++ b/cdec/installation-manager-core/src/test/resources/logback-test.xml
@@ -19,12 +19,11 @@
 
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n%nopex</pattern>
         </encoder>
     </appender>
-
     <appender name="file" class="ch.qos.logback.core.FileAppender">
-        <File>target/tests.log</File>
+        <File>target/log/test.log</File>
         <encoder>
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
Tests of **installation-manager-core** project which are fixed by this request:

```
Tests run: 778, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 99.598 sec <<< FAILURE! - in TestSuite
testInterruptWhenAddErrorOnNode(com.codenvy.im.commands.decorators.TestPuppetErrorInterrupterOnNode)  Time elapsed: 3.399 sec  <<< FAILURE!
java.lang.AssertionError: mockCommand should be interrupted by spyInterrupter, but wasn't
	at org.testng.Assert.fail(Assert.java:94)
	at com.codenvy.im.commands.decorators.TestPuppetErrorInterrupterOnNode.testInterruptWhenAddErrorOnNode(TestPuppetErrorInterrupterOnNode.java:164)


Results :

Failed tests: 
  TestPuppetErrorInterrupterOnNode.testInterruptWhenAddErrorOnNode:164 mockCommand should be interrupted by spyInterrupter, but wasn't

Tests run: 778, Failures: 1, Errors: 0, Skipped: 1
```

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>