### PR TITLE
fix cli.log flushing

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -500,7 +500,9 @@ wait_until_server_is_booted () {
 
 server_is_booted() {
   HTTP_STATUS_CODE=$(curl -I -k $CODENVY_HOST/api/ \
-                     -s -o "${LOGS}" --write-out "%{http_code}")
+                     -s -o /dev/null --write-out "%{http_code}")
+  log "${HTTP_STATUS_CODE}"
+
   if [[ "${HTTP_STATUS_CODE}" = "200" ]] || [[ "${HTTP_STATUS_CODE}" = "302" ]]; then
     return 0
   else


### PR DESCRIPTION
the issue is was with curl doing `-o "${LOGS}"` it did overwrite of whole log.
@TylerJewell @benoitf @garagatyi 