### PR TITLE
Fix CLI to append output instead of overwrite

### DIFF
--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -137,7 +137,7 @@ grab_initial_images() {
 }
 
 check_host_volume_mount() {
-  echo 'test' > /codenvy/test > "${LOGS}" 2>&1
+  echo 'test' > /codenvy/test >> "${LOGS}" 2>&1
   
   if [[ ! -f /codenvy/test ]]; then
     error "Docker installed, but unable to write files to your host."
@@ -956,14 +956,18 @@ cmd_stop() {
     return
   fi
 
-  info "stop" "Stopping containers..."
-  log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME stop >> \"${LOGS}\" 2>&1 || true"
-  docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
-                 -p=$CHE_MINI_PRODUCT_NAME stop >> "${LOGS}" 2>&1 || true
-  info "stop" "Removing containers..."
-  log "y | docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME rm >> \"${LOGS}\" 2>&1 || true"
-  docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
-                 -p=$CHE_MINI_PRODUCT_NAME rm --force >> "${LOGS}" 2>&1 || true
+  if is_initialized; then
+    info "stop" "Stopping containers..."
+    log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME stop >> \"${LOGS}\" 2>&1 || true"
+    docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
+                   -p=$CHE_MINI_PRODUCT_NAME stop >> "${LOGS}" 2>&1 || true
+    info "stop" "Removing containers..."
+    log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME rm >> \"${LOGS}\" 2>&1 || true"
+    docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
+                   -p=$CHE_MINI_PRODUCT_NAME rm --force >> "${LOGS}" 2>&1 || true
+  else
+    info "stop" "Not initialized - nothing to stop..."
+  fi
 }
 
 cmd_restart() {

--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -956,8 +956,8 @@ cmd_stop() {
     return
   fi
 
+  info "stop" "Stopping containers..."
   if is_initialized; then
-    info "stop" "Stopping containers..."
     log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME stop >> \"${LOGS}\" 2>&1 || true"
     docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
                    -p=$CHE_MINI_PRODUCT_NAME stop >> "${LOGS}" 2>&1 || true
@@ -965,8 +965,6 @@ cmd_stop() {
     log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME rm >> \"${LOGS}\" 2>&1 || true"
     docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
                    -p=$CHE_MINI_PRODUCT_NAME rm --force >> "${LOGS}" 2>&1 || true
-  else
-    info "stop" "Not initialized - nothing to stop..."
   fi
 }
 
@@ -994,7 +992,7 @@ cmd_destroy() {
   docker_run -v "${CODENVY_HOST_CONFIG}":/root/codenvy-config \
              -v "${CODENVY_HOST_INSTANCE}":/root/codenvy-instance \
                 alpine:3.4 sh -c "rm -rf /root/codenvy-instance/* && rm -rf /root/codenvy-config/*"
-  LOG_INITIALIZED=false
+
   rm -rf "${CODENVY_CONTAINER_CONFIG}"
   rm -rf "${CODENVY_CONTAINER_INSTANCE}"
   if has_docker_for_windows_client; then

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -405,7 +405,7 @@ get_container_repo_folder() {
 
 get_container_cli_folder() {
   THIS_CONTAINER_ID=$(get_this_container_id)
-  FOLDER=$(get_container_host_bind_folder ":/cli" $THIS_CONTAINER_ID)
+  FOLDER=$(get_container_host_bind_folder ":/cli/cli.log" $THIS_CONTAINER_ID)
   echo "${FOLDER:=not set}"
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ If you run into an issue, please [open a GitHub issue](http://github.com/codenvy
 - output of the `docker version` command
 - output of the `docker info` command
 - the full Docker run syntax you used for the `codenvy <command>`
-- the output of `/instance/logs/cli/cli.log`
+- the output of `cli.log` - see [CLI Reference](#cli-reference)
 
 ## System Requirements
 Codenvy installs on Linux, Mac and Windows. 
@@ -483,7 +483,14 @@ We currently do not support migrating from the puppet-based configuration of Cod
 We maintain a disaster recovery [policy and best practices](http://codenvy.readme.io/v5.0/docs/disaster-recovery).
 
 ## CLI Reference
-The CLI is configured to hide most error conditions from the output screen. If you believe that Codenvy or the CLI is starting with errors, the `/instance/logs/cli/cli.logs` file contains traces and error output from your execution.
+The CLI is configured to hide most error conditions from the output screen. The CLI prints internal stack traces and error output to `cli.log`. To see the output of this log, you will need to volume mount a local path to `:/cli`. For example:
+
+```
+docker run --rm -it 
+           -v /var/run/docker.sock:/var/run/docker.sock 
+           -v /c/codenvy:/codenvy 
+           -v /c/codenvy/cli:/cli codenvy/cli:nightly [COMMAND]
+```
 
 ### `codenvy init`
 Initializes an empty directory with a Codenvy configuration and instance folder where user data and runtime configuration will be stored. If you only provide a `<path>:/codenvy` volume mount, then Codenvy creates a `instance`, `config`, and `backup` subfolder of `<path>`. If you provide three volume mounts of `<path-1>:/codenvy/config`, `<path-2>:/codenvy/instance`, `<path-3>:/codenvy/backup` then these specific folders will be used instead of the subfolders approach. The `codenvy.env` file is placed into the `/codenvy/config` folder, which is the file you use to configure how Codenvy is configured and run. Other files in this folder are used by Codenvy's configuration system to structure the runtime microservices. 


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where in certain situations the cli.log was overwritten instead of appended to. Also fixes an issue where we were attempting to stop Codenvy on systems where the directory has not been initialized. Found this situation happening due to error messages in cli.log.