### PR TITLE
print compose logs to console in dev mode, add license mount, sync conf

### DIFF
--- a/dockerfiles/cli/cmd_start.sh
+++ b/dockerfiles/cli/cmd_start.sh
@@ -53,8 +53,13 @@ cmd_start() {
   # Start Codenvy
   # Note bug in docker requires relative path, not absolute path to compose file
   info "start" "Starting containers..."
-  log "docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=$CHE_MINI_PRODUCT_NAME up -d >> \"${LOGS}\" 2>&1"
-  docker_compose --file="${REFERENCE_CONTAINER_COMPOSE_FILE}" \
-                 -p=$CHE_MINI_PRODUCT_NAME up -d >> "${LOGS}" 2>&1
+  COMPOSE_UP_COMMAND="docker_compose --file=\"${REFERENCE_CONTAINER_COMPOSE_FILE}\" -p=\"${CHE_MINI_PRODUCT_NAME}\" up -d"
+
+  if [ "${CODENVY_DEVELOPMENT_MODE}" != "on" ]; then
+    COMPOSE_UP_COMMAND+=" >> \"${LOGS}\" 2>&1"
+  fi
+
+  log ${COMPOSE_UP_COMMAND}
+  eval ${COMPOSE_UP_COMMAND}
   check_if_booted
 }

--- a/modules/codenvy/templates/cleanUpWorkspaceStorage.sh.erb
+++ b/modules/codenvy/templates/cleanUpWorkspaceStorage.sh.erb
@@ -1,6 +1,16 @@
 #!/bin/sh
 
 DST_FOLDER=${1}
-CLEANUP_REGEX='^(/opt/codenvy-data/fs/([0-9a-f]{2}/){3}workspace[0-9a-z]+)$'
+CLEANUP_REGEX='^(.*/codenvy-data/fs/([0-9a-f]{2}/){3}workspace[0-9a-z]+)$'
 
-[[ ${DST_FOLDER} =~ ${CLEANUP_REGEX} ]] && sudo rm -rf "${DST_FOLDER}"
+hasSudoCommand() {
+  hash sudo 2>/dev/null && return 0 || return 1
+}
+
+if echo "${DST_FOLDER}" | grep -q -E "${CLEANUP_REGEX}"; then
+  if hasSudoCommand; then
+    sudo rm -rf "${DST_FOLDER}";
+  else
+    rm -rf "${DST_FOLDER}";
+  fi;
+fi

--- a/modules/compose/templates/docker-compose-container.yml.erb
+++ b/modules/compose/templates/docker-compose-container.yml.erb
@@ -146,6 +146,7 @@ services:
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/codenvy/:/opt/codenvy-data/logs/'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/codenvy/che-machines-logs/:/opt/codenvy-data/che-machines-logs/'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/codenvy/fs/:/opt/codenvy-data/fs/'
+       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/codenvy/license/:/opt/codenvy-data/license/'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/codenvy/che-machines/:/opt/codenvy-data/che-machines/'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/conf:/opt/codenvy-data/conf'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/conf/server.xml:/opt/codenvy-tomcat/conf/server.xml'


### PR DESCRIPTION
1) in dev mode we have to print compose output to console to make devs life easier
2) added missing mount for license file to not loss it after restart
3) sync script with deployment

@garagatyi @TylerJewell @benoitf 