### PR TITLE
CLI Fixup

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -158,6 +158,14 @@ cmd_config_post_action() {
     echo "  codenvy-postgresql-volume:" >> "${REFERENCE_CONTAINER_COMPOSE_FILE}"
     echo "     external: true" >> "${REFERENCE_CONTAINER_COMPOSE_FILE}"
 
+    # This is a post-config creation, so we should also do this to the host version of the file
+    sed "s|^.*postgresql\/data.*$|\ \ \ \ \ \ \-\ \'codenvy-postgresql-volume\:\/var\/lib\/postgresql\/data\:Z\'|" -i "${REFERENCE_CONTAINER_COMPOSE_HOST_FILE}"
+
+    echo "" >> "${REFERENCE_CONTAINER_COMPOSE_HOST_FILE}"
+    echo "volumes:" >> "${REFERENCE_CONTAINER_COMPOSE_HOST_FILE}"
+    echo "  codenvy-postgresql-volume:" >> "${REFERENCE_CONTAINER_COMPOSE_HOST_FILE}"
+    echo "     external: true" >> "${REFERENCE_CONTAINER_COMPOSE_HOST_FILE}"
+
     # On Windows, it is not possible to volume mount postgres data folder directly
     # This creates a named volume which will store postgres data in docker for win VM
     # TODO - in future, we can write synchronizer utility to copy data from win VM to host


### PR DESCRIPTION
### What does this PR do?
1. Fixes an issue where you cannot run `docker-compose up` on the host system without using the CLI on Windows. We needed to add in additional modifications that we make to docker-compose-container.yml into the docker-compose.yml file. Those modifications for windows are now added.

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
This content may also be included in the release notes.

### Tests written?
Yes/No

### Docs requirements?
Include the content for all the docs changes required. 
1.  API changes  
2.  User docs changes  

