### PR TITLE
Add check for makes sure that last selected project not null

### DIFF
--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionExtension.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionExtension.java
@@ -90,8 +90,10 @@ public class ContributionExtension {
         eventBus.addHandler(WorkspaceStoppedEvent.TYPE, new WorkspaceStoppedEvent.Handler() {
             @Override
             public void onWorkspaceStopped(WorkspaceStoppedEvent event) {
-                workflowExecutor.invalidateContext(lastSelectedProject);
-                contributePart.minimize();
+                if (lastSelectedProject != null) {
+                    workflowExecutor.invalidateContext(lastSelectedProject);
+                    contributePart.minimize();
+                }
             }
         });
 


### PR DESCRIPTION
### What does this PR do?
Fix the npe while stopping the workspace without projects.
this side effect was the result of https://github.com/codenvy/codenvy/pull/768

@skabashnyuk, @evoevodin, @vitaliy-guliy please take a look.