### PR TITLE
CODENVY-1112: Add workspces number limit check, when starting workspace from config

### DIFF
--- a/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -141,7 +141,6 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
         checkMaxEnvironmentRam(config);
         return checkNumberOfWorkspacesAndPropagateCreation(namespace, () -> checkLimitsAndPropagateLimitedThroughputStart(
                 namespace, () -> LimitsCheckingWorkspaceManager.super.startWorkspace(config, namespace, isTemporary)));
-
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Add workspces number limit check, when starting workspace from config.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1112

### Previous Behavior
It was allowed to create infinite number of workspaces by starting workspaces from config (from swagger or other rest client).

### New Behavior
Creating workspace when starting workspace from config is controlled by `limits.user.workspaces.count` property.

### Tests written?
Yes

@evoevodin please review

