### PR TITLE
Use preRemove event instead of cascade remove for automatically removing of suborganizations

### DIFF
--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationJpaModule.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationJpaModule.java
@@ -35,6 +35,7 @@ public class OrganizationJpaModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(OrganizationDao.class).to(JpaOrganizationDao.class);
+        bind(JpaOrganizationDao.RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriber.class).asEagerSingleton();
         bind(new TypeLiteral<AbstractPermissionsDomain<MemberImpl>>() {}).to(OrganizationDomain.class);
         bind(MemberDao.class).to(JpaMemberDao.class);
         bind(JpaMemberDao.RemoveMembersBeforeOrganizationRemovedEventSubscriber.class).asEagerSingleton();

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/impl/OrganizationImpl.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/impl/OrganizationImpl.java
@@ -78,9 +78,6 @@ public class OrganizationImpl implements Organization {
     @JoinColumn(name = "parent", insertable = false, updatable = false)
     public OrganizationImpl parentObj;
 
-    @OneToMany(cascade = {CascadeType.REMOVE, CascadeType.REFRESH}, mappedBy = "parentObj", orphanRemoval = true)
-    List<OrganizationImpl> children;
-
     public OrganizationImpl() {}
 
     public OrganizationImpl(Organization organization) {

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/jpa/JpaOrganizationDao.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/jpa/JpaOrganizationDao.java
@@ -14,6 +14,7 @@
  */
 package com.codenvy.organization.spi.jpa;
 
+import com.codenvy.organization.api.event.BeforeOrganizationRemovedEvent;
 import com.codenvy.organization.api.event.OrganizationPersistedEvent;
 import com.codenvy.organization.spi.OrganizationDao;
 import com.codenvy.organization.spi.impl.OrganizationImpl;
@@ -24,8 +25,11 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.jdbc.jpa.DuplicateKeyException;
+import org.eclipse.che.api.core.jdbc.jpa.event.CascadeRemovalEventSubscriber;
 import org.eclipse.che.api.core.notification.EventService;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -160,8 +164,54 @@ public class JpaOrganizationDao implements OrganizationDao {
         final EntityManager manager = managerProvider.get();
         final OrganizationImpl organization = manager.find(OrganizationImpl.class, organizationId);
         if (organization != null) {
-            manager.refresh(organization);
             manager.remove(organization);
+            manager.flush();
+        }
+    }
+
+    @Singleton
+    public static class RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriber
+            extends CascadeRemovalEventSubscriber<BeforeOrganizationRemovedEvent> {
+        private static final int PAGE_SIZE = 100;
+
+        @Inject
+        private EventService eventService;
+
+        @Inject
+        private OrganizationDao organizationDao;
+
+        @PostConstruct
+        public void subscribe() {
+            eventService.subscribe(this, BeforeOrganizationRemovedEvent.class);
+        }
+
+        @PreDestroy
+        public void unsubscribe() {
+            eventService.unsubscribe(this, BeforeOrganizationRemovedEvent.class);
+        }
+
+        @Override
+        public void onRemovalEvent(BeforeOrganizationRemovedEvent event) throws Exception {
+            removeSuborganizations(event.getOrganization().getId(), PAGE_SIZE);
+        }
+
+        /**
+         * Removes suborganizations of given parent organization page by page
+         *
+         * @param organizationId
+         *         parent organization id
+         * @param pageSize
+         *         number of items which should removed by one request
+         */
+        void removeSuborganizations(String organizationId, int pageSize) throws ServerException {
+            Page<OrganizationImpl> suborganizationsPage;
+            do {
+                // skip count always equals to 0 because elements will be shifted after removing previous items
+                suborganizationsPage = organizationDao.getByParent(organizationId, pageSize, 0);
+                for (OrganizationImpl suborganization : suborganizationsPage.getItems()) {
+                    organizationDao.remove(suborganization.getId());
+                }
+            } while (suborganizationsPage.hasNextPage());
         }
     }
 }

--- a/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/spi/jpa/RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriberTest.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/spi/jpa/RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriberTest.java
@@ -1,0 +1,128 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.organization.spi.jpa;
+
+import com.codenvy.organization.api.OrganizationJpaModule;
+import com.codenvy.organization.spi.impl.OrganizationImpl;
+import com.codenvy.organization.spi.jpa.JpaOrganizationDao.RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriber;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.persist.jpa.JpaPersistModule;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.jdbc.jpa.eclipselink.EntityListenerInjectionManagerInitializer;
+import org.eclipse.che.api.core.jdbc.jpa.guice.JpaInitializer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.persistence.EntityManager;
+import java.util.concurrent.Callable;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Tests for {@link RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriber}
+ *
+ * @author Sergii Leschenko
+ */
+public class RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriberTest {
+    private EntityManager manager;
+
+    private JpaOrganizationDao jpaOrganizationDao;
+
+    private RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriber suborganizationsRemover;
+
+    private OrganizationImpl[] organizations;
+
+    @BeforeClass
+    public void setupEntities() throws Exception {
+        organizations = new OrganizationImpl[] {new OrganizationImpl("org1", "parentOrg", null),
+                                                new OrganizationImpl("org2", "childOrg1", "org1"),
+                                                new OrganizationImpl("org3", "childOrg2", "org1")};
+
+        Injector injector = Guice.createInjector(new OrganizationJpaModule(), new TestModule());
+
+        manager = injector.getInstance(EntityManager.class);
+        jpaOrganizationDao = injector.getInstance(JpaOrganizationDao.class);
+        suborganizationsRemover =
+                injector.getInstance(RemoveSuborganizationsBeforeParentOrganizationRemovedEventSubscriber.class);
+        suborganizationsRemover.subscribe();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        manager.getTransaction().begin();
+        for (OrganizationImpl organization : organizations) {
+            manager.persist(organization);
+            manager.flush();
+        }
+        manager.getTransaction().commit();
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        manager.getTransaction().begin();
+        manager.createQuery("SELECT org FROM Organization org", OrganizationImpl.class)
+               .getResultList()
+               .forEach(manager::remove);
+        manager.getTransaction().commit();
+    }
+
+    @AfterClass
+    public void shutdown() throws Exception {
+        suborganizationsRemover.unsubscribe();
+        manager.getEntityManagerFactory().close();
+    }
+
+    @Test
+    public void shouldRemoveAllSuborganizationsWhenParentOrganizationIsRemoved() throws Exception {
+        jpaOrganizationDao.remove(organizations[0].getId());
+
+        assertNull(notFoundToNull(() -> jpaOrganizationDao.getById(organizations[0].getId())));
+        assertNull(notFoundToNull(() -> jpaOrganizationDao.getById(organizations[1].getId())));
+        assertNull(notFoundToNull(() -> jpaOrganizationDao.getById(organizations[2].getId())));
+    }
+
+    @Test
+    public void shouldRemoveAllSuborganizationsWhenPageSizeEqualsToOne() throws Exception {
+        suborganizationsRemover.removeSuborganizations(organizations[0].getId(), 1);
+
+        assertNotNull(notFoundToNull(() -> jpaOrganizationDao.getById(organizations[0].getId())));
+        assertNull(notFoundToNull(() -> jpaOrganizationDao.getById(organizations[1].getId())));
+        assertNull(notFoundToNull(() -> jpaOrganizationDao.getById(organizations[2].getId())));
+    }
+
+    private static <T> T notFoundToNull(Callable<T> action) throws Exception {
+        try {
+            return action.call();
+        } catch (NotFoundException x) {
+            return null;
+        }
+    }
+
+    private static class TestModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            install(new JpaPersistModule("main"));
+            bind(JpaInitializer.class).asEagerSingleton();
+            bind(EntityListenerInjectionManagerInitializer.class).asEagerSingleton();
+        }
+    }
+}

--- a/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/spi/tck/OrganizationDaoTest.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/spi/tck/OrganizationDaoTest.java
@@ -174,27 +174,6 @@ public class OrganizationDaoTest {
         assertNull(notFoundToNull(() -> organizationDao.getById(organization.getId())));
     }
 
-    @Test(dependsOnMethods = "shouldThrowNotFoundExceptionOnGettingNonExistingOrganizationById")
-    public void shouldRemoveParentOrganizationWithAllSuborganizationsTree() throws Exception {
-        //given
-        final OrganizationImpl parentOrganization = organizations[1];
-        OrganizationImpl suborganization = new OrganizationImpl(NameGenerator.generate("organization", 10),
-                                                                "subOrg",
-                                                                parentOrganization.getId());
-        OrganizationImpl secondLevelSuborganization = new OrganizationImpl(NameGenerator.generate("organization", 10),
-                                                                           "subSubOrg",
-                                                                           suborganization.getId());
-        tckRepository.createAll(Arrays.asList(suborganization, secondLevelSuborganization));
-
-        //when
-        organizationDao.remove(parentOrganization.getId());
-
-        //then
-        assertNull(notFoundToNull(() -> organizationDao.getById(organizations[1].getId())));
-        assertNull(notFoundToNull(() -> organizationDao.getById(suborganization.getId())));
-        assertNull(notFoundToNull(() -> organizationDao.getById(secondLevelSuborganization.getId())));
-    }
-
     @Test
     public void shouldNotThrowAnyExceptionOnRemovingNonExistingOrganization() throws Exception {
         organizationDao.remove("non-existing-org");

--- a/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/spi/jpa/JpaWorkerDao.java
+++ b/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/spi/jpa/JpaWorkerDao.java
@@ -145,7 +145,7 @@ public class JpaWorkerDao extends AbstractJpaPermissionsDao<WorkerImpl> implemen
 
         @PreDestroy
         public void unsubscribe() {
-            eventService.unsubscribe(this);
+            eventService.unsubscribe(this, BeforeWorkspaceRemovedEvent.class);
         }
 
         @Override

--- a/wsmaster/codenvy-hosted-integration-tests/codenvy-integration-cascade-jpa/src/test/java/com/codenvy/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
+++ b/wsmaster/codenvy-hosted-integration-tests/codenvy-integration-cascade-jpa/src/test/java/com/codenvy/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
@@ -293,8 +293,13 @@ public class JpaEntitiesCascadeRemovalTest {
         assertFalse(stackPermissionsDao.getByUser(user3.getId()).isEmpty());
         // Check existence of organizations
         assertNull(notFoundToNull(() -> organizationDao.getById(organization.getId())));
+        assertTrue(memberDao.getMembers(organization.getId()).isEmpty());
+
         assertNull(notFoundToNull(() -> organizationDao.getById(childOrganization.getId())));
+        assertTrue(memberDao.getMembers(childOrganization.getId()).isEmpty());
+
         assertNotNull(notFoundToNull(() -> organizationDao.getById(organization2.getId())));
+        assertFalse(memberDao.getMembers(organization2.getId()).isEmpty());
 
         // free resources limit is removed
         assertNull(notFoundToNull(() -> freeResourcesLimitDao.get(user.getId())));
@@ -402,6 +407,7 @@ public class JpaEntitiesCascadeRemovalTest {
         organizationDao.create(organization2 = new OrganizationImpl("org321", "anotherOrg", null));
 
         memberDao.store(new MemberImpl(user.getId(), organization.getId(), singletonList(OrganizationDomain.SET_PERMISSIONS)));
+        memberDao.store(new MemberImpl(user.getId(), childOrganization.getId(), singletonList(OrganizationDomain.SET_PERMISSIONS)));
 
         memberDao.store(new MemberImpl(user.getId(), organization2.getId(), singletonList(OrganizationDomain.SET_PERMISSIONS)));
         memberDao.store(new MemberImpl(user2.getId(), organization2.getId(), singletonList(OrganizationDomain.SET_PERMISSIONS)));
@@ -414,6 +420,7 @@ public class JpaEntitiesCascadeRemovalTest {
         freeResourcesLimitDao.remove(freeResourcesLimit.getAccountId());
 
         memberDao.remove(organization.getId(), user.getId());
+        memberDao.remove(childOrganization.getId(), user.getId());
         memberDao.remove(organization2.getId(), user.getId());
         memberDao.remove(organization2.getId(), user2.getId());
         memberDao.remove(organization2.getId(), user3.getId());


### PR DESCRIPTION
### What does this PR do?
Reworks automatically removing of suborganizations by using preRemove event instead of cascade removing. It is needed because cascade remove doesn't throw pre remove event for suborganization in this case. As result we can't remove root organization because members of suborganization will not be removed.

### Tests written?
Yes