### PR TITLE
(#1297) Add migration patch for Codenvy on-prem 5.0.0-M8

### DIFF
--- a/cdec/installation-manager-resources/src/main/resources/patches/5.0.0-M8/single_server/patch_before_update.sh
+++ b/cdec/installation-manager-resources/src/main/resources/patches/5.0.0-M8/single_server/patch_before_update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e  # tells bash that it should exit the script if any statement returns value > 0
+
+dollar_symbol='$'
+
+CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+LOG_FILE="$CODENVY_IM_BASE/migration.log"
+rm -f "$LOG_FILE"
+
+
+# Fix locations in PostgreSQL
+echo >> "$LOG_FILE"
+echo "Fix locations in PostgreSQL..." >> "$LOG_FILE"
+
+sudo su - postgres -c "psql dbcodenvy << EOF
+UPDATE environment
+SET location=regexp_replace(location, '${host_protocol}://${host_url}/api', '')
+EOF" >> "$LOG_FILE"


### PR DESCRIPTION
Add migration script to fix locations in **environment** table of PostgreSQL when updating Codenvy on-prem 5.0.0-M7 to 5.0.0-M8:

```
UPDATE environment
SET location=regexp_replace(location, '${host_protocol}://${host_url}/api', '')
```

@riuvshin: please, review this request.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>