### PR TITLE
Fix backup command of IM CLI to work with long file names in workspaces

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
@@ -329,10 +329,6 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
         Path tempDir = backupConfig.obtainArtifactTempDirectory();
         Path backupFile = Paths.get(backupConfig.getBackupFile());
 
-        // re-create local temp dir
-        commands.add(createCommand(format("rm -rf %s", tempDir)));
-        commands.add(createCommand(format("mkdir -p %s", tempDir)));
-
         // stop services
         commands.add(createStopServiceCommand("crond"));
         commands.add(createStopServiceCommand("puppet"));
@@ -375,19 +371,16 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
         }
 
         // pack dumps into backup file
-        commands.add(createPackCommand(tempDir, backupFile, ".", false));
+        commands.add(createPackCommand(tempDir, backupFile, "*", false));
 
         // pack filesystem data into the {backup_file}/fs folder
-        commands.add(createPackCommand(Paths.get("/home/codenvy/codenvy-data"), backupFile, "fs/.", true));
+        commands.add(createPackCommand(Paths.get("/home/codenvy/codenvy-data"), backupFile, "fs", true));
 
         // start services
         commands.add(createStartServiceCommand("puppet"));
 
         // wait until API server starts
         commands.add(new WaitOnAliveArtifactCommand(original));
-
-        // remove temp dir
-        commands.add(createCommand(format("rm -rf %s", tempDir)));
 
         return new MacroCommand(commands, "Backup data commands");
     }
@@ -415,10 +408,6 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
         List<Command> commands = new ArrayList<>();
         Config codenvyConfig = configManager.loadInstalledCodenvyConfig();
         Path tempDir = backupConfig.obtainArtifactTempDirectory();
-        Path backupFile = Paths.get(backupConfig.getBackupFile());
-
-        // unpack backupFile into the tempDir
-        TarUtils.unpackAllFiles(backupFile, tempDir);
 
         // stop services
         commands.add(createStopServiceCommand("puppet"));
@@ -488,9 +477,6 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
 
         // wait until API server restarts
         commands.add(new WaitOnAliveArtifactCommand(original));
-
-        // remove temp dir
-        commands.add(createCommand(format("rm -rf %s", tempDir)));
 
         return new MacroCommand(commands, "Restore data commands");
     }

--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/utils/TarUtils.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/utils/TarUtils.java
@@ -137,6 +137,7 @@ public class TarUtils {
         }
 
         try (TarArchiveOutputStream out = new TarArchiveOutputStream(os)) {
+            out.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
             out.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
             TarArchiveEntry tarEntry = new TarArchiveEntry(fileToPack.toFile(),
                                                            fileToPack.getFileName().toString());

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestCDECArtifact.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestCDECArtifact.java
@@ -607,7 +607,8 @@ public class TestCDECArtifact extends BaseTest {
         List<Command> commands = ((MacroCommand) backupCommand).getCommands();
 
         int i = 0;
-        assertEquals(commands.get(i++).toString(), "{'command'='rm -rf /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
+        assertEquals(commands.size(), 16);
+
         assertEquals(commands.get(i++).toString(), "{'command'='mkdir -p /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status crond.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop crond.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop puppet.service; fi; ', 'agent'='LocalAgent'}");
@@ -624,7 +625,6 @@ public class TestCDECArtifact extends BaseTest {
         assertTrue(commands.get(i).toString().matches("\\{'command'='if sudo test -f some_dir/codenvy_backup_.*.tar; then    sudo tar -C /home/codenvy/codenvy-data  -rf some_dir/codenvy_backup_.*.tar fs/.;else    sudo tar -C /home/codenvy/codenvy-data  -cf some_dir/codenvy_backup_.*.tar fs/.;fi;', 'agent'='LocalAgent'\\}"), "Actual command: " + commands.get(i++).toString());
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -ne 0 ]; then   sudo /bin/systemctl start puppet.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "Wait until artifact 'codenvy' becomes alive");
-        assertEquals(commands.get(i++).toString(), "{'command'='rm -rf /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
     }
 
     @Test
@@ -643,22 +643,19 @@ public class TestCDECArtifact extends BaseTest {
         assertNotNull(backupCommand);
 
         List<Command> commands = ((MacroCommand) backupCommand).getCommands();
-        assertEquals(commands.size(), 13);
+        assertEquals(commands.size(), 10);
 
         int i = 0;
-        assertEquals(commands.get(i++).toString(), "{'command'='rm -rf /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
-        assertEquals(commands.get(i++).toString(), "{'command'='mkdir -p /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status crond.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop crond.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop puppet.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "Repeat 2 times: {'command'='/bin/systemctl status codenvy.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop codenvy.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='mkdir -p /tmp/codenvy/codenvy/pgsql', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='sudo chmod o+w /tmp/codenvy/codenvy/pgsql', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='sudo su - postgres -c \"pg_dump -Ft -d dbconfig -f /tmp/codenvy/codenvy/pgsql/dump.tar\"', 'agent'='LocalAgent'}");
-        assertTrue(commands.get(i).toString().matches("\\{'command'='if test -f some_dir/codenvy_backup_.*.tar; then    tar -C /tmp/codenvy/codenvy  -rf some_dir/codenvy_backup_.*.tar .;else    tar -C /tmp/codenvy/codenvy  -cf some_dir/codenvy_backup_.*.tar .;fi;', 'agent'='LocalAgent'\\}"), "Actual command: " + commands.get(i++).toString());
-        assertTrue(commands.get(i).toString().matches("\\{'command'='if sudo test -f some_dir/codenvy_backup_.*.tar; then    sudo tar -C /home/codenvy/codenvy-data  -rf some_dir/codenvy_backup_.*.tar fs/.;else    sudo tar -C /home/codenvy/codenvy-data  -cf some_dir/codenvy_backup_.*.tar fs/.;fi;', 'agent'='LocalAgent'\\}"), "Actual command: " + commands.get(i++).toString());
+        assertTrue(commands.get(i).toString().matches("\\{'command'='if test -f some_dir/codenvy_backup_.*.tar; then    tar -H posix -C /tmp/codenvy/codenvy  -rf some_dir/codenvy_backup_.*.tar .;else    tar -C /tmp/codenvy/codenvy  -cf some_dir/codenvy_backup_.*.tar .;fi;', 'agent'='LocalAgent'\\}"), "Actual command: " + commands.get(i++).toString());
+        assertTrue(commands.get(i).toString().matches("\\{'command'='if sudo test -f some_dir/codenvy_backup_.*.tar; then    sudo -H posix tar -C /home/codenvy/codenvy-data  -rf some_dir/codenvy_backup_.*.tar fs/.;else    sudo tar -C /home/codenvy/codenvy-data  -cf some_dir/codenvy_backup_.*.tar fs/.;fi;', 'agent'='LocalAgent'\\}"), "Actual command: " + commands.get(i++).toString());
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -ne 0 ]; then   sudo /bin/systemctl start puppet.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "Wait until artifact 'codenvy' becomes alive");
-        assertEquals(commands.get(i++).toString(), "{'command'='rm -rf /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
     }
 
     @Test
@@ -676,7 +673,7 @@ public class TestCDECArtifact extends BaseTest {
         assertNotNull(backupCommand);
 
         List<Command> commands = ((MacroCommand) backupCommand).getCommands();
-        assertEquals(commands.size(), 16);
+        assertEquals(commands.size(), 13);
     }
 
     @Test
@@ -693,7 +690,7 @@ public class TestCDECArtifact extends BaseTest {
         assertNotNull(restoreCommand);
 
         List<Command> commands = ((MacroCommand) restoreCommand).getCommands();
-        assertEquals(commands.size(), 20);
+        assertEquals(commands.size(), 19);
 
         int i = 0;
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop puppet.service; fi; ', 'agent'='LocalAgent'}");
@@ -715,7 +712,6 @@ public class TestCDECArtifact extends BaseTest {
         assertEquals(commands.get(i++).toString(), "{'command'='sudo chown -R codenvy:codenvy /home/codenvy/codenvy-data/fs', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -ne 0 ]; then   sudo /bin/systemctl start puppet.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "Wait until artifact 'codenvy' becomes alive");
-        assertEquals(commands.get(i++).toString(), "{'command'='rm -rf /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
     }
 
     @Test
@@ -736,7 +732,7 @@ public class TestCDECArtifact extends BaseTest {
         assertNotNull(restoreCommand);
 
         List<Command> commands = ((MacroCommand) restoreCommand).getCommands();
-        assertEquals(commands.size(), 16);
+        assertEquals(commands.size(), 15);
     }
 
     @Test
@@ -757,7 +753,7 @@ public class TestCDECArtifact extends BaseTest {
         assertNotNull(restoreCommand);
 
         List<Command> commands = ((MacroCommand) restoreCommand).getCommands();
-        assertEquals(commands.size(), 11);
+        assertEquals(commands.size(), 10);
 
         int i = 0;
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -eq 0 ]; then   sudo /bin/systemctl stop puppet.service; fi; ', 'agent'='LocalAgent'}");
@@ -770,7 +766,6 @@ public class TestCDECArtifact extends BaseTest {
         assertEquals(commands.get(i++).toString(), "{'command'='sudo chown -R codenvy:codenvy /home/codenvy/codenvy-data/fs', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "{'command'='/bin/systemctl status puppet.service; if [ $? -ne 0 ]; then   sudo /bin/systemctl start puppet.service; fi; ', 'agent'='LocalAgent'}");
         assertEquals(commands.get(i++).toString(), "Wait until artifact 'codenvy' becomes alive");
-        assertEquals(commands.get(i++).toString(), "{'command'='rm -rf /tmp/codenvy/codenvy', 'agent'='LocalAgent'}");
     }
 
     @Test

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/managers/TestBackupConfig.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/managers/TestBackupConfig.java
@@ -15,7 +15,6 @@
 package com.codenvy.im.managers;
 
 import com.codenvy.im.artifacts.CDECArtifact;
-import com.codenvy.im.utils.TarUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.testng.annotations.AfterMethod;
@@ -206,23 +205,17 @@ public class TestBackupConfig {
     }
 
     @Test
-    public void testStoreConfigIntoBackup() throws IOException {
-        Files.createDirectories(TEST_BASE_TMP_DIRECTORY);
-        Path testBackupFile = TEST_BASE_TMP_DIRECTORY.resolve("test_backup.tar");
+    public void shouldCreateConfigFile() throws IOException {
         BackupConfig testConfig = new BackupConfig().setArtifactName("codenvy")
-                                                    .setArtifactVersion("1.0.0")
-                                                    .setBackupFile(testBackupFile.toString());
+                                                    .setArtifactVersion("1.0.0");
+        Path tmpDir = testConfig.obtainArtifactTempDirectory();
+        Files.createDirectories(tmpDir);
 
-        testConfig.storeConfigIntoBackup();
-        assertTrue(Files.exists(Paths.get(testConfig.getBackupFile())));
+        testConfig.createConfigFileInTmpDir();
+        Path configFile = tmpDir.resolve(BackupConfig.BACKUP_CONFIG_FILE);
+        assertTrue(Files.exists(configFile));
 
-        Path tempDir = TEST_BASE_TMP_DIRECTORY;
-        Files.createDirectories(tempDir);
-
-        TarUtils.unpackFile(testBackupFile, tempDir, Paths.get(BackupConfig.BACKUP_CONFIG_FILE));
-        Path storedConfigFile = tempDir.resolve(BackupConfig.BACKUP_CONFIG_FILE);
-
-        String storedTestConfigContent = FileUtils.readFileToString(storedConfigFile.toFile());
+        String storedTestConfigContent = FileUtils.readFileToString(configFile.toFile());
         assertEquals(storedTestConfigContent, "{\n"
                                               + "  \"artifactName\" : \"codenvy\",\n"
                                               + "  \"artifactVersion\" : \"1.0.0\"\n"
@@ -236,7 +229,7 @@ public class TestBackupConfig {
                                                     .setArtifactVersion("1.0.0")
                                                     .setBackupFile(testingBackup);
 
-        BackupConfig testConfig = backupConfig.extractConfigFromBackup();
+        BackupConfig testConfig = backupConfig.loadConfigFromTempDir();
         assertEquals(testConfig.toString(), "{" +
                                             "'artifactName':'codenvy', " +
                                             "'artifactVersion':'1.0.0', " +
@@ -254,7 +247,7 @@ public class TestBackupConfig {
                                                       .setArtifactVersion("1.0.0")
                                                       .setBackupFile(testingBackup);
 
-        backupConfig.extractConfigFromBackup();
+        backupConfig.loadConfigFromTempDir();
     }
 
     @Test(expectedExceptions = BackupException.class,
@@ -265,6 +258,6 @@ public class TestBackupConfig {
                                                       .setArtifactVersion("1.0.0")
                                                       .setBackupFile(testingBackup);
 
-        backupConfig.extractConfigFromBackup();
+        backupConfig.loadConfigFromTempDir();
     }
 }

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/managers/TestBackupManager.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/managers/TestBackupManager.java
@@ -151,8 +151,7 @@ public class TestBackupManager {
         Path tempBackupFile = expectedBackupDirectory.resolve(backupFile.getFileName().toString());
         expectedBackupConfig.setBackupFile(tempBackupFile.toString());
 
-        doReturn(mockCommand).when(mockCdecArtifact).getRestoreCommand(expectedBackupConfig
-                                                                      );
+        doReturn(mockCommand).when(mockCdecArtifact).getRestoreCommand(expectedBackupConfig);
 
         spyManager.restore(initialBackupConfig);
     }
@@ -204,7 +203,7 @@ public class TestBackupManager {
                                                              .setBackupFile(compressedBackupFile.toString()));
 
         doReturn(spyBackupConfig).when(spyBackupConfig).clone();
-        doThrow(new BackupException("error")).when(spyBackupConfig).extractConfigFromBackup();
+        doThrow(new BackupException("error")).when(spyBackupConfig).loadConfigFromTempDir();
 
         spyManager.restore(spyBackupConfig);
     }
@@ -218,7 +217,7 @@ public class TestBackupManager {
                                                              .setBackupFile(compressedBackupFile.toString()));
 
         doReturn(spyBackupConfig).when(spyBackupConfig).clone();
-        doReturn(spyBackupConfig).when(spyBackupConfig).extractConfigFromBackup();
+        doReturn(spyBackupConfig).when(spyBackupConfig).loadConfigFromTempDir();
         doThrow(new IllegalArgumentException("error")).when(spyManager).checkBackup(mockCdecArtifact, spyBackupConfig);
 
         spyManager.restore(spyBackupConfig);
@@ -233,7 +232,7 @@ public class TestBackupManager {
                                                              .setBackupFile(compressedBackupFile.toString()));
 
         doReturn(spyBackupConfig).when(spyBackupConfig).clone();
-        doReturn(spyBackupConfig).when(spyBackupConfig).extractConfigFromBackup();
+        doReturn(spyBackupConfig).when(spyBackupConfig).loadConfigFromTempDir();
         doThrow(new IllegalStateException("error")).when(spyManager).checkBackup(mockCdecArtifact, spyBackupConfig);
 
         spyManager.restore(spyBackupConfig);


### PR DESCRIPTION
### What does this PR do?
Fix bug when Codenvy Installation manager backup fails on long file path in workspace

@tolusha: please, review this pull request.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>