### PR TITLE
Start to make some common files for codenvy/cli and eclipse/che-cli 

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Florent Benoit - Initial Implementation
+
+init() {
+  BLUE='\033[1;34m'
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+  if [[ $# -eq 0 ]] ; then
+    TAG="nightly"
+    echo "No tag provided, using nightly as default"
+  else
+    TAG=${1}
+  fi
+}
+
+build() {
+  DIR=$(cd "$(dirname "$0")"; pwd)
+  echo "Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG"
+  cd $DIR && docker build -t ${IMAGE_NAME}:${TAG} .
+  if [ $? -eq 0 ]; then
+    echo "${GREEN}Script run successfully: ${BLUE}${IMAGE_NAME}:${TAG}${NC}"
+    else
+      echo "${RED}Failure when building docker image ${IMAGE_NAME}:${TAG}${NC}"
+      exit 1
+  fi
+}

--- a/dockerfiles/cli/Dockerfile
+++ b/dockerfiles/cli/Dockerfile
@@ -15,33 +15,14 @@
 # use:
 #    docker run -v $(pwd):/codenvy codenvy/cli [command]
 
-FROM alpine:3.4
-RUN mkdir -p /codenvy \
-    && mkdir -p /version \
-    && mkdir -p /cli \
-    && apk add --no-cache ca-certificates curl openssl jq \
-    && apk add --update bash \
-    && rm -rf /var/cache/apk/*
-
-ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 1.11.2
-ENV DOCKER_SHA256 8c2e0c35e3cda11706f54b2d46c2521a6e9026a7b13c7d4b8ae1f3a706fc55e1
-
-RUN set -x \
-	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
-	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
-	&& tar -xzvf docker.tgz \
-	&& mv docker/* /usr/local/bin/ \
-	&& rmdir docker \
-	&& rm docker.tgz \
-	&& docker -v
+FROM eclipse/che-base:nightly
 
 COPY codenvy.sh /scripts/
 COPY cli.sh /scripts/
 COPY cmd_*.sh /scripts/
 COPY version /version/
 
-RUN chmod +x /scripts/codenvy.sh
+RUN mkdir /codenvy && chmod +x /scripts/codenvy.sh
 
 ENTRYPOINT ["/scripts/codenvy.sh"]
 

--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Florent Benoit - Initial Implementation
+
+IMAGE_NAME="codenvy/cli"
+. $(cd "$(dirname "$0")"; pwd)/../build.include
+
+init
+build

--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -93,7 +93,7 @@ grab_offline_images(){
     fi
 
     IFS=$'\n'
-    for file in "${CODENVY_CONTAINER_OFFLINE_FOLDER}"/*.tar 
+    for file in "${CODENVY_CONTAINER_OFFLINE_FOLDER}"/*.tar
     do
       if ! $(docker load < "${CODENVY_CONTAINER_OFFLINE_FOLDER}"/"${file##*/}" > /dev/null); then
         error "Failed to restore ${CHE_MINI_PRODUCT_NAME} Docker images"
@@ -386,7 +386,7 @@ verify_version_compatibility() {
     INSTALLED_VERSION=$(get_installed_version)
 
     case "${COMPARE_CLI_ENV}" in
-      "match") 
+      "match")
       ;;
       "nightly")
         error ""
@@ -453,7 +453,7 @@ verify_version_upgrade_compatibility() {
   ##      - If they don't match, then if CLI is newer then good
   CODENVY_IMAGE_VERSION=$(get_image_version)
 
-  if ! is_initialized || ! is_configured; then 
+  if ! is_initialized || ! is_configured; then
     info "upgrade" "$CHE_MINI_PRODUCT_NAME is not installed or configured. Nothing to upgrade."
     return 2
   fi
@@ -463,7 +463,7 @@ verify_version_upgrade_compatibility() {
     CONFIGURED_VERSION=$(get_installed_version)
 
     case "${COMPARE_CLI_ENV}" in
-      "match") 
+      "match")
         error ""
         error "Your CLI version '${CHE_MINI_PRODUCT_NAME}/cli:$CODENVY_IMAGE_VERSION' is identical to your installed version '$INSTALLED_VERSION'."
         error ""

--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -44,7 +44,7 @@ cli_init() {
     info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
     info "                      -v <local-path>:/codenvy"
     info "                      -e CODENVY_HOST=<your-ip-or-host>"
-    info "                         $CHE_MINI_PRODUCT_NAME/cli:${CODENVY_IMAGE_VERSION} $@"
+    info "                         $CODENVY_IMAGE_NAME $*"
     return 2;
   fi
 

--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -164,65 +164,6 @@ cli_parse () {
   eval $COMMAND "$@"
 }
 
-get_docker_install_type() {
-  debug $FUNCNAME
-  if is_boot2docker; then
-    echo "boot2docker"
-  elif is_docker_for_windows; then
-    echo "docker4windows"
-  elif is_docker_for_mac; then
-    echo "docker4mac"
-  else
-    echo "native"
-  fi
-}
-
-has_docker_for_windows_client(){
-  debug $FUNCNAME
-  if [[ "${GLOBAL_HOST_IP}" = "10.0.75.2" ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-is_boot2docker() {
-  debug $FUNCNAME
-  if uname -r | grep -q 'boot2docker'; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-is_docker_for_windows() {
-  debug $FUNCNAME
-  if uname -r | grep -q 'moby' && has_docker_for_windows_client; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-is_docker_for_mac() {
-  debug $FUNCNAME
-  if uname -r | grep -q 'moby' && ! has_docker_for_windows_client; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-is_native() {
-  debug $FUNCNAME
-  if [ $(get_docker_install_type) = "native" ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-
 has_env_variables() {
   debug $FUNCNAME
   PROPERTIES=$(env | grep CODENVY_)
@@ -530,20 +471,6 @@ port_open(){
   fi
 }
 
-container_exist_by_name(){
-  docker inspect ${1} > /dev/null 2>&1
-  if [ "$?" == "0" ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-get_server_container_id() {
-  log "docker inspect -f '{{.Id}}' ${1}"
-  docker inspect -f '{{.Id}}' ${1}
-}
-
 wait_until_container_is_running() {
   CONTAINER_START_TIMEOUT=${1}
 
@@ -553,14 +480,6 @@ wait_until_container_is_running() {
     sleep 1
     ELAPSED=$((ELAPSED+1))
   done
-}
-
-container_is_running() {
-  if [ "$(docker ps -qa -f "status=running" -f "id=${1}" | wc -l)" -eq 0 ]; then
-    return 1
-  else
-    return 0
-  fi
 }
 
 wait_until_server_is_booted () {

--- a/dockerfiles/cli/cli.sh
+++ b/dockerfiles/cli/cli.sh
@@ -149,6 +149,7 @@ cli_parse () {
       ;;
       *)
          error "You passed an unknown command."
+         usage
          return 2
       ;;
   esac

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -14,6 +14,8 @@ init_constants() {
   GREEN='\033[0;32m'
   RED='\033[0;31m'
   YELLOW='\033[38;5;220m'
+  BOLD='\033[1m'
+  UNDERLINE='\033[4m'
   NC='\033[0m'
   LOG_INITIALIZED=false
 

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -52,7 +52,7 @@ init_constants() {
 
 init_usage() {
   USAGE="
-Usage: docker run -it --rm 
+Usage: docker run -it --rm
                   -v /var/run/docker.sock:/var/run/docker.sock
                   -v <LOCAL_DATA_PATH>:${CHE_CONTAINER_ROOT}
                   ${CODENVY_IMAGE_NAME} [COMMAND]
@@ -61,7 +61,7 @@ Usage: docker run -it --rm
     version                              Installed version and upgrade paths
     init                                 Initializes a directory with a ${CHE_FORMAL_PRODUCT_NAME} install
          [--no-force                         Default - uses cached local Docker images
-          --pull                             Checks for newer images from DockerHub  
+          --pull                             Checks for newer images from DockerHub
           --force                            Removes all images and re-pulls all images from DockerHub
           --offline                          Uses images saved to disk from the offline command
           --accept-license                   Auto accepts the ${CHE_FORMAL_PRODUCT_NAME} license during installation

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -227,18 +227,6 @@ is_debug() {
   fi
 }
 
-has_docker() {
-  hash docker 2>/dev/null && return 0 || return 1
-}
-
-has_compose() {
-  hash docker-compose 2>/dev/null && return 0 || return 1
-}
-
-has_curl() {
-  hash curl 2>/dev/null && return 0 || return 1
-}
-
 check_docker() {
   if ! has_docker; then
     error "Docker not found. Get it at https://docs.docker.com/engine/installation/."
@@ -392,67 +380,6 @@ check_mounts() {
   fi
 }
 
-check_host_volume_mount() {
-  echo 'test' > ${CHE_CONTAINER_ROOT}/test
-  
-  if [[ ! -f ${CHE_CONTAINER_ROOT}/test ]]; then
-    error "Docker installed, but unable to write files to your host."
-    error "Have you enabled Docker to allow mounting host directories?"
-    error "Did you give our CLI rights to create files on your host?"
-    return 2;
-  fi
-
-  rm -rf ${CHE_CONTAINER_ROOT}/test
-}
-
-get_mount_path() {
-  debug $FUNCNAME
-  FULL_PATH=$(get_full_path "${1}")
-  POSIX_PATH=$(convert_windows_to_posix "${FULL_PATH}")
-  CLEAN_PATH=$(get_clean_path "${POSIX_PATH}")
-  echo $CLEAN_PATH
-}
-
-get_full_path() {
-  debug $FUNCNAME
-  # create full directory path
-  echo "$(cd "$(dirname "${1}")"; pwd)/$(basename "$1")"
-}
-
-convert_windows_to_posix() {
-  debug $FUNCNAME
-  echo "/"$(echo "$1" | sed 's/\\/\//g' | sed 's/://')
-}
-
-convert_posix_to_windows() {
-  debug $FUNCNAME
-  # Remove leading slash
-  VALUE="${1:1}"
-
-  # Get first character (drive letter)
-  VALUE2="${VALUE:0:1}"
-
-  # Replace / with \
-  VALUE3=$(echo ${VALUE} | tr '/' '\\' | sed 's/\\/\\\\/g')
-
-  # Replace c\ with c:\ for drive letter
-  echo "$VALUE3" | sed "s/./$VALUE2:/1"
-}
-
-get_clean_path() {
-  debug $FUNCNAME
-  INPUT_PATH=$1
-  # \some\path => /some/path
-  OUTPUT_PATH=$(echo ${INPUT_PATH} | tr '\\' '/')
-  # /somepath/ => /somepath
-  OUTPUT_PATH=${OUTPUT_PATH%/}
-  # /some//path => /some/path
-  OUTPUT_PATH=$(echo ${OUTPUT_PATH} | tr -s '/')
-  # "/some/path" => /some/path
-  OUTPUT_PATH=${OUTPUT_PATH//\"}
-  echo ${OUTPUT_PATH}
-}
-
 init_logging() {
   # Initialize CLI folder
   CLI_DIR="/cli"
@@ -466,65 +393,6 @@ init_logging() {
   log "$(date)"
 }
 
-get_container_folder() {
-  THIS_CONTAINER_ID=$(get_this_container_id)
-  FOLDER=$(get_container_host_bind_folder "$1" $THIS_CONTAINER_ID)
-  echo "${FOLDER:=not set}"
-}
-
-get_this_container_id() {
-  hostname
-}
-
-get_container_host_bind_folder() {
-  # BINDS in the format of var/run/docker.sock:/var/run/docker.sock <path>:${CHE_CONTAINER_ROOT}
-  BINDS=$(docker inspect --format="{{.HostConfig.Binds}}" "${2}" | cut -d '[' -f 2 | cut -d ']' -f 1)
-  
-  # Remove /var/run/docker.sock:/var/run/docker.sock
-  VALUE=${BINDS/\/var\/run\/docker\.sock\:\/var\/run\/docker\.sock/}
-
-  # Remove leading and trailing spaces
-  VALUE2=$(echo "${VALUE}" | xargs)
-
-  MOUNT=""
-  IFS=$' '
-  for SINGLE_BIND in $VALUE2; do
-    case $SINGLE_BIND in
-      *$1)
-        MOUNT="${MOUNT} ${SINGLE_BIND}"
-        echo "${MOUNT}" | cut -f1 -d":" | xargs
-      ;;
-      *)
-        # Super ugly - since we parse by space, if the next parameter is not a colon, then
-        # we know that next parameter is second part of a directory with a space in it.
-        if [[ ${SINGLE_BIND} != *":"* ]]; then
-          MOUNT="${MOUNT} ${SINGLE_BIND}"
-        else
-          MOUNT=""
-        fi
-      ;;
-    esac
-  done
-}
-
-docker_run() {
-  debug $FUNCNAME
-  # Setup options for connecting to docker host
-  if [ -z "${DOCKER_HOST+x}" ]; then
-      DOCKER_HOST="/var/run/docker.sock"
-  fi
-
-  if [ -S "$DOCKER_HOST" ]; then
-    docker run --rm -v $DOCKER_HOST:$DOCKER_HOST \
-                    -v $HOME:$HOME \
-                    -w "$(pwd)" "$@"
-  else
-    docker run --rm -e DOCKER_HOST -e DOCKER_TLS_VERIFY -e DOCKER_CERT_PATH \
-                    -v $HOME:$HOME \
-                    -w "$(pwd)" "$@"
-  fi
-}
-
 docker_compose() {
   debug $FUNCNAME
 
@@ -535,19 +403,15 @@ docker_compose() {
                   docker/compose:1.8.1 "$@"
   fi
 }
-
-curl() {
-  if ! has_curl; then
-    log "docker run --rm --net=host appropriate/curl \"$@\""
-    docker run --rm --net=host appropriate/curl "$@"
-  else
-    log "$(which curl) \"$@\""
-    $(which curl) "$@"
-  fi
-}
-
 init() {
   init_constants
+
+  SCRIPTS_BASE_CONTAINER_SOURCE_DIR="/scripts/base"
+  # add helper scripts
+  for COMMAND_FILE in "${SCRIPTS_BASE_CONTAINER_SOURCE_DIR}"/*.sh
+  do
+    source "${COMMAND_FILE}"
+  done
 
   # Make sure Docker is working and we have /var/run/docker.sock mounted or valid DOCKER_HOST
   check_docker "$@"

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -48,12 +48,14 @@ init_constants() {
   # Activates console output
   DEFAULT_CHE_CLI_LOG="true"
   CHE_CLI_LOG=${CLI_LOG:-${DEFAULT_CHE_CLI_LOG}}
+}
 
+init_usage() {
   USAGE="
 Usage: docker run -it --rm 
                   -v /var/run/docker.sock:/var/run/docker.sock
                   -v <LOCAL_DATA_PATH>:/$CHE_MINI_PRODUCT_NAME
-                  ${CHE_MINI_PRODUCT_NAME}/cli:<version> [COMMAND]
+                  ${CODENVY_IMAGE_NAME}:${CODENVY_IMAGE_VERSION} [COMMAND]
 
     help                                 This message
     version                              Installed version and upgrade paths
@@ -313,7 +315,7 @@ check_mounts() {
     info "Simplest syntax:"
     info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
     info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
-    info "                         $CHE_MINI_PRODUCT_NAME/cli:${CODENVY_VERSION} $1"
+    info "                         ${CODENVY_IMAGE_NAME}:${CODENVY_IMAGE_VERSION} $*"
     info ""
     info ""
     info "Or run with overrides for instance and/or backup:"
@@ -321,7 +323,7 @@ check_mounts() {
     info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
     info "                      -v <YOUR_INSTANCE_PATH>:/$CHE_MINI_PRODUCT_NAME/instance"
     info "                      -v <YOUR_BACKUP_PATH>:/$CHE_MINI_PRODUCT_NAME/backup"
-    info "                         $CHE_MINI_PRODUCT_NAME/cli:${CODENVY_VERSION} $1"
+    info "                         ${CODENVY_IMAGE_NAME}:${CODENVY_IMAGE_VERSION} $*"
     return 2;
   fi
 
@@ -549,12 +551,13 @@ curl() {
 init() {
   init_constants
 
+  # Make sure Docker is working and we have /var/run/docker.sock mounted or valid DOCKER_HOST
+  check_docker "$@"
+
+  init_usage
   if [[ $# == 0 ]]; then
     usage;
   fi
-
-  # Make sure Docker is working and we have /var/run/docker.sock mounted or valid DOCKER_HOST
-  check_docker "$@"
 
   # Only verify mounts after Docker is confirmed to be working.
   check_mounts "$@"

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -124,11 +124,11 @@ info() {
     PRINT_STATEMENT=$2
   fi
   if is_info; then
-    printf "${GREEN}INFO:${NC} %s%s\n" \
+    printf "${GREEN}INFO:${NC} %b%b\n" \
               "${PRINT_COMMAND}" \
               "${PRINT_STATEMENT}"
   fi
-  log $(printf "INFO: %s %s\n" \
+  log $(printf "INFO: %b %b\n" \
         "${PRINT_COMMAND}" \
         "${PRINT_STATEMENT}")
 }

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -255,7 +255,7 @@ check_docker() {
       info "Syntax:"
       info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
       info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
-      info "                           $CHE_MINI_PRODUCT_NAME/cli $1"
+      info "                           $CHE_MINI_PRODUCT_NAME/cli $*"
       return 2;
     fi
   fi

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -62,7 +62,7 @@ Usage: docker run -it --rm
           --pull                             Checks for newer images from DockerHub  
           --force                            Removes all images and re-pulls all images from DockerHub
           --offline                          Uses images saved to disk from the offline command
-          --accept-license                   Auto accepts the Codenvy license during installation
+          --accept-license                   Auto accepts the ${CHE_FORMAL_PRODUCT_NAME} license during installation
           --reinit]                          Reinstalls using existing $CHE_MINI_PRODUCT_NAME.env configuration
     start [--pull | --force | --offline] Starts ${CHE_MINI_PRODUCT_NAME} services
     stop                                 Stops ${CHE_MINI_PRODUCT_NAME} services
@@ -74,8 +74,8 @@ Usage: docker run -it --rm
     config                               Generates a ${CHE_MINI_PRODUCT_NAME} config from vars; run on any start / restart
     add-node                             Adds a physical node to serve workspaces intto the ${CHE_MINI_PRODUCT_NAME} cluster
     remove-node <ip>                     Removes the physical node from the ${CHE_MINI_PRODUCT_NAME} cluster
-    upgrade                              Upgrades Codenvy from one version to another with migrations and backups
-    download [--pull|--force|--offline]  Pulls Docker images for the current Codenvy version
+    upgrade                              Upgrades ${CHE_FORMAL_PRODUCT_NAME} from one version to another with migrations and backups
+    download [--pull|--force|--offline]  Pulls Docker images for the current ${CHE_FORMAL_PRODUCT_NAME} version
     backup [--quiet | --skip-data]           Backups ${CHE_MINI_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
     restore [--quiet]                    Restores ${CHE_MINI_PRODUCT_NAME} configuration and data from ${CHE_CONTAINER_ROOT}/backup mount
     offline                              Saves ${CHE_MINI_PRODUCT_NAME} Docker images into TAR files for offline install
@@ -360,7 +360,7 @@ check_mounts() {
     if [[ ! -d "${CODENVY_CONTAINER_DEVELOPMENT_REPO}"  ]] || [[ ! -d "${CODENVY_CONTAINER_DEVELOPMENT_REPO}/assembly" ]]; then
       info "Welcome to $CHE_FORMAL_PRODUCT_NAME!"
       info ""
-      info "You volume mounted ':/repo', but we did not detect a valid Codenvy source repo."
+      info "You volume mounted ':/repo', but we did not detect a valid ${CHE_FORMAL_PRODUCT_NAME} source repo."
       info ""
       info "Volume mounting ':/repo' activate dev mode, using assembly and CLI files from $CHE_FORMAL_PRODUCT_NAME repo."
       info ""

--- a/dockerfiles/cli/codenvy.sh
+++ b/dockerfiles/cli/codenvy.sh
@@ -26,12 +26,12 @@ init_constants() {
   DEFAULT_CHE_MINI_PRODUCT_NAME="codenvy"
   CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
 
-  # Path to root folder inside the container
-  DEFAULT_CHE_CONTAINER_ROOT="/codenvy"
-  CHE_CONTAINER_ROOT=${CHE_CONTAINER_ROOT:-${DEFAULT_CHE_CONTAINER_ROOT}}
-
   DEFAULT_CHE_FORMAL_PRODUCT_NAME="Codenvy"
   CHE_FORMAL_PRODUCT_NAME=${CHE_FORMAL_PRODUCT_NAME:-${DEFAULT_CHE_FORMAL_PRODUCT_NAME}}
+
+  # Path to root folder inside the container
+  DEFAULT_CHE_CONTAINER_ROOT="/${CHE_MINI_PRODUCT_NAME}"
+  CHE_CONTAINER_ROOT=${CHE_CONTAINER_ROOT:-${DEFAULT_CHE_CONTAINER_ROOT}}
 
   # Turns on stack trace
   DEFAULT_CHE_CLI_DEBUG="false"
@@ -54,44 +54,44 @@ init_usage() {
   USAGE="
 Usage: docker run -it --rm 
                   -v /var/run/docker.sock:/var/run/docker.sock
-                  -v <LOCAL_DATA_PATH>:/$CHE_MINI_PRODUCT_NAME
-                  ${CODENVY_IMAGE_NAME}:${CODENVY_IMAGE_VERSION} [COMMAND]
+                  -v <LOCAL_DATA_PATH>:${CHE_CONTAINER_ROOT}
+                  ${CODENVY_IMAGE_NAME} [COMMAND]
 
     help                                 This message
     version                              Installed version and upgrade paths
-    init                                 Initializes a directory with a ${CHE_MINI_PRODUCT_NAME} install
+    init                                 Initializes a directory with a ${CHE_FORMAL_PRODUCT_NAME} install
          [--no-force                         Default - uses cached local Docker images
           --pull                             Checks for newer images from DockerHub  
           --force                            Removes all images and re-pulls all images from DockerHub
           --offline                          Uses images saved to disk from the offline command
           --accept-license                   Auto accepts the ${CHE_FORMAL_PRODUCT_NAME} license during installation
           --reinit]                          Reinstalls using existing $CHE_MINI_PRODUCT_NAME.env configuration
-    start [--pull | --force | --offline] Starts ${CHE_MINI_PRODUCT_NAME} services
-    stop                                 Stops ${CHE_MINI_PRODUCT_NAME} services
-    restart [--pull | --force]           Restart ${CHE_MINI_PRODUCT_NAME} services
-    destroy                              Stops services, and deletes ${CHE_MINI_PRODUCT_NAME} instance data
+    start [--pull | --force | --offline] Starts ${CHE_FORMAL_PRODUCT_NAME} services
+    stop                                 Stops ${CHE_FORMAL_PRODUCT_NAME} services
+    restart [--pull | --force]           Restart ${CHE_FORMAL_PRODUCT_NAME} services
+    destroy                              Stops services, and deletes ${CHE_FORMAL_PRODUCT_NAME} instance data
             [--quiet                         Does not ask for confirmation before destroying instance data
              --cli]                          If :/cli is mounted, will destroy the cli.log
     rmi [--quiet]                        Removes the Docker images for <version>, forcing a repull
-    config                               Generates a ${CHE_MINI_PRODUCT_NAME} config from vars; run on any start / restart
-    add-node                             Adds a physical node to serve workspaces intto the ${CHE_MINI_PRODUCT_NAME} cluster
-    remove-node <ip>                     Removes the physical node from the ${CHE_MINI_PRODUCT_NAME} cluster
+    config                               Generates a ${CHE_FORMAL_PRODUCT_NAME} config from vars; run on any start / restart
+    add-node                             Adds a physical node to serve workspaces intto the ${CHE_FORMAL_PRODUCT_NAME} cluster
+    remove-node <ip>                     Removes the physical node from the ${CHE_FORMAL_PRODUCT_NAME} cluster
     upgrade                              Upgrades ${CHE_FORMAL_PRODUCT_NAME} from one version to another with migrations and backups
     download [--pull|--force|--offline]  Pulls Docker images for the current ${CHE_FORMAL_PRODUCT_NAME} version
-    backup [--quiet | --skip-data]           Backups ${CHE_MINI_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
-    restore [--quiet]                    Restores ${CHE_MINI_PRODUCT_NAME} configuration and data from ${CHE_CONTAINER_ROOT}/backup mount
-    offline                              Saves ${CHE_MINI_PRODUCT_NAME} Docker images into TAR files for offline install
-    info                                 Displays info about ${CHE_MINI_PRODUCT_NAME} and the CLI 
+    backup [--quiet | --skip-data]       Backups $${CHE_FORMAL_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
+    restore [--quiet]                    Restores ${CHE_FORMAL_PRODUCT_NAME} configuration and data from ${CHE_CONTAINER_ROOT}/backup mount
+    offline                              Saves ${CHE_FORMAL_PRODUCT_NAME} Docker images into TAR files for offline install
+    info                                 Displays info about ${CHE_FORMAL_PRODUCT_NAME} and the CLI
          [ --all                             Run all debugging tests
            --debug                           Displays system information
-           --network]                        Test connectivity between ${CHE_MINI_PRODUCT_NAME} sub-systems
+           --network]                        Test connectivity between ${CHE_FORMAL_PRODUCT_NAME} sub-systems
     ssh <wksp-name> [machine-name]       SSH to a workspace if SSH agent enabled
     mount <wksp-name>                    Synchronize workspace with current working directory
-    action <action-name> [--help]        Start action on ${CHE_MINI_PRODUCT_NAME} instance
-    test <test-name> [--help]            Start test on ${CHE_MINI_PRODUCT_NAME} instance
+    action <action-name> [--help]        Start action on ${CHE_FORMAL_PRODUCT_NAME} instance
+    test <test-name> [--help]            Start test on ${CHE_FORMAL_PRODUCT_NAME} instance
 
 Variables:
-    CODENVY_HOST                         IP address or hostname where ${CHE_MINI_PRODUCT_NAME} will serve its users
+    CODENVY_HOST                         IP address or hostname where ${CHE_FORMAL_PRODUCT_NAME} will serve its users
     CLI_DEBUG                            Default=false. Prints stack trace during execution
     CLI_INFO                             Default=true. Prints out INFO messages to standard out
     CLI_WARN                             Default=true. Prints WARN messages to standard out
@@ -251,13 +251,11 @@ check_docker() {
       info "Welcome to ${CHE_FORMAL_PRODUCT_NAME}!"
       info ""
       info "$CHE_FORMAL_PRODUCT_NAME commands require additional parameters:"
-      info "  1: Mounting 'docker.sock', which let's us access Docker"
-      info "  2: A local path where ${CHE_FORMAL_PRODUCT_NAME} will save user data"
+      info "  Mounting 'docker.sock', which let's us access Docker"
       info ""
       info "Syntax:"
-      info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
-      info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
-      info "                           $CHE_MINI_PRODUCT_NAME/cli $*"
+      info "  docker run -it --rm ${BOLD} -v /var/run/docker.sock:/var/run/docker.sock${NC}"
+      info "                  $CHE_MINI_PRODUCT_NAME/cli $*"
       return 2;
     fi
   fi
@@ -314,16 +312,16 @@ check_mounts() {
     info ""
     info "Simplest syntax:"
     info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
-    info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
-    info "                         ${CODENVY_IMAGE_NAME}:${CODENVY_IMAGE_VERSION} $*"
+    info "                      -v <YOUR_LOCAL_PATH>:${CHE_CONTAINER_ROOT}"
+    info "                         ${CODENVY_IMAGE_NAME} $*"
     info ""
     info ""
     info "Or run with overrides for instance and/or backup:"
     info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
-    info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
-    info "                      -v <YOUR_INSTANCE_PATH>:/$CHE_MINI_PRODUCT_NAME/instance"
-    info "                      -v <YOUR_BACKUP_PATH>:/$CHE_MINI_PRODUCT_NAME/backup"
-    info "                         ${CODENVY_IMAGE_NAME}:${CODENVY_IMAGE_VERSION} $*"
+    info "                      -v <YOUR_LOCAL_PATH>:${CHE_CONTAINER_ROOT}"
+    info "                      -v <YOUR_INSTANCE_PATH>:${CHE_CONTAINER_ROOT}/instance"
+    info "                      -v <YOUR_BACKUP_PATH>:${CHE_CONTAINER_ROOT}/backup"
+    info "                         ${CODENVY_IMAGE_NAME} $*"
     return 2;
   fi
 
@@ -370,18 +368,18 @@ check_mounts() {
       info ""
       info "Simplest syntax::"
       info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
-      info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
+      info "                      -v <YOUR_LOCAL_PATH>:${CHE_CONTAINER_ROOT}"
       info "                      -v <YOUR_${CHE_PRODUCT_NAME}_REPO>:/repo"
-      info "                         $CHE_MINI_PRODUCT_NAME/cli:${CODENVY_VERSION} $1"
+      info "                         ${CODENVY_IMAGE_NAME} $*"
       info ""
       info ""
       info "Or run with overrides for instance, and backup (all required):"
       info "  docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock"
-      info "                      -v <YOUR_LOCAL_PATH>:/$CHE_MINI_PRODUCT_NAME"
-      info "                      -v <YOUR_INSTANCE_PATH>:/$CHE_MINI_PRODUCT_NAME/instance"
-      info "                      -v <YOUR_BACKUP_PATH>:/$CHE_MINI_PRODUCT_NAME/backup"
+      info "                      -v <YOUR_LOCAL_PATH>:${CHE_CONTAINER_ROOT}"
+      info "                      -v <YOUR_INSTANCE_PATH>:${CHE_CONTAINER_ROOT}/instance"
+      info "                      -v <YOUR_BACKUP_PATH>:${CHE_CONTAINER_ROOT}/backup"
       info "                      -v <YOUR_${CHE_PRODUCT_NAME}_REPO>:/repo"
-      info "                         $CHE_MINI_PRODUCT_NAME/cli:${CODENVY_VERSION} $1"
+      info "                         ${CODENVY_IMAGE_NAME} $*"
       return 2
     fi
     if [[ ! -d $(echo "${CODENVY_CONTAINER_DEVELOPMENT_REPO}"/"${DEFAULT_CODENVY_DEVELOPMENT_TOMCAT}"-*/) ]]; then

--- a/dockerfiles/init/build.sh
+++ b/dockerfiles/init/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+IMAGE_NAME="codenvy/init"
+. $(cd "$(dirname "$0")"; pwd)/../build.include
+
+init
+build


### PR DESCRIPTION
- allow to use ansi text with printf
- add ansi text formatting constants
- replace "/codenvy" by $CHE_CONTAINER_ROOT
- replace "codenvy" by $CHE_MINI_PRODUCT_NAME
- replace "Codenvy" by $CHE_PRODUCT_NAME
- initialize usage in its own function (for allowing to override constant)
- add sh script to build the cli image 


- use of eclipse/che-base as base image for common scripts for both eclipse/che-cli and codenvy/cli