### PR TITLE
CHE-1787: Remove workspace id from websocket connection path to master

### DIFF
--- a/assembly/onpremises-ide-packaging-war-platform-api/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/onpremises-ide-packaging-war-platform-api/src/main/webapp/WEB-INF/web.xml
@@ -29,7 +29,7 @@
     </context-param>
     <context-param>
         <param-name>org.eclipse.che.websocket.endpoint</param-name>
-        <param-value>/ws/{ws-id}</param-value>
+        <param-value>/ws</param-value>
     </context-param>
     <context-param>
         <param-name>org.eclipse.che.eventbus.endpoint</param-name>

--- a/dashboard/src/app/factories/load-factory/load-factory.controller.ts
+++ b/dashboard/src/app/factories/load-factory/load-factory.controller.ts
@@ -189,7 +189,7 @@ export class LoadFactoryCtrl {
    */
   startWorkspace(workspace) {
     this.workspace = workspace;
-    var bus = this.cheAPI.getWebsocket().getBus(workspace.id);
+    var bus = this.cheAPI.getWebsocket().getBus();
 
     if (workspace.status === 'RUNNING') {
       this.loadFactoryService.setCurrentProgressStep(4);

--- a/dashboard/src/components/api/codenvy-system.factory.ts
+++ b/dashboard/src/components/api/codenvy-system.factory.ts
@@ -29,7 +29,6 @@ export class CodenvySystem {
     this.applicationNotifications = applicationNotifications;
     this.$log = $log;
 
-    this.SYSTEM_BUS = 'system';
     this.SYSTEM_RAM_CHANNEL = 'system_ram_channel';
 
     this.LOW_RAM_TITLE = 'Low RAM';
@@ -63,7 +62,7 @@ export class CodenvySystem {
    * Listen to system RAM limit channel.
    */
   listenToSystemRamEvent() {
-    let bus = this.cheWebsocket.getBus(this.SYSTEM_BUS);
+    let bus = this.cheWebsocket.getBus();
     bus.subscribe(this.SYSTEM_RAM_CHANNEL, (message) => {
       if (message.systemRamLimitExceeded) {
         this.notification = this.applicationNotifications.addErrorNotification(this.LOW_RAM_TITLE, this.LOW_RAM_MESSAGE);


### PR DESCRIPTION
### What does this PR do?

Removes workspace id from websocket connection path to master.
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/1787

### Previous Behavior

Separate web-socket connection was created for each workspase.
### New Behavior

All workspaces are using one web-socket connection.

@vparfonov @akurinnoy @ashumilova Please review
