### PR TITLE
Use go flags to compile binaries in static mode

### DIFF
--- a/lib/websocket-terminal/pom.xml
+++ b/lib/websocket-terminal/pom.xml
@@ -244,10 +244,14 @@
                                         <workingDirectory>${project.build.directory}/${item}/go</workingDirectory>
                                         <arguments>
                                             <argument>build</argument>
+                                            <argument>-a</argument>
+                                            <argument>-installsuffix</argument>
+                                            <argument>cgo</argument>
                                             <argument>-o</argument>
                                             <argument>che-websocket-terminal</argument>
                                         </arguments>
                                         <environmentVariables>
+                                            <CGO_ENABLED>0</CGO_ENABLED>
                                             <GOOS>${terminal.target.os}</GOOS>
                                             <GOARCH>${terminal.target.architecture}</GOARCH>
                                             <GOARM>${terminal.target.arm.version}</GOARM>


### PR DESCRIPTION
### What does this PR do?

no need to have glibc installed for example (some "small in size" linux distributions don't have it by default like Alpine)

it's a backport of che change https://github.com/eclipse/che-lib/pull/14

### What issues does this PR fix or reference?
run terminal go in alpine where glibc is not installed by default

### Previous Behavior
error if glibc is not installed

### New Behavior
it works

### Tests written?
No

Change-Id: Iae715a460c1f09d11a16865d4f113d205fc7170c
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>