### PR TITLE
CHE-2365: Add deserializer for 'command' field ComposeServiceImpl.

### DIFF
--- a/assembly/onpremises-ide-packaging-war-platform-api/pom.xml
+++ b/assembly/onpremises-ide-packaging-war-platform-api/pom.xml
@@ -288,6 +288,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-docker-compose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-docker-machine</artifactId>
         </dependency>
         <dependency>

--- a/assembly/onpremises-ide-packaging-war-platform-api/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiModule.java
+++ b/assembly/onpremises-ide-packaging-war-platform-api/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiModule.java
@@ -161,6 +161,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
         install(new org.eclipse.che.api.core.util.FileCleaner.FileCleanerModule());
 
         install(new org.eclipse.che.api.machine.server.MachineModule());
+        install(new org.eclipse.che.plugin.docker.compose.ComposeModule());
 
         install(new org.eclipse.che.swagger.deploy.DocsModule());
 

--- a/pom.xml
+++ b/pom.xml
@@ -887,6 +887,11 @@
                 <classifier>linux_arm6</classifier>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.che.plugin</groupId>
+                <artifactId>che-plugin-docker-compose</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.everrest</groupId>
                 <artifactId>everrest-groovy</artifactId>
                 <version>${org.everrest.version}</version>

--- a/wsmaster/codenvy-hosted-api-resource/pom.xml
+++ b/wsmaster/codenvy-hosted-api-resource/pom.xml
@@ -118,6 +118,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-docker-compose</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
         </dependency>

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/ram/WorkspaceRamConsumerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/ram/WorkspaceRamConsumerTest.java
@@ -24,9 +24,8 @@ import org.eclipse.che.account.api.AccountManager;
 import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.environment.server.EnvironmentParser;
-import org.eclipse.che.api.environment.server.compose.ComposeEnvironmentImpl;
-import org.eclipse.che.api.environment.server.compose.ComposeFileParser;
-import org.eclipse.che.api.environment.server.compose.ComposeServiceImpl;
+import org.eclipse.che.plugin.docker.compose.ComposeEnvironment;
+import org.eclipse.che.plugin.docker.compose.ComposeServiceImpl;
 import org.eclipse.che.api.machine.server.util.RecipeDownloader;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
@@ -36,6 +35,7 @@ import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Size;
+import org.eclipse.che.plugin.docker.compose.yaml.ComposeEnvironmentParser;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -80,9 +80,9 @@ public class WorkspaceRamConsumerTest {
     @Mock
     RecipeDownloader recipeDownloader;
 
-    ComposeFileParser composeFileParser = new ComposeFileParser();
+    ComposeEnvironmentParser composeFileParser = new ComposeEnvironmentParser(recipeDownloader);
 
-    EnvironmentParser environmentParser = new EnvironmentParser(composeFileParser, recipeDownloader);
+    EnvironmentParser environmentParser = new EnvironmentParser(singletonMap("compose", composeFileParser));
 
     @InjectMocks
     private WorkspaceRamConsumer ramConsumer;
@@ -232,7 +232,7 @@ public class WorkspaceRamConsumerTest {
                                                                                                        machineRamsMb[i] + "mb"))))));
             }
         }
-        ComposeEnvironmentImpl composeEnvironment = new ComposeEnvironmentImpl();
+        ComposeEnvironment composeEnvironment = new ComposeEnvironment();
         composeEnvironment.setServices(services);
         String yaml = YAML_PARSER.writeValueAsString(composeEnvironment);
         EnvironmentRecipeImpl recipe = new EnvironmentRecipeImpl("compose", "application/x-yaml", yaml, null);

--- a/wsmaster/codenvy-hosted-platform-api-impl/pom.xml
+++ b/wsmaster/codenvy-hosted-platform-api-impl/pom.xml
@@ -90,6 +90,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-docker-compose</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -23,9 +23,8 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.environment.server.EnvironmentParser;
-import org.eclipse.che.api.environment.server.compose.ComposeFileParser;
-import org.eclipse.che.api.machine.server.util.RecipeDownloader;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.plugin.docker.compose.yaml.ComposeEnvironmentParser;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
@@ -42,6 +41,7 @@ import static com.codenvy.api.workspace.TestObjects.createConfig;
 import static com.codenvy.api.workspace.TestObjects.createRuntime;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.eclipse.che.commons.lang.Size.parseSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
@@ -349,7 +349,7 @@ public class LimitsCheckingWorkspaceManagerTest {
             systemRamInfoProvider = mock(SystemRamInfoProvider.class);
             when(systemRamInfoProvider.getSystemRamInfo()).thenReturn(new SystemRamInfo(0, parseSize("3 GiB")));
 
-            environmentParser = new EnvironmentParser(new ComposeFileParser(), mock(RecipeDownloader.class));
+            environmentParser = new EnvironmentParser(singletonMap("compose", new ComposeEnvironmentParser(null)));
         }
 
         public LimitsCheckingWorkspaceManager build() {

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/TestObjects.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/TestObjects.java
@@ -21,8 +21,6 @@ import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.model.machine.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
-import org.eclipse.che.api.environment.server.compose.ComposeEnvironmentImpl;
-import org.eclipse.che.api.environment.server.compose.ComposeServiceImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineLimitsImpl;
@@ -36,6 +34,8 @@ import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceRuntimeImpl;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Size;
+import org.eclipse.che.plugin.docker.compose.ComposeEnvironment;
+import org.eclipse.che.plugin.docker.compose.ComposeServiceImpl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -78,7 +78,7 @@ public final class TestObjects {
                                                                                  Long.toString(Size.parseSize(machineRams[i])))));
             }
         }
-        ComposeEnvironmentImpl composeEnvironment = new ComposeEnvironmentImpl();
+        ComposeEnvironment composeEnvironment = new ComposeEnvironment();
         composeEnvironment.setServices(services);
         String yaml = YAML_PARSER.writeValueAsString(composeEnvironment);
         EnvironmentRecipeImpl recipe = new EnvironmentRecipeImpl("compose", "application/x-yaml", yaml, null);


### PR DESCRIPTION
### What does this PR do?
Add deserializer for 'command' field ComposeServiceImpl. Create separated docker compose module.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/2365

Signed-off-by: Aleksandr Andrienko <aandrienko@codenvy.com>