### PR TITLE
Define all codenvy/* images to have codenvy versioning

### DIFF
--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -11,5 +11,5 @@
 IMAGE_NAME="codenvy/cli"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"

--- a/dockerfiles/cli/version/latest/images
+++ b/dockerfiles/cli/version/latest/images
@@ -1,4 +1,4 @@
-IMAGE_SOCAT=codenvy/socat:1.7.3.1
+IMAGE_SOCAT=codenvy/socat:latest
 IMAGE_HAPROXY=haproxy:1.5.18-alpine
 IMAGE_NGINX=nginx:1.10-alpine
 IMAGE_SWARM=swarm:1.2.5
@@ -7,4 +7,4 @@ IMAGE_POSTGRES=postgres:9.5.4
 IMAGE_INIT=codenvy/init:latest
 IMAGE_CODENVY=codenvy/codenvy:latest
 IMAGE_COMPOSE=docker/compose:1.8.1
-IMAGE_RSYSLOG=codenvy/rsyslog:8.18.0
+IMAGE_RSYSLOG=codenvy/rsyslog:latest

--- a/dockerfiles/cli/version/nightly/images
+++ b/dockerfiles/cli/version/nightly/images
@@ -1,4 +1,4 @@
-IMAGE_SOCAT=codenvy/socat:1.7.3.1
+IMAGE_SOCAT=codenvy/socat:nightly
 IMAGE_HAPROXY=haproxy:1.5.18-alpine
 IMAGE_NGINX=nginx:1.10-alpine
 IMAGE_SWARM=swarm:1.2.5
@@ -7,4 +7,4 @@ IMAGE_POSTGRES=postgres:9.5.4
 IMAGE_INIT=codenvy/init:nightly
 IMAGE_CODENVY=codenvy/codenvy:nightly
 IMAGE_COMPOSE=docker/compose:1.8.1
-IMAGE_RSYSLOG=codenvy/rsyslog:8.18.0
+IMAGE_RSYSLOG=codenvy/rsyslog:nightly

--- a/dockerfiles/init/build.sh
+++ b/dockerfiles/init/build.sh
@@ -8,5 +8,5 @@
 IMAGE_NAME="codenvy/init"
 . $(cd "$(dirname "$0")"; pwd)/../build.include
 
-init
-build
+init "$@"
+build "$@"


### PR DESCRIPTION
As per https://github.com/codenvy/codenvy/pull/1188#issuecomment-261662827
all codenvy/* images defined in codenvy/codenvy repository should have version of codenvy/codenvy tag.

codenvy/codenvy:nightly inherit from codenvy/jdk:nightly
codenvy/haproxy, codenvy/puppet, codenvy/socat are need to match latest, 5.0.0-M7, etc

Change-Id: I3b5922ed22ac8db5bf041c3b23ce50c3306776de
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>