### PR TITLE
CODENVY-657: Do not log SourceNotFoundException

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
@@ -154,8 +154,7 @@ public class HostedMachineProviderImpl extends MachineProviderImpl {
                                               .addBuildArg(MAINTENANCE_CONSTRAINT_KEY, MAINTENANCE_CONSTRAINT_VALUE),
                               progressMonitor);
 
-        }
-        catch (ImageNotFoundException e) {
+        } catch (ImageNotFoundException e) {
             throw new SourceNotFoundException(e.getLocalizedMessage(), e);
         } catch (IOException e) {
             throw new MachineException(e.getLocalizedMessage(), e);

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.core.model.machine.ServerConf;
 import org.eclipse.che.api.core.util.FileCleaner;
 import org.eclipse.che.api.environment.server.model.CheServiceImpl;
 import org.eclipse.che.api.machine.server.exception.MachineException;
+import org.eclipse.che.api.machine.server.exception.SourceNotFoundException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.os.WindowsPathEscaper;
@@ -29,6 +30,7 @@ import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.DockerConnectorConfiguration;
 import org.eclipse.che.plugin.docker.client.ProgressMonitor;
 import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredentialsProvider;
+import org.eclipse.che.plugin.docker.client.exception.ImageNotFoundException;
 import org.eclipse.che.plugin.docker.client.params.BuildImageParams;
 import org.eclipse.che.plugin.docker.machine.DockerInstanceStopDetector;
 import org.eclipse.che.plugin.docker.machine.DockerMachineFactory;
@@ -151,6 +153,10 @@ public class HostedMachineProviderImpl extends MachineProviderImpl {
                                               // don't build an image on a node under maintenance
                                               .addBuildArg(MAINTENANCE_CONSTRAINT_KEY, MAINTENANCE_CONSTRAINT_VALUE),
                               progressMonitor);
+
+        }
+        catch (ImageNotFoundException e) {
+            throw new SourceNotFoundException(e.getLocalizedMessage(), e);
         } catch (IOException e) {
             throw new MachineException(e.getLocalizedMessage(), e);
         } finally {


### PR DESCRIPTION
### What does this PR do?
Do not log `SourceNotFoundException` when starting workspace.

### What issues does this PR fix or reference?

### Previous Behavior
If user will create a worcspace from config with wrong recipe location and then will start it, ERROR will appear in logs. This situation shouldn't be logged because it is normal situation.

### Tests written?
No

Related to https://github.com/eclipse/che/pull/3084

@garagatyi please review