### PR TITLE
Increase timeout to wait start of workspace in integration tests

### DIFF
--- a/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
+++ b/cdec/installation-manager-tests/src/main/resources/bin/codenvy/install/test-install-single-node-behind-the-proxy.sh
@@ -134,7 +134,7 @@ authWithoutRealmAndServerDns "cdec" "pwd123ABC"
 doPost "application/json" "{}" "http://${HOST_URL}/api/workspace/${WORKSPACE_ID}/runtime?token=${TOKEN}"
 
 # obtain network ports
-doSleep "6m"  "Wait until workspace starts to avoid 'java.lang.NullPointerException' error on verifying workspace state"
+doSleep "12m"  "Wait until workspace starts to avoid 'java.lang.NullPointerException' error on verifying workspace state"
 doGet "http://${HOST_URL}/api/workspace/${WORKSPACE_ID}?token=${TOKEN}"
 validateExpectedString ".*\"status\":\"RUNNING\".*"
 fetchJsonParameter "network.ports"


### PR DESCRIPTION
Increase timeout to wait start of workspace in integration tests of Installation Manager CLI.

Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>