### PR TITLE
Fix bootstrap script to work around new admin name/password properties

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -1912,14 +1912,14 @@ updateLoader() {
 printPostInstallInfo_codenvy() {
     local systemAdminName=$(readProperty "admin_ldap_user_name")
     if [ -z "$systemAdminName" ]; then
-        systemAdminName=$(readProperty "codenvy_admin_name")  # property name starting from version 5.0.0-M3
+        systemAdminName=$(readProperty "codenvy_admin_name")  # property name starting from version 5.0.0-M4
     fi
 
 
     if [[ "${VERSION}" =~ ^([4-5]).* ]]; then
         local systemAdminPassword=$(readProperty "admin_ldap_password")
         if [ -z "$systemAdminPassword" ]; then
-            systemAdminPassword=$(readProperty "codenvy_admin_initial_password")  # property name starting from version 5.0.0-M3
+            systemAdminPassword=$(readProperty "codenvy_admin_initial_password")  # property name starting from version 5.0.0-M4
         fi
     else
         local systemAdminPassword=$(readProperty "system_ldap_password")
@@ -2139,11 +2139,19 @@ pauseInternetAccessChecker
 pauseFooterUpdater
 
 if [[ "${ARTIFACT}" == "codenvy" ]] && [[ "${VERSION}" =~ ^([4-5]).* ]]; then
-    adminName=$(readProperty 'admin_ldap_user_name')
-    adminPassword=$(readProperty 'admin_ldap_password')
+    systemAdminName=$(readProperty "admin_ldap_user_name")
+    if [ -z "$systemAdminName" ]; then
+        systemAdminName=$(readProperty "codenvy_admin_name")  # property name starting from version 5.0.0-M4
+    fi
+
+    systemAdminPassword=$(readProperty "admin_ldap_password")
+    if [ -z "$systemAdminPassword" ]; then
+        systemAdminPassword=$(readProperty "codenvy_admin_initial_password")  # property name starting from version 5.0.0-M4
+    fi
+
     toolVersion=$(if [[ "${VERSION}" =~ .*SNAPSHOT$ ]]; then echo "nightly"; else echo ${VERSION}; fi)
 
-    postFlightCheckOfCodenvy "$adminName" "$adminPassword" "$toolVersion"
+    postFlightCheckOfCodenvy "$systemAdminName" "$systemAdminPassword" "$toolVersion"
     println
 fi
 


### PR DESCRIPTION
This request fixes error: 

> 'Call on rest url /api/workspace?account= returned invalid response code (401) with error:User not authorized to call this method.'

![5 0 0-m4-testing-error](https://cloud.githubusercontent.com/assets/1197777/19045515/ddcf909a-89a1-11e6-941b-36680fe10bc2.png)


Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>