### PR TITLE
Work around trailing slash in proxy url and dosker registry mirror url

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -160,52 +160,52 @@ setRunOptions() {
             ARTIFACT="installation-manager-cli"
 
         elif [[ "$var" =~ --version=.* ]]; then
-            VERSION=$(echo "$var" | sed -e "s/--version=//g")
+            VERSION="$(echo "$var" | sed -e "s/--version=//g")"
 
         elif [[ "$var" =~ --hostname=.* ]]; then
-            HOST_NAME=$(echo "$var" | sed -e "s/--hostname=//g")
+            HOST_NAME="$(echo "$var" | sed -e "s/--hostname=//g")"
 
         elif [[ "$var" =~ --license=accept ]]; then
             LICENSE_ACCEPTED=true
 
         elif [[ "$var" =~ --install-directory=.* ]]; then
-            INSTALL_DIR=$(echo "$var" | sed -e "s/--install-directory=//g")
+            INSTALL_DIR="$(echo "$var" | sed -e "s/--install-directory=//g")"
 
         elif [[ "$var" =~ --docker-registry-mirror=.* ]]; then
-            DOCKER_REGISTRY_MIRROR=$(echo "$var" | sed -e "s/--docker-registry-mirror=//g")
+            DOCKER_REGISTRY_MIRROR="$(removeTrailingSlash "$(echo "$var" | sed -e "s/--docker-registry-mirror=//g")")"
 
         elif [[ "$var" =~ --http-proxy-for-installation=.* ]]; then
-            HTTP_PROXY_FOR_INSTALLATION=$(echo "$var" | sed -e "s/--http-proxy-for-installation=//g")
+            HTTP_PROXY_FOR_INSTALLATION="$(echo "$var" | sed -e "s/--http-proxy-for-installation=//g")"
             CURL_PROXY_OPTION="--proxy $HTTP_PROXY_FOR_INSTALLATION"
         elif [[ "$var" =~ --https-proxy-for-installation=.* ]]; then
-            HTTPS_PROXY_FOR_INSTALLATION=$(echo "$var" | sed -e "s/--https-proxy-for-installation=//g")
+            HTTPS_PROXY_FOR_INSTALLATION="$(echo "$var" | sed -e "s/--https-proxy-for-installation=//g")"
             CURL_PROXY_OPTION="--proxy $HTTPS_PROXY_FOR_INSTALLATION"
         elif [[ "$var" =~ --no-proxy-for-installation=.* ]]; then
-            NO_PROXY_FOR_INSTALLATION=$(echo "$var" | sed -e "s/--no-proxy-for-installation=//g")
+            NO_PROXY_FOR_INSTALLATION="$(echo "$var" | sed -e "s/--no-proxy-for-installation=//g")"
 
         elif [[ "$var" =~ --http-proxy-for-codenvy=.* ]]; then
-            HTTP_PROXY_FOR_CODENVY=$(echo "$var" | sed -e "s/--http-proxy-for-codenvy=//g")
+            HTTP_PROXY_FOR_CODENVY="$(echo "$var" | sed -e "s/--http-proxy-for-codenvy=//g")"
         elif [[ "$var" =~ --https-proxy-for-codenvy=.* ]]; then
-            HTTPS_PROXY_FOR_CODENVY=$(echo "$var" | sed -e "s/--https-proxy-for-codenvy=//g")
+            HTTPS_PROXY_FOR_CODENVY="$(echo "$var" | sed -e "s/--https-proxy-for-codenvy=//g")"
         elif [[ "$var" =~ --no-proxy-for-codenvy=.* ]]; then
-            NO_PROXY_FOR_CODENVY=$(echo "$var" | sed -e "s/--no-proxy-for-codenvy=//g")
+            NO_PROXY_FOR_CODENVY="$(echo "$var" | sed -e "s/--no-proxy-for-codenvy=//g")"
 
         elif [[ "$var" =~ --http-proxy-for-codenvy-workspaces=.* ]]; then
-            HTTP_PROXY_FOR_CODENVY_WORKSPACES=$(echo "$var" | sed -e "s/--http-proxy-for-codenvy-workspaces=//g")
+            HTTP_PROXY_FOR_CODENVY_WORKSPACES="$(echo "$var" | sed -e "s/--http-proxy-for-codenvy-workspaces=//g")"
         elif [[ "$var" =~ --https-proxy-for-codenvy-workspaces=.* ]]; then
-            HTTPS_PROXY_FOR_CODENVY_WORKSPACES=$(echo "$var" | sed -e "s/--https-proxy-for-codenvy-workspaces=//g")
+            HTTPS_PROXY_FOR_CODENVY_WORKSPACES="$(echo "$var" | sed -e "s/--https-proxy-for-codenvy-workspaces=//g")"
         elif [[ "$var" =~ --no-proxy-for-codenvy-workspaces=.* ]]; then
-            NO_PROXY_FOR_CODENVY_WORKSPACES=$(echo "$var" | sed -e "s/--no-proxy-for-codenvy-workspaces=//g")
+            NO_PROXY_FOR_CODENVY_WORKSPACES="$(echo "$var" | sed -e "s/--no-proxy-for-codenvy-workspaces=//g")"
 
         elif [[ "$var" =~ --http-proxy-for-docker-daemon=.* ]]; then
-            HTTP_PROXY_FOR_DOCKER_DAEMON=$(echo "$var" | sed -e "s/--http-proxy-for-docker-daemon=//g")
+            HTTP_PROXY_FOR_DOCKER_DAEMON="$(echo "$var" | sed -e "s/--http-proxy-for-docker-daemon=//g")"
         elif [[ "$var" =~ --https-proxy-for-docker-daemon=.* ]]; then
-            HTTPS_PROXY_FOR_DOCKER_DAEMON=$(echo "$var" | sed -e "s/--https-proxy-for-docker-daemon=//g")
+            HTTPS_PROXY_FOR_DOCKER_DAEMON="$(echo "$var" | sed -e "s/--https-proxy-for-docker-daemon=//g")"
         elif [[ "$var" =~ --no-proxy-for-docker-daemon=.* ]]; then
-            NO_PROXY_FOR_DOCKER_DAEMON=$(echo "$var" | sed -e "s/--no-proxy-for-docker-daemon=//g")
+            NO_PROXY_FOR_DOCKER_DAEMON="$(echo "$var" | sed -e "s/--no-proxy-for-docker-daemon=//g")"
 
         elif [[ "$var" =~ --config=.* ]]; then
-            CUSTOM_CONFIG=$(echo "$var" | sed -e "s/--config=//g")
+            CUSTOM_CONFIG="$(echo "$var" | sed -e "s/--config=//g")"
 
         elif [[ "$var" == "--disable-monitoring-tools" ]]; then
             DISABLE_MONITORING_TOOLS=true
@@ -214,7 +214,7 @@ setRunOptions() {
             SKIP_POST_FLIGHT_CHECK=true
 
         elif [[ "$var" =~ --advertise-network-interface=.* ]]; then
-            ADVERTISE_NETWORK_INTERFACE=$(echo "$var" | sed -e "s/--advertise-network-interface=//g")
+            ADVERTISE_NETWORK_INTERFACE="$(echo "$var" | sed -e "s/--advertise-network-interface=//g")"
 
         else
             UNRECOGNIZED_PARAMETERS[$((i++))]="$var"
@@ -252,6 +252,13 @@ setRunOptions() {
 
     INSTALL_LOG="$INSTALL_DIR/install.log"
     CONFIG="$INSTALL_DIR/codenvy.properties"
+}
+
+# $1 - url
+# given: $1="http://test:8080/path"
+# returns: "http://test:8080"
+removeTrailingSlash() {
+    echo $(echo $1 | sed "s/\/[^/]*$//")
 }
 
 # $1 - url

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
@@ -66,11 +66,11 @@ validateExpectedString ".*no_proxy_for_codenvy_workspaces.=.\"$NO_PROXY\".*"
 
 validateExpectedString ".*http_proxy_for_docker_daemon.=.\"$HTTPS_PASSWORDLESS_PROXY\".*"
 validateExpectedString ".*https_proxy_for_docker_daemon.=.\"$HTTP_PASSWORDLESS_PROXY\".*"
-validateExpectedString ".*docker_registry_mirror.=.\"$HTTP_PASSWORDLESS_PROXY\".*"
+validateExpectedString ".*docker_registry_mirror.=.\"$HTTPS_PASSWORDLESS_PROXY_WITHOUT_TRAILING_SLASH\".*"
 
 # validate docker settings
 executeSshCommand "sudo systemctl status docker"
-validateExpectedString ".*--registry-mirror=$HTTPS_PASSWORDLESS_PROXY.*"
+validateExpectedString ".*--registry-mirror=$HTTPS_PASSWORDLESS_PROXY_WITHOUT_TRAILING_SLASH.*"
 
 executeSshCommand "cat /etc/sysconfig/docker"
 validateExpectedString ".*HTTP_PROXY=\"$HTTP_PASSWORDLESS_PROXY\".*"

--- a/cdec/installation-manager-tests/src/main/resources/bin/config.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/config.sh
@@ -52,15 +52,16 @@ STORAGE_FILE=/usr/local/codenvy/im/storage/config.properties
 
 CODENVY_DATA_DIR=/home/codenvy/codenvy-data
 
-HTTP_PROXY=http://testuser:testpassword@proxy.ua.codenvy-dev.com:3129
-HTTPS_PROXY=http://testuser:testpassword@proxy.ua.codenvy-dev.com:3129
+HTTP_PROXY=http://testuser:testpassword@proxy.ua.codenvy-dev.com:3129/
+HTTPS_PROXY=http://testuser:testpassword@proxy.ua.codenvy-dev.com:3129/
 PROXY_SERVER=$(echo $HTTP_PROXY | sed 's|http://.*@\(.*\):.*|\1|')
 PROXY_SERVER_WITHOUT_CREDENTIALS="http://$(echo $HTTP_PROXY | sed 's|http://.*@\(.*\)|\1|')"
 PROXY_USERNAME=testuser
 PROXY_PASSWORD=testpassword
 PROXY_IP=172.19.11.156
-HTTP_PASSWORDLESS_PROXY=http://proxy.ua.codenvy-dev.com:3128
-HTTPS_PASSWORDLESS_PROXY=http://proxy.ua.codenvy-dev.com:3128
+HTTP_PASSWORDLESS_PROXY=http://proxy.ua.codenvy-dev.com:3128/
+HTTPS_PASSWORDLESS_PROXY=http://proxy.ua.codenvy-dev.com:3128/
+HTTPS_PASSWORDLESS_PROXY_WITHOUT_TRAILING_SLASH=${HTTPS_PASSWORDLESS_PROXY%?}  # remove trailing slash of $HTTPS_PASSWORDLESS_PROXY
 
 PATH_TO_CODENVY_PUPPET_MANIFEST="/etc/puppet/manifests/nodes/codenvy/codenvy.pp"
 

--- a/cli/assembly/src/main/resources/bin/unix/codenvy
+++ b/cli/assembly/src/main/resources/bin/unix/codenvy
@@ -272,14 +272,14 @@ setupProxy() {
 # "-Dhttp.proxyUser=user -Dhttp.proxyPassword=pass -Dhttp.proxyHost=proxy.org -Dhttp.proxyPort=8080
 #  -Dhttps.proxyUser=user -Dhttps.proxyPassword=pass -Dhttps.proxyHost=proxy.org -Dhttps.proxyPort=8080 -Djava.net.useSystemProxies=true"
 #
-# parameter 1: proxy url, for example, "http://proxy.host:8080", "https://user:password@proxy.host:8080"
+# parameter 1: proxy url, for example, "http://proxy.host:8080", "https://user:password@proxy.host:8080/"
 # parameter 2: type of proxy = [http|https]
 extractProxySettings() {
     local proxyUrl=$1
     local proxyType=$2
 
-    local PROXY_WITH_USER_AUTH_REGEXP="https?://([^:]*):?(.*)@([^:]*):?(.*)"
-    local PROXY_WITHOUT_USER_AUTH_REGEXP="https?://([^:]*):?(.*)"
+    local PROXY_WITH_USER_AUTH_REGEXP="https?://([^:]*):?(.*)@([^:]*):?([^/]*).*"
+    local PROXY_WITHOUT_USER_AUTH_REGEXP="https?://([^:]*):?([^/]*).*"
 
     if [ -n "$proxyUrl" ]; then
         local proxyUserName


### PR DESCRIPTION
### What does this PR do?
For issue #886:
- fix regexp to parse proxy url with trailing slash
- remove trailing slash from the docker registry mirror
- update integration tests

@tolusha: please, review this request.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>