### PR TITLE
use codenvy.env from dev repo in dev mode

### DIFF
--- a/dockerfiles/cli/scripts/cmd_init.sh
+++ b/dockerfiles/cli/scripts/cmd_init.sh
@@ -84,6 +84,7 @@ cmd_init() {
   if [ "${CHE_DEVELOPMENT_MODE}" = "on" ]; then
     docker_run -v "${CHE_HOST_CONFIG}":/copy \
                -v "${CHE_HOST_DEVELOPMENT_REPO}"/dockerfiles/init:/files \
+               -v "${CHE_HOST_DEVELOPMENT_REPO}"/dockerfiles/init/manifests/codenvy.env:/etc/puppet/manifests/codenvy.env \
                    $IMAGE_INIT
   else
     docker_run -v "${CHE_HOST_CONFIG}":/copy $IMAGE_INIT


### PR DESCRIPTION
in dev mode we should take codenvy.env from dev repo not from the image
@benoitf @TylerJewell @garagatyi 