### PR TITLE
use images names and versions from manifest file for particular version

### DIFF
--- a/modules/compose/templates/docker-compose.yml.erb
+++ b/modules/compose/templates/docker-compose.yml.erb
@@ -10,7 +10,7 @@ services:
 # HAPROXY
 ########################
   haproxy:
-    image: codenvy/haproxy:1.5.18
+    image: <%= ENV["IMAGE_HAPROXY"] %>
     volumes:
 <% if scope.lookupvar('codenvy::host_protocol') == 'https' -%>
       - '<%= scope.lookupvar('compose::path_to_haproxy_ssl_certificate') -%>:/etc/haproxy/cert.pem'
@@ -34,7 +34,7 @@ services:
 # NGINX
 ########################
   nginx:
-    image: nginx:1.10-alpine
+    image: <%= ENV["IMAGE_NGINX"] %>
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/nginx/nginx.conf:/etc/nginx/nginx.conf'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/nginx/:/var/log/nginx'
@@ -49,7 +49,7 @@ services:
 # SOCAT
 ########################
   socat:
-    image: codenvy/socat
+    image: <%= ENV["IMAGE_SOCAT"] %>
     command: -d -d TCP-L:2375,fork UNIX:/var/run/docker.sock
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
@@ -66,7 +66,7 @@ services:
 # SWARM
 ########################
   swarm:
-    image: swarm:1.2.5
+    image: <%= ENV["IMAGE_SWARM"] %>
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/swarm/node_list:/node_list'
     command: manage -H 0.0.0.0:2375 file:///node_list
@@ -83,9 +83,9 @@ services:
 # DOCKER REGISTRY
 ########################
   registry:
-    image: registry:2.5.0
+    image: <%= ENV["IMAGE_REGISTRY"] %>
     env_file:
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/registry/registry.env'
+      - '/codenvy/instance/config/registry/registry.env'
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/registry:/var/lib/registry'
     ports:
@@ -101,9 +101,9 @@ services:
 # POSTGRES
 ########################
   postgres:
-    image: postgres:9.5.4
+    image: <%= ENV["IMAGE_POSTGRES"] %>
     env_file:
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/postgres/postgres.env'
+      - '/codenvy/instance/config/postgres/postgres.env'
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/postgres:/var/lib/postgresql/data'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/postgres/postgresql.conf:/usr/share/postgresql/postgresql.conf.sample'
@@ -118,12 +118,12 @@ services:
 # CODENVY
 ########################
   codenvy:
-    image: codenvy/codenvy:<%= scope.lookupvar('compose::codenvy_version') %>
+    image: <%= ENV["IMAGE_CODENVY"] %>
     depends_on:
       - haproxy
       - postgres
     env_file:
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/codenvy.env'
+      - '/codenvy/instance/config/codenvy/codenvy.env'
     volumes:
        - '<%= scope.lookupvar('compose::puppet_src_folder') -%>:/puppet-configuration'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/codenvy/:/opt/codenvy-data/logs/'


### PR DESCRIPTION
needed for: https://github.com/codenvy/codenvy/issues/1156
- compose now used images with versions from `images` manifest file.
- improved dev mode, now it prints really needed puppet output to console.
- remove unnecessary sed commands
@TylerJewell @garagatyi Please take a look.