### PR TITLE
Minor changes of installation manager

### DIFF
--- a/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestInstallCommand.java
+++ b/cdec/installation-manager-cli-bundle/src/test/java/com/codenvy/im/cli/command/TestInstallCommand.java
@@ -730,7 +730,7 @@ public class TestInstallCommand extends AbstractTestCommand {
     @Test
     public void shouldReturnPathToUpdateInfoFile() {
         assertEquals(spyCommand.getPathToUpdateInfoFile().toString(),
-                     format("/home/%s/codenvy/update.info", SYSTEM_USER_NAME));
+                     format("%s/codenvy/update.info", System.getProperty("user.home")));
     }
 
     @Test

--- a/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
+++ b/cdec/installation-manager-resources/src/main/resources/im-scripts/install-codenvy.sh
@@ -2012,19 +2012,19 @@ postFlightCheckOfCodenvy() {
     runLoader
 
     # load che-test tool
-    pullDockerImage "codenvy/che-test:${imageVersion}"
+    pullDockerImage "eclipse/che-test:${imageVersion}"
     if [[ $? != 0 ]]; then
         return 1
     fi
 
     # load che-ip tool
-    pullDockerImage "codenvy/che-ip:${imageVersion}"
+    pullDockerImage "eclipse/che-ip:${imageVersion}"
     if [[ $? != 0 ]]; then
         return 1
     fi
 
     # run che-test tool
-    runDockerTool "codenvy/che-test:${imageVersion}" \
+    runDockerTool "eclipse/che-test:${imageVersion}" \
                   "post-flight-check" \
                   "$adminName" \
                   "$adminPassword" \
@@ -2048,7 +2048,7 @@ pullDockerImage() {
     if [[ $? != 0 ]]; then
         pauseLoader
 
-        echo "Error of loading 'codenvy/che-test' docker image: '$errorMessage'" >> ${INSTALL_LOG}
+        echo "Error of loading '$image' docker image: '$errorMessage'" >> ${INSTALL_LOG}
 
         echo -e "$(printError "[NOT OK]")"
         println

--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-and-update-codenvy-config.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-and-update-codenvy-config.sh
@@ -65,7 +65,7 @@ executeSshCommand "sudo grep \"che.api=http://${NEW_HOST_URL}/api\" /home/codenv
 
 # verify changes on installation-manager service
 executeSshCommand "sudo cat /home/codenvy-im/codenvy-im-data/conf/installation-manager.properties"
-executeSshCommand "sudo grep \"che.api=http://${NEW_HOST_URL}/api\" /home/codenvy-im/codenvy-im-data/conf/installation-manager.properties"
+executeSshCommand "sudo grep \"api.endpoint=http://${NEW_HOST_URL}/api\" /home/codenvy-im/codenvy-im-data/conf/installation-manager.properties"
 
 authWithoutRealmAndServerDns "admin" "password" "http://${NEW_HOST_URL}"
 


### PR DESCRIPTION
### What does this PR do?
- Fix bootstrap script to reflect movement _che-test_ and _che-ip_ images from **codenvy** to **eclipse** namespace.
- Check **api.endpoint** property of IM Server instead if non-exists **che.api** in integration tests.
- Fix unit test com.codenvy.im.cli.command.TestInstallCommand.

@riuvshin: please, review this request.