### PR TITLE
(#1168) Add che.api property to the installation manager server config

### DIFF
--- a/cdec/installation-manager-core/src/main/resources/codenvy/installation-manager.properties
+++ b/cdec/installation-manager-core/src/main/resources/codenvy/installation-manager.properties
@@ -30,6 +30,7 @@ license-manager.public_key=30820122300d06092a864886f70d01010105000382010f0030303
 puppet.base_dir=/etc/puppet
 
 api.endpoint=http://localhost/api
+che.api=http://localhost/api
 saas.api.endpoint=https://codenvy.com/api
 
 os.redhat_release_file=/etc/redhat-release


### PR DESCRIPTION
### What does this PR do?
It fixes error of loading Installation Manager Server https://github.com/codenvy/codenvy/issues/1168

@tolusha: please, review this request.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>