### PR TITLE
CLI Improvements

### DIFF
--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -11,9 +11,19 @@
 
 cli_init() {
 
-  grab_offline_images
+  # Constants
+  CODENVY_MANIFEST_DIR="/version"
+  CODENVY_CONTAINER_OFFLINE_FOLDER="/${CHE_MINI_PRODUCT_NAME}/backup"
+  CODENVY_VERSION_FILE="${CHE_MINI_PRODUCT_NAME}.ver"
+  CODENVY_ENVIRONMENT_FILE="${CHE_MINI_PRODUCT_NAME}.env"
+  CODENVY_COMPOSE_FILE="docker-compose-container.yml"
+  CODENVY_SERVER_CONTAINER_NAME="${CHE_MINI_PRODUCT_NAME}_${CHE_MINI_PRODUCT_NAME}_1"
+  CODENVY_CONFIG_BACKUP_FILE_NAME="${CHE_MINI_PRODUCT_NAME}_config_backup.tar"
+  CODENVY_INSTANCE_BACKUP_FILE_NAME="${CHE_MINI_PRODUCT_NAME}_instance_backup.tar"
+  DOCKER_CONTAINER_NAME_PREFIX="${CHE_MINI_PRODUCT_NAME}_"
+
+  grab_offline_images "$@"
   grab_initial_images
-  check_host_volume_mount
 
   DEFAULT_CODENVY_CLI_ACTION="help"
   CODENVY_CLI_ACTION=${CODENVY_CLI_ACTION:-${DEFAULT_CODENVY_CLI_ACTION}}
@@ -25,34 +35,23 @@ cli_init() {
   CODENVY_HOST=${CODENVY_HOST:-${DEFAULT_CODENVY_HOST}}
 
   if [[ "${CODENVY_HOST}" = "" ]]; then
-      info "Welcome to Codenvy!"
-      info ""
-      info "We did not auto-detect a valid HOST or IP address."
-      info "Pass CODENVY_HOST with your hostname or IP address."
-      info ""
-      info "Rerun the CLI:"
-      info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
-      info "                      -v <local-path>:/codenvy"
-      info "                      -e CODENVY_HOST=<your-ip-or-host>"
-      info "                         codenvy/cli:${CODENVY_VERSION} $@"
-      return 2;
+    info "Welcome to Codenvy!"
+    info ""
+    info "We did not auto-detect a valid HOST or IP address."
+    info "Pass CODENVY_HOST with your hostname or IP address."
+    info ""
+    info "Rerun the CLI:"
+    info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
+    info "                      -v <local-path>:/codenvy"
+    info "                      -e CODENVY_HOST=<your-ip-or-host>"
+    info "                         codenvy/cli:${CODENVY_VERSION} $@"
+    return 2;
   fi
-
-  CODENVY_VERSION_FILE="codenvy.ver"
-  CODENVY_ENVIRONMENT_FILE="codenvy.env"
-  CODENVY_COMPOSE_FILE="docker-compose-container.yml"
-  CODENVY_SERVER_CONTAINER_NAME="codenvy_codenvy_1"
-  CODENVY_CONFIG_BACKUP_FILE_NAME="codenvy_config_backup.tar"
-  CODENVY_INSTANCE_BACKUP_FILE_NAME="codenvy_instance_backup.tar"
-  DOCKER_CONTAINER_NAME_PREFIX="codenvy_"
 
   REFERENCE_HOST_ENVIRONMENT_FILE="${CODENVY_HOST_CONFIG}/${CODENVY_ENVIRONMENT_FILE}"
   REFERENCE_HOST_COMPOSE_FILE="${CODENVY_HOST_INSTANCE}/${CODENVY_COMPOSE_FILE}"
   REFERENCE_CONTAINER_ENVIRONMENT_FILE="${CODENVY_CONTAINER_CONFIG}/${CODENVY_ENVIRONMENT_FILE}"
   REFERENCE_CONTAINER_COMPOSE_FILE="${CODENVY_CONTAINER_INSTANCE}/${CODENVY_COMPOSE_FILE}"
-
-  CODENVY_MANIFEST_DIR="/version"
-  CODENVY_OFFLINE_FOLDER="/codenvy/backup"
 
   CODENVY_HOST_CONFIG_MANIFESTS_FOLDER="$CODENVY_HOST_CONFIG/manifests"
   CODENVY_CONTAINER_CONFIG_MANIFESTS_FOLDER="$CODENVY_CONTAINER_CONFIG/manifests"
@@ -78,25 +77,23 @@ grab_offline_images(){
   # If you are using codenvy in offline mode, images must be loaded here
   # This is the point where we know that docker is working, but before we run any utilities
   # that require docker.
-  if [ ! -z ${2+x} ]; then
-    if [ "${2}" == "--offline" ]; then
-      info "init" "Importing ${CHE_MINI_PRODUCT_NAME} Docker images from tars..."
+  if [[ "$@" == *"--offline"* ]]; then
+    info "init" "Importing ${CHE_MINI_PRODUCT_NAME} Docker images from tars..."
 
-      if [ ! -d offline ]; then
-        info "init" "You requested offline loading of images, but could not find 'offline/'"
+    if [ ! -d ${CODENVY_CONTAINER_OFFLINE_FOLDER} ]; then
+      info "init" "You requested offline image loading, but '${CODENVY_CONTAINER_OFFLINE_FOLDER}' folder not found"
+      return 2;
+    fi
+
+    IFS=$'\n'
+    for file in "${CODENVY_CONTAINER_OFFLINE_FOLDER}"/*.tar 
+    do
+      if ! $(docker load < "${CODENVY_CONTAINER_OFFLINE_FOLDER}"/"${file##*/}" > /dev/null); then
+        error "Failed to restore ${CHE_MINI_PRODUCT_NAME} Docker images"
         return 2;
       fi
-
-      IFS=$'\n'
-      for file in "offline"/*.tar 
-      do
-        if ! $(docker load < "offline"/"${file##*/}" > /dev/null); then
-          error "Failed to restore ${CHE_MINI_PRODUCT_NAME} Docker images"
-          return 2;
-        fi
-        info "init" "Loading ${file##*/}..."
-      done
-    fi
+      info "init" "Loading ${file##*/}..."
+    done
   fi
 }
 
@@ -134,19 +131,6 @@ grab_initial_images() {
       return 2;
     fi
   fi
-}
-
-check_host_volume_mount() {
-  echo 'test' > /codenvy/test >> "${LOGS}" 2>&1
-  
-  if [[ ! -f /codenvy/test ]]; then
-    error "Docker installed, but unable to write files to your host."
-    error "Have you enabled Docker to allow mounting host directories?"
-    error "Did our CLI not have user rights to create files on your host?"
-    return 2;
-  fi
-
-  rm -rf /codenvy/test 
 }
 
 cli_parse () {
@@ -749,17 +733,8 @@ cmd_init() {
 
   while [ $# -gt 0 ]; do
     case $1 in
-      --no-force)
-        FORCE_UPDATE="--no-force"
-        shift ;;
-      --force)
-        FORCE_UPDATE="--force"
-        shift ;;
-      --pull)
-        FORCE_UPDATE="--pull"
-        shift ;;
-      --offline)
-        FORCE_UPDATE="--offline"
+      --no-force|--force|--pull|--offline)
+        FORCE_UPDATE=$1
         shift ;;
       --accept-license)
         AUTO_ACCEPT_LICENSE="true"
@@ -1041,7 +1016,7 @@ cmd_destroy() {
     docker volume rm codenvy-postgresql-volume > /dev/null 2>&1  || true
   fi
 
-  # Sometimes users wnat the CLI after they have destroyed their instance
+  # Sometimes users want the CLI after they have destroyed their instance
   # If they pass destroy --cli then we will also destroy the CLI
   if [[ "${DESTROY_CLI}" = "true" ]]; then
     if [[ "${CLI_MOUNT}" = "not set" ]]; then
@@ -1269,7 +1244,7 @@ cmd_restore() {
 }
 
 cmd_offline() {
-  info "offline" "Checking registry for version '$CODENVY_VERSION' images"
+  info "offline" "Grabbing image manifest for version '$CODENVY_VERSION'"
   if ! has_version_registry $CODENVY_VERSION; then
     version_error $CODENVY_VERSION
     return 1;
@@ -1278,7 +1253,7 @@ cmd_offline() {
   # Make sure the images have been pulled and are in your local Docker registry
   cmd_download
 
-  mkdir -p $CODENVY_OFFLINE_FOLDER
+  mkdir -p $CODENVY_CONTAINER_OFFLINE_FOLDER
 
   IMAGE_LIST=$(cat "$CODENVY_MANIFEST_DIR"/$CODENVY_VERSION/images)
   IFS=$'\n'
@@ -1288,8 +1263,8 @@ cmd_offline() {
     VALUE_IMAGE=$(echo $SINGLE_IMAGE | cut -d'=' -f2)
     TAR_NAME=$(echo $VALUE_IMAGE | sed "s|\/|_|")
     info "offline" "Saving $CODENVY_HOST_BACKUP/$TAR_NAME.tar..."
-    if ! $(docker save $VALUE_IMAGE > $CODENVY_OFFLINE_FOLDER/$TAR_NAME.tar); then
-      error "Docker was interrupted while saving $CODENVY_OFFLINE_FOLDER/$TAR_NAME.tar"
+    if ! $(docker save $VALUE_IMAGE > $CODENVY_CONTAINER_OFFLINE_FOLDER/$TAR_NAME.tar); then
+      error "Docker was interrupted while saving $CODENVY_CONTAINER_OFFLINE_FOLDER/$TAR_NAME.tar"
       return 1;
     fi
   done

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -52,11 +52,18 @@ Usage: docker run -it --rm
 
     help                                 This message
     version                              Installed version and upgrade paths
-    init [--pull|--force|--offline]      Initializes a directory with a ${CHE_MINI_PRODUCT_NAME} configuration
+    init                                 Initializes a directory with a ${CHE_MINI_PRODUCT_NAME} install
+         [--no-force|                      Default - uses cached local Docker images
+          --pull|                          Checks for newer images from DockerHub  
+          --force|                         Removes all images and re-pulls all images from DockerHub
+          --offline|                       Uses images saved to disk from the offline command
+          --accept-license]                Auto accepts the Codenvy license during installation
     start [--pull|--force|--offline]     Starts ${CHE_MINI_PRODUCT_NAME} services
     stop                                 Stops ${CHE_MINI_PRODUCT_NAME} services
     restart [--pull|--force]             Restart ${CHE_MINI_PRODUCT_NAME} services
-    destroy [--quiet]                    Stops services, and deletes ${CHE_MINI_PRODUCT_NAME} instance data
+    destroy                              Stops services, and deletes ${CHE_MINI_PRODUCT_NAME} instance data
+            [--quiet|                      Does not ask for confirmation before destroying instance data
+             --cli]                        If :/cli is mounted, will destroy the cli.log
     rmi [--quiet]                        Removes the Docker images for <version>, forcing a repull
     config                               Generates a ${CHE_MINI_PRODUCT_NAME} config from vars; run on any start / restart
     add-node                             Adds a physical node to serve workspaces intto the ${CHE_MINI_PRODUCT_NAME} cluster
@@ -405,7 +412,7 @@ get_container_repo_folder() {
 
 get_container_cli_folder() {
   THIS_CONTAINER_ID=$(get_this_container_id)
-  FOLDER=$(get_container_host_bind_folder ":/cli/cli.log" $THIS_CONTAINER_ID)
+  FOLDER=$(get_container_host_bind_folder ":/cli" $THIS_CONTAINER_ID)
   echo "${FOLDER:=not set}"
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -516,6 +516,8 @@ You can control the nature of how Codenvy downloads these images with command li
 | `--force` | Performs a forced removal of the local image using `docker rmi` and then pulls it again (anew) from DockerHub. You can use this as a way to clean your local cache and ensure that all images are new. |
 | `--offline` | Loads Docker images from `offline/*.tar` folder during a pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet. |
 
+The initialization of a Codenvy installation requires the acceptance of our default Fair Source 3 license agreement, which allows for some access to the source code and [usage for up to three people](http://codenvy.com/legal). You can auto-accept the license agreement without prompting for a response for silent installation by passing the `--accept-license` command line option.
+
 ### `codenvy config`
 Generates a Codenvy instance configuration using the templates and environment variables stored in `/codenvy/config` and places the configuration in `/codenvy/instance`. Uses puppet to generate the configuration files for Codenvy, haproxy, swarm, socat, nginx, and postgres which are mounted when Codenvy services are started. This command is executed on every `start` or `restart`.
 
@@ -533,7 +535,9 @@ Stops all of the Codenvy service containers and removes them.
 Performs a `codenvy stop` followed by a `codenvy start`, respecting `--pull`, `--force`, and `--offline`.
 
 ### `codenvy destroy`
-Deletes `/codenvy/config` and `/codenvy/instance`, including destroying all user workspaces, projects, data, and user database. If you provide `--force` then the confirmation warning will be skipped.
+Deletes `/codenvy/config` and `/codenvy/instance`, including destroying all user workspaces, projects, data, and user database. If you pass `--quiet` then the confirmation warning will be skipped. 
+
+If you have mounted the `:/cli` path, then we write the `cli.log` to your host directory. By default, this log is not destroyed in a `codenvy destroy` command so that you can maintain a record of all CLI executions. You can also have this file removed from your host by mounting `:/cli` and passing the `--cli` parameter to this command.
 
 ### `codenvy offline`
 Saves all of the Docker images that Codenvy requires into `/codenvy/backup/*.tar` files. Each image is saved as its own file. If the `backup` folder is available on a machine that is disconnected from the Internet and you start Codenvy with `--offline`, the CLI pre-boot sequence will load all of the Docker images in the `/codenvy/backup/` folder.

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,7 +196,7 @@ A `NO_PROXY` variable is required if you use a fake local DNS. Java and other in
 We support the ability to install and run Codenvy while disconnected from the Internet. This is helpful for certain restricted environments, regulated datacenters, or offshore installations. 
 
 ##### Save Docker Images
-While connected to the Internet and with access to DockerHub, download Codenvy's Docker images as a set of files with `codenvy offline`. Codenvy will download all dependent images and save them to `/codenvy/backup/*.tar` with each image saved as its own file. The version tag of the CLI Docker image will be used to determine which versions of dependent images to download. There is about 1GB of data that will be saved.
+While connected to the Internet and with access to DockerHub, download Codenvy's Docker images as a set of files with `codenvy offline`. Codenvy will download all dependent images and save them to `/codenvy/backup/*.tar` with each image saved as its own file. The `/backup` folder will be created as a subdirectory of `/codenvy` if that is the only folder you mount, otherwise you can direct mount a host folder to that directory. The version tag of the CLI Docker image will be used to determine which versions of dependent images to download. There is about 1GB of data that will be saved.
 
 ##### Save Codenvy CLI
 ```
@@ -514,7 +514,7 @@ You can control the nature of how Codenvy downloads these images with command li
 | `--no-force` | Default behavior. Will download an image if not found locally. A local check of the image will see if an image of a matching name is in your local registry and then skip the pull if it is found. This mode does not check DockerHub for a newer version of the same image. |
 | `--pull` | Will always perform a `docker pull` when an image is requested. If there is a newer version of the same tagged image at DockerHub, it will pull it, or use the one in local cache. This keeps your images up to date, but execution is slower. |
 | `--force` | Performs a forced removal of the local image using `docker rmi` and then pulls it again (anew) from DockerHub. You can use this as a way to clean your local cache and ensure that all images are new. |
-| `--offline` | Loads Docker images from `offline/*.tar` folder during a pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet. |
+| `--offline` | Loads Docker images from `backup/*.tar` folder during a pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet. |
 
 The initialization of a Codenvy installation requires the acceptance of our default Fair Source 3 license agreement, which allows for some access to the source code and [usage for up to three people](http://codenvy.com/legal). You can auto-accept the license agreement without prompting for a response for silent installation by passing the `--accept-license` command line option.
 


### PR DESCRIPTION
### What does this PR do?
1. Adds a '--cli' parameter to `codenvy destroy` which, if `:/cli` is volume mounted, then will destroy the cli.log from the host.  This is not enabled by default so you can monitor the log over time.

2. Adds a 'accept-license' parameter to the 'codenvy init' command which will auto-accept the codenvy license during installation allowing for silent mode.

3. Adds in a structure that allows for parsing multiple parameters on a single command which is generally more flexible than what is currently provided on the command line.