### PR TITLE
CODENVY-924; add range based search by group during sync

### DIFF
--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/MembershipSelector.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/MembershipSelector.java
@@ -23,6 +23,7 @@ import org.ldaptive.SearchOperation;
 import org.ldaptive.SearchRequest;
 import org.ldaptive.SearchResult;
 import org.ldaptive.ad.handler.ObjectGuidHandler;
+import org.ldaptive.ad.handler.RangeEntryHandler;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -67,6 +68,7 @@ public class MembershipSelector implements LdapEntrySelector {
         groupsSearch.setSearchFilter(new SearchFilter(groupsFilter));
         groupsSearch.setSearchScope(SUBTREE);
         groupsSearch.setReturnAttributes(membersAttr);
+        groupsSearch.setSearchEntryHandlers(new RangeEntryHandler());
         try {
             final Response<SearchResult> response = new SearchOperation(connection).execute(groupsSearch);
             if (response.getResultCode() != SUCCESS) {


### PR DESCRIPTION
### What does this PR do?

Adds range based search by group during sync when it's needed, e.g. ```member;range=1000-1500```

### What issue is fixed?
CODENVY-924