### PR TITLE
Set up contribution mixins after IDE has been initialized

### DIFF
--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-pullrequest/src/test/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProviderTest.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-pullrequest/src/test/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProviderTest.java
@@ -1,0 +1,135 @@
+/*
+ *  [2012] - [2016] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.plugin.pullrequest.client;
+
+import com.codenvy.plugin.pullrequest.client.parts.contribute.ContributePartPresenter;
+import com.codenvy.plugin.pullrequest.client.vcs.VcsService;
+import com.codenvy.plugin.pullrequest.client.vcs.VcsServiceProvider;
+import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingService;
+import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingServiceProvider;
+import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.promises.client.Function;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.constraints.Constraints;
+import org.eclipse.che.ide.api.parts.PartStack;
+import org.eclipse.che.ide.api.parts.PartStackType;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.api.resources.Project;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link ContributionMixinProvider}
+ */
+@Listeners(MockitoTestNGListener.class)
+public class ContributionMixinProviderTest {
+
+    @Mock
+    EventBus                  eventBus;
+    @Mock
+    AppContext                appContext;
+    @Mock
+    WorkspaceAgent            workspaceAgent;
+    @Mock
+    ContributePartPresenter   contributePartPresenter;
+    @Mock
+    WorkflowExecutor          workflowExecutor;
+    @Mock
+    VcsServiceProvider        vcsServiceProvider;
+    @Mock
+    VcsHostingServiceProvider vcsHostingServiceProvider;
+
+    @Mock
+    Project                project;
+    @Mock
+    PartStack              toolingPartStack;
+    @Mock
+    VcsService             vcsService;
+    @Mock
+    VcsHostingService      vcsHostingService;
+    @Mock
+    Project.ProjectRequest projectRequest;
+
+    @Mock
+    Promise<VcsHostingService> vcsHostingServicePromise;
+    @Mock
+    Promise<String>            branchPromise;
+    @Mock
+    Promise<Project>           projectPromise;
+
+    @Captor
+    ArgumentCaptor<Operation<VcsHostingService>>       vcsOperationArgumentCaptor;
+    @Captor
+    ArgumentCaptor<Function<String, Promise<Project>>> branchCaptor;
+    @Captor
+    ArgumentCaptor<Operation<Project>>                 projectCaptor;
+
+    private ContributionMixinProvider provider;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        provider = new ContributionMixinProvider(eventBus,
+                                                 appContext,
+                                                 workspaceAgent,
+                                                 contributePartPresenter,
+                                                 workflowExecutor,
+                                                 vcsServiceProvider,
+                                                 vcsHostingServiceProvider);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testShouldSetupMixinForTheProjectAndAddPart() throws Exception {
+        when(appContext.getRootProject()).thenReturn(project);
+        when(vcsServiceProvider.getVcsService(eq(project))).thenReturn(vcsService);
+        when(project.getMixins()).thenReturn(emptyList());
+        when(vcsHostingServiceProvider.getVcsHostingService(eq(project))).thenReturn(vcsHostingServicePromise);
+        when(vcsHostingServicePromise.then(any(Operation.class))).thenReturn(vcsHostingServicePromise);
+        when(vcsService.getBranchName(eq(project))).thenReturn(branchPromise);
+        when(branchPromise.<Project>thenPromise(any(Function.class))).thenReturn(projectPromise);
+        when(projectPromise.<PromiseError>catchError(any(Operation.class))).thenReturn(projectPromise);
+        when(projectPromise.then(any(Operation.class))).thenReturn(projectPromise);
+        when(workspaceAgent.getPartStack(eq(PartStackType.TOOLING))).thenReturn(toolingPartStack);
+        when(toolingPartStack.containsPart(eq(contributePartPresenter))).thenReturn(false);
+
+        provider.processCurrentProject();
+
+        verify(vcsHostingServicePromise).then(vcsOperationArgumentCaptor.capture());
+        vcsOperationArgumentCaptor.getValue().apply(vcsHostingService);
+
+        verify(projectPromise).then(projectCaptor.capture());
+        projectCaptor.getValue().apply(project);
+
+        verify(workflowExecutor).init(eq(vcsHostingService), eq(project));
+        verify(toolingPartStack).addPart(eq(contributePartPresenter), eq(Constraints.FIRST));
+    }
+
+}

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionExtension.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionExtension.java
@@ -14,28 +14,10 @@
  */
 package com.codenvy.plugin.pullrequest.client;
 
-import com.codenvy.plugin.pullrequest.client.parts.contribute.ContributePartPresenter;
-import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingService;
-import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingServiceProvider;
-import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
-import com.google.web.bindery.event.shared.EventBus;
-
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
-import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.event.SelectionChangedEvent;
-import org.eclipse.che.ide.api.event.SelectionChangedHandler;
 import org.eclipse.che.ide.api.extension.Extension;
-import org.eclipse.che.ide.api.parts.PartStack;
-import org.eclipse.che.ide.api.parts.PartStackType;
-import org.eclipse.che.ide.api.parts.WorkspaceAgent;
-import org.eclipse.che.ide.api.resources.Project;
-import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import static com.codenvy.plugin.pullrequest.shared.ContributionProjectTypeConstants.CONTRIBUTION_PROJECT_TYPE_ID;
 
 /**
  * Registers event handlers for adding/removing contribution part.
@@ -52,57 +34,10 @@ import static com.codenvy.plugin.pullrequest.shared.ContributionProjectTypeConst
 @Extension(title = "Contributor", version = "1.0.0")
 public class ContributionExtension {
 
-    private final WorkflowExecutor          workflowExecutor;
-
-    private Project lastSelectedProject;
-
     @Inject
-    public ContributionExtension(final EventBus eventBus,
-                                 final ContributeResources resources,
-                                 final AppContext appContext,
-                                 final WorkflowExecutor workflow,
-                                 final VcsHostingServiceProvider vcsHostingServiceProvider,
-                                 final ContributePartPresenter contributePart,
-                                 final WorkspaceAgent workspaceAgent) {
-        this.workflowExecutor = workflow;
-
-        eventBus.addHandler(SelectionChangedEvent.TYPE, new SelectionChangedHandler() {
-            @Override
-            public void onSelectionChanged(SelectionChangedEvent event) {
-                final Project rootProject = appContext.getRootProject();
-                if (rootProject == null) {
-                    workspaceAgent.getPartStack(PartStackType.TOOLING).removePart(contributePart);
-                    return;
-                }
-
-                if (rootProject.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID) && !rootProject.equals(lastSelectedProject)) {
-                    vcsHostingServiceProvider.getVcsHostingService(rootProject).then(new Operation<VcsHostingService>() {
-                        @Override
-                        public void apply(VcsHostingService arg) throws OperationException {
-                            final PartStack partStack = workspaceAgent.getPartStack(PartStackType.TOOLING);
-                            if (partStack.getActivePart() == null || !partStack.getActivePart().equals(contributePart)) {
-                                partStack.addPart(contributePart);
-                            }
-                            workflowExecutor.init(arg, rootProject);
-                        }
-                    });
-
-                }
-
-                lastSelectedProject = rootProject;
-            }
-        });
-
-        eventBus.addHandler(WorkspaceStoppedEvent.TYPE, new WorkspaceStoppedEvent.Handler() {
-            @Override
-            public void onWorkspaceStopped(WorkspaceStoppedEvent event) {
-                if (lastSelectedProject != null) {
-                    workflowExecutor.invalidateContext(lastSelectedProject);
-                    contributePart.minimize();
-                }
-            }
-        });
-
+    @SuppressWarnings("unused")
+    public ContributionExtension(ContributeResources resources,
+                                 ContributionMixinProvider contributionMixinProvider) {
         resources.contributeCss().ensureInjected();
     }
 }

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProvider.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProvider.java
@@ -19,9 +19,13 @@ import com.codenvy.plugin.pullrequest.client.vcs.VcsService;
 import com.codenvy.plugin.pullrequest.client.vcs.VcsServiceProvider;
 import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingService;
 import com.codenvy.plugin.pullrequest.client.vcs.hosting.VcsHostingServiceProvider;
+import com.codenvy.plugin.pullrequest.client.workflow.Context;
 import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+import com.google.web.bindery.event.shared.HandlerRegistration;
 
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
@@ -30,97 +34,180 @@ import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.promises.client.js.Promises;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.event.SelectionChangedEvent;
+import org.eclipse.che.ide.api.event.SelectionChangedHandler;
+import org.eclipse.che.ide.api.factory.FactoryAcceptedEvent;
+import org.eclipse.che.ide.api.factory.FactoryAcceptedHandler;
+import org.eclipse.che.ide.api.parts.PartStack;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.resources.Project;
-import org.eclipse.che.ide.api.resources.Resource;
-import org.eclipse.che.ide.api.resources.ResourceInterceptor;
+import org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent;
 
 import static com.codenvy.plugin.pullrequest.shared.ContributionProjectTypeConstants.CONTRIBUTE_TO_BRANCH_VARIABLE_NAME;
 import static com.codenvy.plugin.pullrequest.shared.ContributionProjectTypeConstants.CONTRIBUTION_PROJECT_TYPE_ID;
 import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.constraints.Constraints.FIRST;
+import static org.eclipse.che.ide.api.parts.PartStackType.TOOLING;
 
 /**
- * Interceptor component, which pre-process resource at loading step.
- * <p>
- * Loading step means, that resource (file, folder or project) which is loaded from server should go through registered interceptors
- * to register on the client side.
- * <p>
- * Current interceptor modifies resource (in our case resource - project) and set up contribution mixin.
+ * Responsible for setting up contribution mixin for the currently selected project in application context.
  *
  * @author Vlad Zhukovskyi
- * @see ResourceInterceptor
  * @since 5.0.0
  */
 @Singleton
-public class ContributionMixinProvider implements ResourceInterceptor {
+public class ContributionMixinProvider {
 
-    private VcsServiceProvider        vcsServiceProvider;
-    private VcsHostingServiceProvider vcsHostingServiceProvider;
-    private WorkflowExecutor          workflowExecutor;
-    private ContributePartPresenter   contributionPartPresenter;
+    private final EventBus                  eventBus;
+    private final AppContext                appContext;
+    private final WorkspaceAgent            workspaceAgent;
+    private final ContributePartPresenter   contributePart;
+    private final WorkflowExecutor          workflowExecutor;
+    private final VcsServiceProvider        vcsServiceProvider;
+    private final VcsHostingServiceProvider vcsHostingServiceProvider;
+
+    private HandlerRegistration handlerRegistration;
+
+    private Project lastSelected;
 
     @Inject
-    public ContributionMixinProvider(VcsServiceProvider vcsServiceProvider,
-                                     VcsHostingServiceProvider vcsHostingServiceProvider,
+    public ContributionMixinProvider(EventBus eventBus,
+                                     AppContext appContext,
+                                     WorkspaceAgent workspaceAgent,
+                                     ContributePartPresenter contributePart,
                                      WorkflowExecutor workflowExecutor,
-                                     ContributePartPresenter contributionPartPresenter) {
+                                     VcsServiceProvider vcsServiceProvider,
+                                     VcsHostingServiceProvider vcsHostingServiceProvider) {
+        this.eventBus = eventBus;
+        this.appContext = appContext;
+        this.workspaceAgent = workspaceAgent;
+        this.contributePart = contributePart;
+        this.workflowExecutor = workflowExecutor;
         this.vcsServiceProvider = vcsServiceProvider;
         this.vcsHostingServiceProvider = vcsHostingServiceProvider;
-        this.workflowExecutor = workflowExecutor;
-        this.contributionPartPresenter = contributionPartPresenter;
+
+        if (appContext.getFactory() != null) {
+            handlerRegistration = eventBus.addHandler(FactoryAcceptedEvent.TYPE, new FactoryAcceptedHandler() {
+                @Override
+                public void onFactoryAccepted(FactoryAcceptedEvent event) {
+                    handlerRegistration.removeHandler();
+
+                    subscribeToSelectionChangedEvent();
+                }
+            });
+        } else {
+            handlerRegistration = eventBus.addHandler(WorkspaceReadyEvent.getType(), new WorkspaceReadyEvent.WorkspaceReadyHandler() {
+                @Override
+                public void onWorkspaceReady(WorkspaceReadyEvent event) {
+                    handlerRegistration.removeHandler();
+
+                    subscribeToSelectionChangedEvent();
+                }
+            });
+        }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void intercept(Resource resource) {
-        if (!resource.isProject()) {
-            return;
-        }
+    private void subscribeToSelectionChangedEvent() {
+        eventBus.addHandler(SelectionChangedEvent.TYPE, new SelectionChangedHandler() {
+            @Override
+            public void onSelectionChanged(SelectionChangedEvent event) {
+                final Project rootProject = appContext.getRootProject();
 
-        final Project project = (Project)resource;
+                if (lastSelected != null && lastSelected.equals(rootProject)) {
+                    return;
+                }
 
-        if (isNotRootProject(project) || hasContributionMixin(project) || hasNoVcsService(project)) {
-            return;
-        }
+                final PartStack toolingPartStack = workspaceAgent.getPartStack(TOOLING);
 
-        vcsHostingServiceProvider.getVcsHostingService(project)
-                                 .then(new Operation<VcsHostingService>() {
-                                     @Override
-                                     public void apply(final VcsHostingService vcsHostingService) throws OperationException {
-                                         addMixin(project)
-                                                 .then(new Operation<Project>() {
+                if (rootProject == null) {
+
+                    if (toolingPartStack.containsPart(contributePart)) {
+                        invalidateContext(lastSelected);
+                        hidePart();
+                    }
+                } else if (hasVcsService(rootProject)) {
+
+                    if (hasContributionMixin(rootProject)) {
+
+                        vcsHostingServiceProvider.getVcsHostingService(rootProject).then(new Operation<VcsHostingService>() {
+                            @Override
+                            public void apply(VcsHostingService vcsHostingService) throws OperationException {
+                                workflowExecutor.init(vcsHostingService, rootProject);
+                                addPart(toolingPartStack);
+                            }
+                        });
+                    } else {
+                        vcsHostingServiceProvider.getVcsHostingService(rootProject)
+                                                 .then(new Operation<VcsHostingService>() {
                                                      @Override
-                                                     public void apply(Project project) throws OperationException {
-                                                         contributionPartPresenter.open();
-                                                         workflowExecutor.init(vcsHostingService, project);
+                                                     public void apply(final VcsHostingService vcsHostingService)
+                                                             throws OperationException {
+                                                         addMixin(rootProject)
+                                                                 .then(new Operation<Project>() {
+                                                                     @Override
+                                                                     public void apply(Project project) throws OperationException {
+                                                                         workflowExecutor.init(vcsHostingService, project);
+
+                                                                         addPart(toolingPartStack);
+
+                                                                         lastSelected = project;
+                                                                     }
+                                                                 })
+                                                                 .catchError(new Operation<PromiseError>() {
+                                                                     @Override
+                                                                     public void apply(final PromiseError error) throws OperationException {
+                                                                         invalidateContext(rootProject);
+                                                                         hidePart();
+                                                                     }
+                                                                 });
                                                      }
                                                  })
                                                  .catchError(new Operation<PromiseError>() {
                                                      @Override
                                                      public void apply(final PromiseError error) throws OperationException {
-                                                         workflowExecutor.invalidateContext(project);
+                                                         invalidateContext(rootProject);
+                                                         hidePart();
                                                      }
                                                  });
-                                     }
-                                 })
-                                 .catchError(new Operation<PromiseError>() {
-                                     @Override
-                                     public void apply(final PromiseError error) throws OperationException {
-                                         workflowExecutor.invalidateContext(project);
-                                     }
-                                 });
+                    }
+
+                } else {
+                    invalidateContext(rootProject);
+                    hidePart();
+                }
+
+                lastSelected = rootProject;
+            }
+        });
     }
 
-    private boolean isNotRootProject(Project project) {
-        return project.getLocation().segmentCount() != 1;
+    private void invalidateContext(Project project) {
+        final Optional<Context> context = workflowExecutor.getContext(project.getName());
+
+        if (context.isPresent()) {
+            workflowExecutor.invalidateContext(context.get().getProject());
+        }
+    }
+
+    private void hidePart() {
+        workspaceAgent.hidePart(contributePart);
+        workspaceAgent.removePart(contributePart);
+    }
+
+    private void addPart(PartStack partStack) {
+        if (!partStack.containsPart(contributePart)) {
+            partStack.addPart(contributePart, FIRST);
+        }
+    }
+
+    private boolean hasVcsService(Project project) {
+        return vcsServiceProvider.getVcsService(project) != null;
     }
 
     private boolean hasContributionMixin(Project project) {
         return project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID);
-    }
-
-    private boolean hasNoVcsService(Project project) {
-        return vcsServiceProvider.getVcsService(project) == null;
     }
 
     private Promise<Project> addMixin(final Project project) {
@@ -130,19 +217,17 @@ public class ContributionMixinProvider implements ResourceInterceptor {
             return Promises.resolve(project);
         }
 
-        final Promise<Project> projectPromise = vcsService.getBranchName(project)
-                                                          .thenPromise(new Function<String, Promise<Project>>() {
-                                                              @Override
-                                                              public Promise<Project> apply(String branchName) throws FunctionException {
-                                                                  MutableProjectConfig mutableConfig = new MutableProjectConfig(project);
-                                                                  mutableConfig.getMixins().add(CONTRIBUTION_PROJECT_TYPE_ID);
-                                                                  mutableConfig.getAttributes().put(CONTRIBUTE_TO_BRANCH_VARIABLE_NAME,
-                                                                                                    singletonList(branchName));
+        return vcsService.getBranchName(project)
+                         .thenPromise(new Function<String, Promise<Project>>() {
+                             @Override
+                             public Promise<Project> apply(String branchName) throws FunctionException {
+                                 MutableProjectConfig mutableConfig = new MutableProjectConfig(project);
+                                 mutableConfig.getMixins().add(CONTRIBUTION_PROJECT_TYPE_ID);
+                                 mutableConfig.getAttributes().put(CONTRIBUTE_TO_BRANCH_VARIABLE_NAME,
+                                                                   singletonList(branchName));
 
-                                                                  return project.update().withBody(mutableConfig).send();
-                                                              }
-                                                          });
-
-        return projectPromise;
+                                 return project.update().withBody(mutableConfig).send();
+                             }
+                         });
     }
 }

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProvider.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/ContributionMixinProvider.java
@@ -155,7 +155,6 @@ public class ContributionMixinProvider {
                                                              @Override
                                                              public void apply(Project project) throws OperationException {
                                                                  workflowExecutor.init(vcsHostingService, project);
-
                                                                  addPart(toolingPartStack);
 
                                                                  lastSelected = project;
@@ -189,7 +188,6 @@ public class ContributionMixinProvider {
 
     private void invalidateContext(Project project) {
         final Optional<Context> context = workflowExecutor.getContext(project.getName());
-
         if (context.isPresent()) {
             workflowExecutor.invalidateContext(context.get().getProject());
         }

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/inject/PullRequestGinModule.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/inject/PullRequestGinModule.java
@@ -14,7 +14,6 @@
  */
 package com.codenvy.plugin.pullrequest.client.inject;
 
-import com.codenvy.plugin.pullrequest.client.ContributionMixinProvider;
 import com.codenvy.plugin.pullrequest.client.dialogs.commit.CommitView;
 import com.codenvy.plugin.pullrequest.client.dialogs.commit.CommitViewImpl;
 import com.codenvy.plugin.pullrequest.client.parts.contribute.ContributePartView;
@@ -26,10 +25,8 @@ import com.codenvy.plugin.pullrequest.client.steps.WaitForkOnRemoteStepFactory;
 import com.codenvy.plugin.pullrequest.client.workflow.WorkflowExecutor;
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
-import com.google.gwt.inject.client.multibindings.GinMultibinder;
 
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
-import org.eclipse.che.ide.api.resources.ResourceInterceptor;
 
 import javax.inject.Singleton;
 
@@ -55,6 +52,5 @@ public class PullRequestGinModule extends AbstractGinModule {
         install(new GinFactoryModuleBuilder().build(PushBranchStepFactory.class));
         install(new GinFactoryModuleBuilder().build(AddForkRemoteStepFactory.class));
 
-        GinMultibinder.newSetBinder(binder(), ResourceInterceptor.class).addBinding().to(ContributionMixinProvider.class);
     }
 }


### PR DESCRIPTION
When IDE has been initialized:

* after factory imported (fires `org.eclipse.che.ide.api.factory.FactoryAcceptedEvent` event)
* after normal IDE bootstrap (fires `org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent` event)

contribution extension subscribes to the `org.eclipse.che.ide.api.event.SelectionChangedEvent` event and starts tracking selection changes. And if current root project doesn't have contribution mixin, it will be setting up for the selected project.

Related issue: https://github.com/codenvy/codenvy/issues/707

@ashumilova review it, please.