### PR TITLE
Change limitations of Codenvy on-prem license

### DIFF
--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/node/test-add-remove-codenvy-nodes.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/node/test-add-remove-codenvy-nodes.sh
@@ -37,14 +37,8 @@ validateInstalledCodenvyVersion ${LATEST_CODENVY_VERSION}
 executeIMCommand "--valid-exit-code=1" "add-node" "node1.${HOST_URL}"
 validateExpectedString ".*Use.the.following.syntax\:.add-node.--codenvy-ip.<CODENVY_IP_ADDRESS>.<NODE_DNS>.*"
 
-# throw error if no Codenvy license
-executeIMCommand "--valid-exit-code=1" "add-node" "--codenvy-ip 192.168.56.110" "node1.${HOST_URL}"
-validateExpectedString ".*Your.Codenvy.subscription.only.allows.a.single.server.*\"status\".\:.\"ERROR\".*"
-
-addCodenvyLicenseConfiguration
-storeCodenvyLicense
-
 # add node1.${HOST_URL}
+# Codenvy license error shouldn't be thrown
 executeIMCommand "add-node" "--codenvy-ip 192.168.56.110" "node1.${HOST_URL}"
 validateExpectedString ".*\"type\".\:.\"MACHINE_NODE\".*\"host\".\:.\"node1.${HOST_URL}\".*"
 
@@ -97,6 +91,9 @@ executeSshCommand "sudo systemctl stop iptables"  # open port 23750
 doGet "http://${NEW_HOST_URL}:23750/info"
 validateExpectedString ".*Nodes\",\"2\".*\[\" ${HOST_URL}\",\"${NEW_HOST_URL}:2375\"\].*\[\" node1.${HOST_URL}\",\"node1.${NEW_HOST_URL}:2375\"\].*"
 ############# End of change Codenvy hostname workflow
+
+addCodenvyLicenseConfiguration
+storeCodenvyLicense
 
 # add node2
 executeIMCommand "add-node" "node2.${NEW_HOST_URL}"

--- a/dashboard/src/app/admin/onprem-administration/yourlicense/yourlicense.html
+++ b/dashboard/src/app/admin/onprem-administration/yourlicense/yourlicense.html
@@ -27,7 +27,7 @@
         <div ng-switch-when="NO_LICENSE">
           <che-label-container che-label-name="License">
             <span class="onprem-license-info-row">
-              <che-link ng-href="http://codenvy.com/legal/fair-source"
+              <che-link ng-href="https://codenvy.com/legal/fair-source/"
                         che-link-text="Codenvy Fair Source {{onPremisesAdminYourLicenseCtrl.numberOfFreeUsers}}"
                         che-no-padding="true" che-new-window></che-link> - {{onPremisesAdminYourLicenseCtrl.numberOfFreeUsers}} users, single server
             </span>
@@ -70,7 +70,7 @@
           <div ng-if="onPremisesAdminYourLicenseCtrl.isLicenseExpired">
             <che-label-container che-label-name="License">
             <span class="onprem-license-info-row">
-              <che-link ng-href="http://codenvy.com/legal/fair-source"
+              <che-link ng-href="https://codenvy.com/legal/fair-source/"
                         che-link-text="Codenvy Fair Source {{onPremisesAdminYourLicenseCtrl.numberOfFreeUsers}}"
                         che-no-padding="true" che-new-window></che-link> - {{onPremisesAdminYourLicenseCtrl.numberOfFreeUsers}} users, single server
             </span>

--- a/dashboard/src/app/onprem/license-nag-message-management/nag-message.html
+++ b/dashboard/src/app/onprem/license-nag-message-management/nag-message.html
@@ -11,8 +11,8 @@
 
 -->
 <div class="license-message">
-  No valid license detected. Codenvy is free for {{nagMessageCtrl.numberOfFreeUsers}} users and a single server.&nbsp;
-  <che-link ng-href="http://codenvy.com/legal/fair-source"
+  No valid license detected. Codenvy is free for {{nagMessageCtrl.numberOfFreeUsers}} users.&nbsp;
+  <che-link ng-href="https://codenvy.com/legal/fair-source/"
             che-link-text="Please upgrade"
             che-no-padding="true" che-new-window>
   </che-link>.&nbsp;Your mother would approve!

--- a/dashboard/src/components/api/codenvy-license.factory.ts
+++ b/dashboard/src/components/api/codenvy-license.factory.ts
@@ -55,7 +55,7 @@ export class CodenvyLicense {
     };
 
     // default number of free users
-    this.numberOfFreeUsers = 5;
+    this.numberOfFreeUsers = 3;
 
     // default license legality
     this.licenseLegality = {value: true};

--- a/wsmaster/codenvy-hosted-license-shared/src/main/java/com/codenvy/api/license/CodenvyLicense.java
+++ b/wsmaster/codenvy-hosted-license-shared/src/main/java/com/codenvy/api/license/CodenvyLicense.java
@@ -32,8 +32,8 @@ import static com.codenvy.api.license.LicenseFeature.USERS;
  */
 public class CodenvyLicense {
     public static final DateFormat EXPIRATION_DATE_FORMAT     = new SimpleDateFormat("yyyy/MM/dd");
-    public static final long       MAX_NUMBER_OF_FREE_USERS   = 5;
-    public static final int        MAX_NUMBER_OF_FREE_SERVERS = 1;
+    public static final long       MAX_NUMBER_OF_FREE_USERS   = 3;
+    public static final int        MAX_NUMBER_OF_FREE_SERVERS = Integer.MAX_VALUE - 1;  // (-1) for testing propose only
 
     private final Map<LicenseFeature, String> features;
     private final String                      licenseText;
@@ -87,18 +87,6 @@ public class CodenvyLicense {
      * Returns true if user have order to create new node.
      */
     public boolean isLicenseNodesUsageLegal(int actualServers) {
-        if (actualServers == 0) {
-            return true;
-        }
-        if (isExpired()) {
-            switch (getLicenseType()) {
-                case EVALUATION_PRODUCT_KEY:
-                    return false;
-                case PRODUCT_KEY:
-                default:
-                    // do nothing
-            }
-        }
         return true;
     }
 
@@ -112,10 +100,10 @@ public class CodenvyLicense {
     public boolean isLicenseUsageLegal(long actualUsers, int actualServers) {
         if (isExpired()) {
             switch (getLicenseType()) {
+                case EVALUATION_PRODUCT_KEY:
                 case PRODUCT_KEY:
                     return actualUsers <= MAX_NUMBER_OF_FREE_USERS;   // don't take into account minimal free number of servers
 
-                case EVALUATION_PRODUCT_KEY:
                 default:
                     return isFreeUsageLegal(actualUsers, actualServers);
             }

--- a/wsmaster/codenvy-hosted-license-shared/src/test/java/com/codenvy/api/license/CodenvyLicenseTest.java
+++ b/wsmaster/codenvy-hosted-license-shared/src/test/java/com/codenvy/api/license/CodenvyLicenseTest.java
@@ -68,7 +68,7 @@ public class CodenvyLicenseTest {
                 // expired evaluation product key
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, 0, 0, true},
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS,
-                 CodenvyLicense.MAX_NUMBER_OF_FREE_USERS, CodenvyLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
+                 CodenvyLicense.MAX_NUMBER_OF_FREE_USERS, CodenvyLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS,
                  CodenvyLicense.MAX_NUMBER_OF_FREE_USERS + 1, CodenvyLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
 
@@ -121,11 +121,11 @@ public class CodenvyLicenseTest {
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, 5, true},
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, 6, true},
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, Integer.MAX_VALUE, true},
-                //free user can use only one node with expired license
+
                 {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, 0, true},
-                {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, 1, false},
-                {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, 5, false},
-                {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, Integer.MAX_VALUE, false},
+                {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, 1, true},
+                {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, 5, true},
+                {CodenvyLicense.LicenseType.EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, Integer.MAX_VALUE, true},
         };
     }
 }


### PR DESCRIPTION
### What does this PR do?
It fixes an issue https://github.com/codenvy/enterprise/issues/16:
- allows adding new machine node when there is no Codenvy license, and after evaluation product key expires;
- set maximum number of free users to 3.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>