### PR TITLE
Don't allow to update the workspace while manager checks it's resourc…

### DIFF
--- a/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -147,7 +147,14 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
                                                                              ServerException,
                                                                              NotFoundException {
         checkMaxEnvironmentRam(update.getConfig());
-        return super.updateWorkspace(id, update);
+        // Workspace must not be updated while the manager checks it's resources to allow start
+        final Lock lock = START_LOCKS.get(getWorkspace(id).getNamespace());
+        lock.lock();
+        try {
+            return super.updateWorkspace(id, update);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
It shouldn't be possible to update the workspace while checking start resources.

@skabashnyuk, @garagatyi please review