### PR TITLE
Exdent LdapSynchronizer functionality

### DIFF
--- a/wsmaster/codenvy-ldap/README.md
+++ b/wsmaster/codenvy-ldap/README.md
@@ -171,6 +171,16 @@ property must be specified in milliseconds. Unlike period, delay MUST be a non-n
 integer value, if it is set to _0_ then synchronization will be performed immediately
 on sever startup.
 
+- __ldap.sync.user_linking_attribute__ _(optional)_ - what attribute to use
+  for linking ldap users and database users. Possible value are: _id_, _email_.
+If this attribute is not configured _id_ will be used
+
+- __ldap.sync.remove_if_missing__ - whether to remove those users who are present
+ in LDAP cache but missing from LDAP storage
+
+- __ldap.sync.update_if_exists__ - whether to update those users who are present in LDAP cache
+and were changed in LDAP storage
+
 #### Users selection configuration
 
 - __ldap.base_dn__ - the root distinguished name to search LDAP entries,
@@ -293,6 +303,8 @@ ldap.connection.sasl.quality_of_protection=NULL
 
 ldap.sync.initial_delay_ms=10000
 ldap.sync.period_ms=-1
+ldap.sync.remove_if_missing=true
+ldap.sync.update_if_exists=true
 ldap.sync.page.size=1000
 ldap.sync.page.read_timeout_ms=30000
 ldap.sync.user.additional_dn=NULL

--- a/wsmaster/codenvy-ldap/pom.xml
+++ b/wsmaster/codenvy-ldap/pom.xml
@@ -79,6 +79,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-user</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/LdapModule.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/LdapModule.java
@@ -22,7 +22,8 @@ import com.codenvy.ldap.sync.LdapEntrySelector;
 import com.codenvy.ldap.sync.LdapEntrySelectorProvider;
 import com.codenvy.ldap.sync.LdapSynchronizer;
 import com.codenvy.ldap.sync.LdapSynchronizerService;
-import com.codenvy.ldap.sync.UserMapper;
+import com.codenvy.ldap.sync.DBUserFinder;
+import com.codenvy.ldap.sync.DBUserFinderProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 
@@ -51,6 +52,7 @@ public class LdapModule extends AbstractModule {
 
         bind(EntryResolver.class).toProvider(EntryResolverProvider.class);
 
+        bind(DBUserFinder.class).toProvider(DBUserFinderProvider.class);
         bind(LdapEntrySelector.class).toProvider(LdapEntrySelectorProvider.class);
         bind(LdapSynchronizer.class).asEagerSingleton();
         bind(LdapSynchronizerService.class);

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBHelper.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBHelper.java
@@ -1,0 +1,49 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ldap.sync;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import java.util.List;
+
+/**
+ * Helps to make db requests.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class DBHelper {
+
+    @Inject
+    private Provider<EntityManager> emProvider;
+
+    /**
+     * Executes native query and returns execution result.
+     *
+     * @param nativeQuery
+     *         query to execute
+     * @return execution result
+     */
+    @Transactional
+    public List executeNativeQuery(String nativeQuery) {
+        return emProvider.get()
+                         .createNativeQuery(nativeQuery)
+                         .getResultList();
+    }
+}

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserFinder.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserFinder.java
@@ -1,0 +1,122 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ldap.sync;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.user.User;
+import org.eclipse.che.api.user.server.spi.UserDao;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Retrieves user from persistence layer.
+ *
+ * @author Yevhenii Voevodin
+ */
+public abstract class DBUserFinder {
+
+    /** Creates a new user finder based on his identifier. */
+    public static DBUserFinder newIdFinder(UserDao userDao, DBHelper dbHelper) {
+        return new ByIdUserFinder(userDao, dbHelper);
+    }
+
+    /** Creates a new user finder based on his email. */
+    public static DBUserFinder newEmailFinder(UserDao userDao, DBHelper dbHelper) {
+        return new ByEmailUserFinder(userDao, dbHelper);
+    }
+
+    protected final UserDao  userDao;
+    protected final DBHelper dbHelper;
+
+    protected DBUserFinder(UserDao userDao, DBHelper dbHelper) {
+        this.userDao = userDao;
+        this.dbHelper = dbHelper;
+    }
+
+    /**
+     * Gets user linking identifier from ldap user.
+     *
+     * @param ldapUser
+     *         user retrieved from ldap
+     * @return an identifier
+     */
+    public abstract String extractLinkingId(User ldapUser);
+
+    /**
+     * Finds user in persistence layer by specified identifier.
+     *
+     * @param linkingAttribute
+     *         the value returned from {@link #extractLinkingId(User)}
+     * @return user from persistence layer
+     * @throws NotFoundException
+     *         when there is no such user
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    public abstract User findOne(String linkingAttribute) throws NotFoundException, ServerException;
+
+    /** Returns linking attribute values for those users who exist in persistence layer. */
+    public abstract Set<String> findLinkingIds();
+
+    /** Retrieves user by his id. */
+    private static class ByIdUserFinder extends DBUserFinder {
+
+        private ByIdUserFinder(UserDao userDao, DBHelper dbHelper) {
+            super(userDao, dbHelper);
+        }
+
+        @Override
+        public String extractLinkingId(User ldapUser) {
+            return ldapUser.getId();
+        }
+
+        @Override
+        public User findOne(String id) throws NotFoundException, ServerException {
+            return userDao.getById(id);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked") // user id is always string
+        public Set<String> findLinkingIds() {
+            return new HashSet<>(dbHelper.executeNativeQuery("SELECT id FROM Usr"));
+        }
+    }
+
+    /** Retrieves user by his email. */
+    private static class ByEmailUserFinder extends DBUserFinder {
+
+        protected ByEmailUserFinder(UserDao userDao, DBHelper dbHelper) {
+            super(userDao, dbHelper);
+        }
+
+        @Override
+        public String extractLinkingId(User ldapUser) {
+            return ldapUser.getEmail();
+        }
+
+        @Override
+        public User findOne(String email) throws NotFoundException, ServerException {
+            return userDao.getByEmail(email);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked") // user email is always string
+        public Set<String> findLinkingIds() {
+            return new HashSet<>(dbHelper.executeNativeQuery("SELECT email FROM Usr"));
+        }
+    }
+}

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserFinderProvider.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserFinderProvider.java
@@ -1,0 +1,50 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ldap.sync;
+
+import org.eclipse.che.api.user.server.spi.UserDao;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+
+/**
+ * Provides {@link DBUserFinder} instances based on configuration.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class DBUserFinderProvider implements Provider<DBUserFinder> {
+
+    @Inject
+    private UserDao userDao;
+
+    @Inject
+    private DBHelper dbHelper;
+
+    @com.google.inject.Inject(optional = true)
+    @Named("ldap.sync.user_linking_attribute")
+    private String linkAttr;
+
+    @Override
+    public DBUserFinder get() {
+        if (linkAttr == null || linkAttr.equals("id")) {
+            return DBUserFinder.newIdFinder(userDao, dbHelper);
+        }
+        if (linkAttr.equals("email")) {
+            return DBUserFinder.newEmailFinder(userDao, dbHelper);
+        }
+        throw new IllegalStateException("Supported values for the property 'ldap.sync.user_linking_attribute' are 'id' or 'email'");
+    }
+}

--- a/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizerTest.java
+++ b/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizerTest.java
@@ -16,7 +16,10 @@ package com.codenvy.ldap.sync;
 
 import com.codenvy.ldap.LdapUserIdNormalizer;
 import com.codenvy.ldap.sync.LdapSynchronizer.SyncResult;
+import com.google.common.collect.ImmutableMap;
 
+import org.eclipse.che.api.core.model.user.User;
+import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
@@ -25,25 +28,23 @@ import org.ldaptive.Connection;
 import org.ldaptive.ConnectionFactory;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
-import org.ldaptive.LdapException;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.persistence.EntityManager;
-import javax.persistence.Query;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,16 +77,18 @@ public class LdapSynchronizerTest {
     private UserDao userDao;
 
     @Mock
+    private DBUserFinder userFinder;
+
+    @Mock
     private ProfileDao profileDao;
 
     private LdapSynchronizer synchronizer;
-    private List<String>     existingIds;
+    private Set<String>      existingIds;
 
     @BeforeMethod
     @SuppressWarnings("unchecked") // synchronizer generic array of string pairs
-    public void setUp() throws LdapException {
+    public void setUp() throws Exception {
         synchronizer = new LdapSynchronizer(connFactory,
-                                            () -> entityManager,
                                             entrySelector,
                                             userDao,
                                             profileDao,
@@ -96,67 +99,164 @@ public class LdapSynchronizerTest {
                                             "uid",
                                             "cn",
                                             "mail",
-                                            new Pair[] {Pair.of("firstName", "givenName")});
+                                            new Pair[] {Pair.of("firstName", "givenName")},
+                                            true,
+                                            true,
+                                            userFinder);
 
         // mocking existing ids
-        final Query q = mock(Query.class);
-        when(q.getResultList()).thenReturn(existingIds = new ArrayList<>());
-        when(entityManager.createNativeQuery(anyString())).thenReturn(q);
+        existingIds = new HashSet<>();
+        when(userFinder.findLinkingIds()).thenReturn(existingIds);
+        when(userFinder.extractLinkingId(any())).thenAnswer(inv -> ((User)inv.getArguments()[0]).getId());
 
         // mocking connection
         when(connFactory.getConnection()).thenReturn(connection);
     }
 
     @Test
-    public void shouldCreateAllTheUsersWhenSynchronizedFirstTime() throws Exception {
+    public void createsAllTheUsersWhenSynchronizedFirstTime() throws Exception {
         when(entrySelector.select(anyObject())).thenReturn(asList(createUserEntry("user123"),
                                                                   createUserEntry("user234"),
                                                                   createUserEntry("user345")));
 
         final SyncResult syncResult = synchronizer.syncAll();
 
+        assertEquals(syncResult.getProcessed(), 3);
         assertEquals(syncResult.getCreated(), 3);
         assertEquals(syncResult.getRemoved(), 0);
-        assertEquals(syncResult.getRefreshed(), 0);
+        assertEquals(syncResult.getUpdated(), 0);
+        assertEquals(syncResult.getUpToDate(), 0);
+        assertEquals(syncResult.getRemoved(), 0);
+        assertEquals(syncResult.getSkipped(), 0);
         verify(userDao, times(3)).create(anyObject());
         verify(profileDao, times(3)).create(anyObject());
     }
 
     @Test
-    public void shouldRemoveThoseUsersWhichAreNotPresentInSelection() throws Exception {
-        when(entrySelector.select(anyObject())).thenReturn(asList(createUserEntry("user123"),
-                                                                  createUserEntry("user234")));
+    public void removesThoseUsersWhoAreNotPresentInSelection() throws Exception {
+        final Map<String, LdapEntry> users = new HashMap<>();
+        users.put("user123", createUserEntry("user123"));
+        users.put("user234", createUserEntry("user234"));
+        when(entrySelector.select(anyObject())).thenReturn(users.values());
+
         existingIds.add("missed-in-selection");
+        when(userFinder.findOne("missed-in-selection")).thenReturn(new UserImpl("missed-in-selection", "email", "name"));
 
         final SyncResult syncResult = synchronizer.syncAll();
 
+        assertEquals(syncResult.getProcessed(), 2);
         assertEquals(syncResult.getCreated(), 2);
+        assertEquals(syncResult.getRemoved(), 1);
+        assertEquals(syncResult.getUpdated(), 0);
+        assertEquals(syncResult.getUpToDate(), 0);
+        assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getSkipped(), 0);
         verify(userDao, times(2)).create(anyObject());
         verify(profileDao, times(2)).create(anyObject());
-        assertEquals(syncResult.getRemoved(), 1);
         verify(userDao).remove("missed-in-selection");
-        assertEquals(syncResult.getRefreshed(), 0);
     }
 
     @Test
-    public void shouldUpdateUsersWhichAreAlreadyPresentInDatabase() throws Exception {
-        when(entrySelector.select(anyObject())).thenReturn(asList(createUserEntry("user123"),
-                                                                  createUserEntry("user234"),
-                                                                  createUserEntry("user345")));
+    public void skipsUsersWhoAreAlreadyPresentInDatabaseAndNotModified() throws Exception {
+        final Map<String, LdapEntry> users = new HashMap<>();
+        users.put("user123", createUserEntry("user123"));
+        users.put("user234", createUserEntry("user234"));
+        users.put("user345", createUserEntry("user345"));
+        when(entrySelector.select(anyObject())).thenReturn(users.values());
+        when(profileDao.getById(any())).thenAnswer(inv -> {
+            final String id = inv.getArguments()[0].toString();
+            return new ProfileImpl(id, ImmutableMap.of("firstName", "firstName-" + id));
+        });
+
+        final UserMapper mapper = new UserMapper("uid", "cn", "mail");
+        when(userFinder.findOne(any())).thenAnswer(inv -> {
+            final String id = inv.getArguments()[0].toString();
+            return mapper.apply(users.get(id));
+        });
+
         existingIds.add("user123");
         existingIds.add("user345");
-        existingIds.add("missing-in-selection");
 
         final SyncResult syncResult = synchronizer.syncAll();
 
+        assertEquals(syncResult.getProcessed(), 3);
         assertEquals(syncResult.getCreated(), 1);
+        assertEquals(syncResult.getRemoved(), 0);
+        assertEquals(syncResult.getUpToDate(), 2);
+        assertEquals(syncResult.getUpdated(), 0);
+        assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getSkipped(), 0);
         verify(userDao).create(anyObject());
         verify(profileDao).create(anyObject());
-        assertEquals(syncResult.getRemoved(), 1);
-        verify(userDao).remove("missing-in-selection");
-        assertEquals(syncResult.getRefreshed(), 2);
-        verify(userDao, times(2)).update(anyObject());
+        verify(userDao, never()).update(anyObject());
+        verify(profileDao, never()).update(anyObject());
+    }
+
+    @Test
+    public void updatesUsersWhoChangedInLdap() throws Exception {
+        final Map<String, LdapEntry> users = new HashMap<>();
+        users.put("user123", createUserEntry("user123"));
+        users.put("user234", createUserEntry("user234"));
+        when(entrySelector.select(anyObject())).thenReturn(users.values());
+
+        when(profileDao.getById(any())).thenAnswer(inv -> {
+            final String id = inv.getArguments()[0].toString();
+            return new ProfileImpl(id, ImmutableMap.of("firstName", "new-firstName-" + id));
+        });
+
+        final UserMapper mapper = new UserMapper("uid", "cn", "mail");
+        when(userFinder.findOne(any())).thenAnswer(inv -> {
+            final String id = inv.getArguments()[0].toString();
+            return mapper.apply(users.get(id));
+        });
+
+        existingIds.add("user123");
+        existingIds.add("user234");
+
+        final SyncResult syncResult = synchronizer.syncAll();
+
+        assertEquals(syncResult.getProcessed(), 2);
+        assertEquals(syncResult.getCreated(), 0);
+        assertEquals(syncResult.getRemoved(), 0);
+        assertEquals(syncResult.getUpToDate(), 0);
+        assertEquals(syncResult.getUpdated(), 2);
+        assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getSkipped(), 0);
+        verify(userDao, never()).update(anyObject());
         verify(profileDao, times(2)).update(anyObject());
+    }
+
+    @Test
+    public void skipsUsersIfTheyAlreadyExistAndUpdateIfExistsAttributeIsSetToFalse() throws Exception {
+        synchronizer = new LdapSynchronizer(connFactory,
+                                            entrySelector,
+                                            userDao,
+                                            profileDao,
+                                            idNormalizer,
+                                            null,
+                                            0,
+                                            0,
+                                            "uid",
+                                            "cn",
+                                            "mail",
+                                            null,
+                                            false, // <- don't update
+                                            true,
+                                            userFinder);
+        when(entrySelector.select(anyObject())).thenReturn(asList(createUserEntry("user123"),
+                                                                  createUserEntry("user234")));
+        existingIds.add("user123");
+        existingIds.add("user234");
+
+        final SyncResult syncResult = synchronizer.syncAll();
+
+        assertEquals(syncResult.getProcessed(), 2);
+        assertEquals(syncResult.getCreated(), 0);
+        assertEquals(syncResult.getUpdated(), 0);
+        assertEquals(syncResult.getUpToDate(), 0);
+        assertEquals(syncResult.getRemoved(), 0);
+        assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getSkipped(), 2);
     }
 
     private static LdapEntry createUserEntry(String id) {

--- a/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/UserFinderTest.java
+++ b/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/UserFinderTest.java
@@ -1,0 +1,134 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ldap.sync;
+
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.user.server.spi.UserDao;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests {@link DBUserFinder}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Listeners(MockitoTestNGListener.class)
+public class UserFinderTest {
+
+    @Mock
+    private UserDao userDao;
+
+    @Mock
+    private DBHelper dbHelper;
+
+    @BeforeMethod
+    private void setUp() {
+        System.out.println();
+    }
+
+    @Test(dataProvider = "findsIdsProvider")
+    public void findsIds(BiFunction<UserDao, DBHelper, DBUserFinder> provider, String query) throws Exception {
+        final DBUserFinder finder = provider.apply(userDao, dbHelper);
+        final List<String> ids = Arrays.asList("id1", "id2");
+        when(dbHelper.executeNativeQuery(query)).thenReturn(ids);
+
+        assertEquals(finder.findLinkingIds(), new HashSet<>(ids));
+    }
+
+    @Test(dataProvider = "findsUserProvider")
+    public void findsUser(BiFunction<UserDao, DBHelper, DBUserFinder> provider, BiConsumer<UserDao, UserImpl> mocker) throws Exception {
+        final DBUserFinder finder = provider.apply(userDao, dbHelper);
+        final UserImpl user = new UserImpl("id", "id", "id");
+        mocker.accept(userDao, user);
+
+        assertEquals(finder.findOne("id"), user);
+    }
+
+    @Test(dataProvider = "extractsIdsProvider")
+    public void extractsIds(BiFunction<UserDao, DBHelper, DBUserFinder> provider, Function<UserImpl, String> idExtractor) {
+        final DBUserFinder finder = provider.apply(userDao, dbHelper);
+        final UserImpl user = new UserImpl("id", "email", "name");
+
+        assertEquals(finder.extractLinkingId(user), idExtractor.apply(user));
+    }
+
+    @DataProvider
+    private Object[][] findsIdsProvider() {
+        return new Object[][] {
+                {
+                        (BiFunction<UserDao, DBHelper, DBUserFinder>)DBUserFinder::newIdFinder,
+                        "SELECT id FROM Usr"
+                },
+                {
+                        (BiFunction<UserDao, DBHelper, DBUserFinder>)DBUserFinder::newEmailFinder,
+                        "SELECT email FROM Usr"
+                }
+        };
+    }
+
+    @DataProvider
+    private Object[][] findsUserProvider() {
+        return new Object[][] {
+                {
+                        (BiFunction<UserDao, DBHelper, DBUserFinder>)DBUserFinder::newIdFinder,
+                        (BiConsumer<UserDao, UserImpl>)(userDao, user) -> {
+                            try {
+                                when(userDao.getById(user.getId())).thenReturn(user);
+                            } catch (Exception x) {
+                                throw new RuntimeException(x);
+                            }
+                        }
+                },
+                {
+                        (BiFunction<UserDao, DBHelper, DBUserFinder>)DBUserFinder::newEmailFinder,
+                        (BiConsumer<UserDao, UserImpl>)(userDao, user) -> {
+                            try {
+                                when(userDao.getByEmail(user.getEmail())).thenReturn(user);
+                            } catch (Exception x) {
+                                throw new RuntimeException(x);
+                            }
+                        }
+                }
+        };
+    }
+
+    @DataProvider
+    private Object[][] extractsIdsProvider() {
+        return new Object[][] {
+                {
+                        (BiFunction<UserDao, DBHelper, DBUserFinder>)DBUserFinder::newIdFinder,
+                        (Function<UserImpl, String>)UserImpl::getId
+                },
+                {
+                        (BiFunction<UserDao, DBHelper, DBUserFinder>)DBUserFinder::newEmailFinder,
+                        (Function<UserImpl, String>)UserImpl::getEmail
+                }
+        };
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds more configuration options to the `LdapSyncrhonizer`.
The options are:
- new attribute for linking users, it can be _id_ or _email_
- new attribute for disabling users update when such users already exist
- new attribute for disabling users removal when users exist in db while missing from ldap storage

Also there are 3 new fileds in synchronization result:
-  up-to-date - users who don't need to be synchronized as they are the same in ldap and db
-  skipped - users who were fetched from ldap storage and were skipped by synchronizer due to configuration options
- processed - the count of the processed users(fetched from ldap).
Moreover now we count not valid users as failed to synchronize.

@skabashnyuk, @sleshchenko, @akorneta please review
