### PR TITLE
Fix variables inside the Codenvy on-prem patch files to be enclosed i…

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/patches/4.3.4/single_server/patch_before_update.sh
+++ b/cdec/installation-manager-resources/src/main/resources/patches/4.3.4/single_server/patch_before_update.sh
@@ -11,4 +11,4 @@ echo "Migration scripts are situated in directory '$CURRENT_DIR'" >> $LOG_FILE
 #### fix mongoDB
 echo "=========== fix mongoDB ======" >> $LOG_FILE
 
-mongo -u$mongo_admin_user_name -p$mongo_admin_pass --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
+mongo -u${mongo_admin_user_name} -p${mongo_admin_pass} --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE

--- a/cdec/installation-manager-resources/src/main/resources/patches/4.6.0/single_server/patch_before_update.sh
+++ b/cdec/installation-manager-resources/src/main/resources/patches/4.6.0/single_server/patch_before_update.sh
@@ -11,4 +11,4 @@ echo "Migration scripts are situated in directory '$CURRENT_DIR'" >> $LOG_FILE
 #### fix mongoDB
 echo "=========== fix mongoDB ======" >> $LOG_FILE
 
-mongo -u$mongo_admin_user_name -p$mongo_admin_pass --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
+mongo -u${mongo_admin_user_name} -p${mongo_admin_pass} --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE

--- a/cdec/installation-manager-resources/src/main/resources/patches/4.6.2/single_server/patch_before_update.sh
+++ b/cdec/installation-manager-resources/src/main/resources/patches/4.6.2/single_server/patch_before_update.sh
@@ -11,4 +11,4 @@ echo "Migration scripts are situated in directory '$CURRENT_DIR'" >> $LOG_FILE
 #### fix mongoDB
 echo "=========== fix mongoDB ======" >> $LOG_FILE
 
-mongo -u$mongo_admin_user_name -p$mongo_admin_pass --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
+mongo -u${mongo_admin_user_name} -p${mongo_admin_pass} --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE

--- a/cdec/installation-manager-resources/src/main/resources/patches/4.7.0/single_server/patch_before_update.sh
+++ b/cdec/installation-manager-resources/src/main/resources/patches/4.7.0/single_server/patch_before_update.sh
@@ -16,5 +16,5 @@ echo "Migration scripts are situated in directory '$CURRENT_DIR'" >> $LOG_FILE
 echo >> $LOG_FILE
 echo "------ fix mongoDB -----" >> $LOG_FILE
 
-mongo -u$mongo_admin_user_name -p$mongo_admin_pass --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
+mongo -u${mongo_admin_user_name} -p${mongo_admin_pass} --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
 

--- a/cdec/installation-manager-resources/src/main/resources/patches/5.0.0-M1/single_server/patch_before_update.sh
+++ b/cdec/installation-manager-resources/src/main/resources/patches/5.0.0-M1/single_server/patch_before_update.sh
@@ -56,12 +56,12 @@ createFileBackup() {
     fi
 }
 
-createFileBackup "$PATH_TO_MANIFEST"
+createFileBackup "${PATH_TO_MANIFEST}"
 
 if [[ '$machine_ws_agent_run_command' =~ .*sleep.5.&&.mkdir.-p.~/che.&&.rm.-rf.~/che/*.&&.unzip.-q./mnt/che/ws-agent.zip.-d.~/che/ws-agent.&&.~/che/ws-agent/bin/catalina.sh.run ]]; then
     echo >> $LOG_FILE
-    echo "Update codenvy property: machine_ws_agent_run_command = '$machine_ws_agent_run_command'" >> $LOG_FILE
-    sudo sed -i 's|sleep 5 && mkdir -p ~/che && rm -rf ~/che/[*] && unzip -q /mnt/che/ws-agent.zip -d ~/che/ws-agent && ~/che/ws-agent/bin/catalina.sh run|~/che/ws-agent/bin/catalina.sh run|g' "$PATH_TO_MANIFEST" &>> $LOG_FILE
+    echo "Update codenvy property: machine_ws_agent_run_command = '${machine_ws_agent_run_command}'" >> $LOG_FILE
+    sudo sed -i 's|sleep 5 && mkdir -p ~/che && rm -rf ~/che/[*] && unzip -q /mnt/che/ws-agent.zip -d ~/che/ws-agent && ~/che/ws-agent/bin/catalina.sh run|~/che/ws-agent/bin/catalina.sh run|g' "${PATH_TO_MANIFEST}" &>> $LOG_FILE
 fi
 
 
@@ -69,5 +69,5 @@ fi
 echo >> $LOG_FILE
 echo "------ fix mongoDB ------" >> $LOG_FILE
 
-mongo -u$mongo_admin_user_name -p$mongo_admin_pass --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
+mongo -u${mongo_admin_user_name} -p${mongo_admin_pass} --authenticationDatabase admin "${CURRENT_DIR}/update_mongo.js" &>> $LOG_FILE
 


### PR DESCRIPTION
### What does this PR do?
This request fixes errors of update from one Codenvy on-prem version to another prior to update to 5.0.0-M4, for example: error of update Codenvy on-prem 4.7.2 to 5.0.0-M1:
```
[vagrant@dev]# codenvy install
[CODENVY] Unzip Codenvy binaries to /tmp/codenvy [OK]
[CODENVY] Configure Codenvy                      [OK]
[CODENVY] Patch resources before update          [FAIL]
[CODENVY] {
  "artifacts" : [ {
    "artifact" : "codenvy",
    "version" : "5.0.0-M1",
    "status" : "FAILURE"
  } ],
  "message" : "Command execution fail. Error: Can't execute command 'bash /tmp/codenvy/patches/single_server/patch_before_update.sh'. Output: ; Error: .",
  "status" : "ERROR"

```
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>