### PR TITLE
CODENVY-518: Fix wrong pull request update status

### DIFF
--- a/plugins/plugin-github/codenvy-plugin-github-pullrequest/src/main/java/com/codenvy/plugin/pullrequest/client/GithubStagesProvider.java
+++ b/plugins/plugin-github/codenvy-plugin-github-pullrequest/src/main/java/com/codenvy/plugin/pullrequest/client/GithubStagesProvider.java
@@ -41,18 +41,21 @@ import static java.util.Arrays.asList;
 @Singleton
 public class GithubStagesProvider implements StagesProvider {
 
-    private static final Set<Class<? extends Step>> UPDATE_STEP_DONE_TYPES;
+    private static final Set<Class<? extends Step>> UPDATE_ORIGIN_STEP_DONE_TYPES;
+    private static final Set<Class<? extends Step>> UPDATE_FORK_STEP_DONE_TYPES;
     private static final Set<Class<? extends Step>> CREATION_ORIGIN_STEP_DONE_TYPES;
     private static final Set<Class<? extends Step>> CREATION_FORK_STEP_DONE_TYPES;
 
     static {
-        UPDATE_STEP_DONE_TYPES = ImmutableSet.of(PushBranchOnForkStep.class,
-                                                 UpdatePullRequestStep.class);
+        UPDATE_FORK_STEP_DONE_TYPES = ImmutableSet.of(PushBranchOnForkStep.class,
+                                                      UpdatePullRequestStep.class);
+        UPDATE_ORIGIN_STEP_DONE_TYPES = ImmutableSet.of(PushBranchOnOriginStep.class,
+                                                        UpdatePullRequestStep.class);
         CREATION_FORK_STEP_DONE_TYPES = ImmutableSet.of(CreateForkStep.class,
-                                                   PushBranchOnForkStep.class,
-                                                   IssuePullRequestStep.class);
+                                                        PushBranchOnForkStep.class,
+                                                        IssuePullRequestStep.class);
         CREATION_ORIGIN_STEP_DONE_TYPES = ImmutableSet.of(PushBranchOnOriginStep.class,
-                                                   IssuePullRequestStep.class);
+                                                          IssuePullRequestStep.class);
     }
 
     private final ContributeMessages messages;
@@ -68,7 +71,7 @@ public class GithubStagesProvider implements StagesProvider {
             return asList(messages.contributePartStatusSectionNewCommitsPushedStepLabel(),
                           messages.contributePartStatusSectionPullRequestUpdatedStepLabel());
         }
-        if (context.isForkAvailable()){
+        if (context.isForkAvailable()) {
             return asList(messages.contributePartStatusSectionForkCreatedStepLabel(),
                           messages.contributePartStatusSectionBranchPushedForkStepLabel(),
                           messages.contributePartStatusSectionPullRequestIssuedStepLabel());
@@ -81,7 +84,7 @@ public class GithubStagesProvider implements StagesProvider {
     @Override
     public Set<Class<? extends Step>> getStepDoneTypes(Context context) {
         if (context.isUpdateMode()) {
-            return UPDATE_STEP_DONE_TYPES;
+            return context.isForkAvailable() ? UPDATE_FORK_STEP_DONE_TYPES : UPDATE_ORIGIN_STEP_DONE_TYPES;
         }
         return context.isForkAvailable() ? CREATION_FORK_STEP_DONE_TYPES : CREATION_ORIGIN_STEP_DONE_TYPES;
     }


### PR DESCRIPTION
### What does this PR do?
Fix missing flag in Pull request status panel when pull request is successfully updated. 

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/518

### Previous Behavior
![356b7ae2-5a5b-11e6-92df-473b028c9d8b](https://cloud.githubusercontent.com/assets/7668752/19558616/2b75d072-96d4-11e6-99ad-3ffa5207745e.png)


### New Behavior
![pull request updated](https://cloud.githubusercontent.com/assets/7668752/19558699/9a883f54-96d4-11e6-80fb-1ddb65eaa67d.png)

@vparfonov Please review