### PR TITLE
CODENVY-602 Avoid NPE when ending sessions of stopped workspaces

### DIFF
--- a/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/MachineSessionInvalidator.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/MachineSessionInvalidator.java
@@ -53,8 +53,10 @@ public class MachineSessionInvalidator implements EventSubscriber<WorkspaceStatu
         if (WorkspaceStatusEvent.EventType.STOPPED.equals(event.getEventType())) {
             for (String token : tokenRegistry.removeTokens(event.getWorkspaceId()).values()) {
                 final HttpSession session = sessionStore.removeSessionByToken(token);
-                session.removeAttribute("principal");
-                session.invalidate();
+                if (session != null) {
+                    session.removeAttribute("principal");
+                    session.invalidate();
+                }
             }
         }
     }

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/MachineSessionInvalidatorTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/MachineSessionInvalidatorTest.java
@@ -45,6 +45,7 @@ public class MachineSessionInvalidatorTest {
         // generating a few tokens for the workspace
         final String token1 = registry.generateToken("user123", "workspace123");
         final String token2 = registry.generateToken("user234", "workspace123");
+        final String token3 = registry.generateToken("user345", "workspace123");
         // creating the sessions for the tokens
         final HttpSession httpSession1 = mockHttpSession();
         sessionStore.saveSession(token1, httpSession1);
@@ -60,6 +61,7 @@ public class MachineSessionInvalidatorTest {
         verify(httpSession1).invalidate();
         assertNull(sessionStore.getSession(token2));
         verify(httpSession2).invalidate();
+        assertNull(sessionStore.getSession(token3));
     }
 
     private static HttpSession mockHttpSession() {


### PR DESCRIPTION
### What does this PR do?
Fix possible NPE in MachineSessionInvalidator, when on workspace stop it removes tokens, and invalidate related sessions.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/602

### New Behavior
Check session for being a null before attempting to invalidate it.

### Tests written?
Yes

