### PR TITLE
Fix bootstrap script error of storing docker_cluster_advertise property

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -1422,8 +1422,8 @@ checkNetworkInterface() {
             println
         fi
 
-        if [ -n "${newAdvertiseNetworkInterface}" ]; then
-            insertProperty "docker_cluster_advertise" "${newAdvertiseNetworkInterface}"
+        if [ -n "${newValueOfDockerClusterAdvertise}" ]; then
+            insertProperty "docker_cluster_advertise" "${newValueOfDockerClusterAdvertise}"
         else
             insertProperty "docker_cluster_advertise" "${ADVERTISE_NETWORK_INTERFACE}"
         fi


### PR DESCRIPTION
### What does this PR do?
It fixes error of storing _docker_cluster_advertise_ property in **codenvy.properties** after entering it by user in time of executing of bootstrap script (issue #922).


Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>