### PR TITLE
Minor fixes of Installation Manager CLI and bootstrap script.

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/artifacts/helper/CDECSingleServerHelper.java
@@ -505,7 +505,7 @@ public class CDECSingleServerHelper extends CDECArtifactHelper {
             // wait until there is changed configuration on API server
             commands.add(createCommand(format("testFile=\"%1$s/general.properties\"; " +
                                               "while true; do " +
-                                              "    if sudo grep \"api.endpoint=http://%2$s/api\" ${testFile}; then break; fi; " +
+                                              "    if sudo grep \"http://%2$s/api\" ${testFile}; then break; fi; " +
                                               "    sleep 5; " +  // sleep 5 sec
                                               "done; " +
                                               "sleep 15; # delay to involve into start of rebooting api server",

--- a/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestCDECArtifact.java
+++ b/cdec/installation-manager-core/src/test/java/com/codenvy/im/artifacts/TestCDECArtifact.java
@@ -1006,7 +1006,7 @@ public class TestCDECArtifact extends BaseTest {
                      "| sed 's|~n|\\n|g' > tmp.tmp " +
                      "&& sudo mv tmp.tmp %1$s/manifests/nodes/single_server/single_server.pp', 'agent'='LocalAgent'}", ETC_PUPPET));
 
-        assertEquals(commands.get(k++).toString(), "{'command'='testFile=\"/home/codenvy/codenvy-data/cloud-ide-local-configuration/general.properties\"; while true; do     if sudo grep \"api.endpoint=http://new/api\" ${testFile}; then break; fi;     sleep 5; done; "
+        assertEquals(commands.get(k++).toString(), "{'command'='testFile=\"/home/codenvy/codenvy-data/cloud-ide-local-configuration/general.properties\"; while true; do     if sudo grep \"http://new/api\" ${testFile}; then break; fi;     sleep 5; done; "
                                                    + "sleep 15; # delay to involve into start of rebooting api server', 'agent'='LocalAgent'}");
         assertEquals(commands.get(k++).toString(), "Wait until artifact 'codenvy' becomes alive");
     }
@@ -1091,7 +1091,7 @@ public class TestCDECArtifact extends BaseTest {
                      "| sed 's|~n|\\n|g' > tmp.tmp " +
                      "&& sudo mv tmp.tmp %1$s/manifests/nodes/single_server/single_server.pp', 'agent'='LocalAgent'}", ETC_PUPPET));
 
-        assertEquals(commands.get(k++).toString(), "{'command'='testFile=\"/home/codenvy/codenvy-data/cloud-ide-local-configuration/general.properties\"; while true; do     if sudo grep \"api.endpoint=http://new/api\" ${testFile}; then break; fi;     sleep 5; done; "
+        assertEquals(commands.get(k++).toString(), "{'command'='testFile=\"/home/codenvy/codenvy-data/cloud-ide-local-configuration/general.properties\"; while true; do     if sudo grep \"http://new/api\" ${testFile}; then break; fi;     sleep 5; done; "
                                                    + "sleep 15; # delay to involve into start of rebooting api server', 'agent'='LocalAgent'}");
         assertEquals(commands.get(k++).toString(), "Wait until artifact 'codenvy' becomes alive");
     }

--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -255,10 +255,15 @@ setRunOptions() {
 }
 
 # $1 - url
-# given: $1="http://test:8080/path"
+# given: $1="http://test:8080/"
 # returns: "http://test:8080"
 removeTrailingSlash() {
-    echo $(echo $1 | sed "s/\/[^/]*$//")
+    local value=$1
+    if [[ "$value" =~ .*/$ ]]; then
+        echo $(echo $value | sed "s/\/[^/]*$//");
+    else
+        echo $value
+    fi;
 }
 
 # $1 - url


### PR DESCRIPTION
### What does this PR do?
- Fix error of removing trailing slash from docker-registry-mirror option (#886).
- Fix add node command to not hang up on reading _api.endpoint_ property in **general.properties** file.

@tolusha: please, review this request.