### PR TITLE
Content updates to Admin Guide docs section

### DIFF
--- a/docs/_docs/admin-guide/cli.md
+++ b/docs/_docs/admin-guide/cli.md
@@ -2,7 +2,7 @@
 title: CLI Reference
 excerpt: "Manage your Codenvy installation on the command line."
 layout: docs
-permalink: /docs/cli/
+permalink: /docs/admin-guide/cli/
 ---
 The CLI will hide most error conditions from standard out. Internal stack traces and error output is redirected to `cli.log`, which is saved in the host folder where `:/data` is mounted.
 
@@ -55,6 +55,8 @@ Deletes `/docs`, `codenvy.env` and `/instance`, including destroying all user wo
 
 ## codenvy offline
 Saves all of the Docker images that Codenvy requires into `/backup/*.tar` files. Each image is saved as its own file. If the `backup` folder is available on a machine that is disconnected from the Internet and you start Codenvy with `--offline`, the CLI pre-boot sequence will load all of the Docker images in the `/backup/` folder.
+
+`--list` option will list all of the core images and optional stack images that can be downloaded. The core system images and the CLI will always be saved, if an existing TAR file is not found. `--image:<image-name>` will download a single stack image and can be used multiple times on the command line. You can use `--all-stacks` or `--no-stacks` to download all or none of the optional stack images.
 
 ## codenvy rmi
 Deletes the Docker images from the local registry that Codenvy has downloaded for this version.

--- a/docs/_docs/admin-guide/installation.md
+++ b/docs/_docs/admin-guide/installation.md
@@ -192,23 +192,18 @@ CODENVY_NO_PROXY_FOR_CODENVY_WORKSPACES=localhost,127.0.0.1,<YOUR_CODENVY_HOST>
 The last three entries are injected into workspaces created by your users. This gives your users access to the Internet from within their workspaces. You can comment out these entries to disable access. However, if that access is turned off, then the default templates with source code will fail to be created in workspaces as those projects are cloned from GitHub.com. Your workspaces are still functional, we just prevent the template cloning.
 
 ## Offline Installation
-We support the ability to install and run Codenvy while disconnected from the Internet. This is helpful for certain restricted environments, regulated datacenters, or offshore installations. The offline installation has you download a custom set of images while connected in a network DMZ that has access to DockerHub and then starting Codenvy with those images.
+We support offline (disconnected from the Internet) installation and operation. This is helpful for  restricted environments, regulated datacenters, or offshore installations. The offline installation downloads the CLI, core system images, and any stack images while you are within a network DMZ with DockerHub access. You can then move those files to a secure environment and start Codenvy.
 
 #### 1. Save Codenvy Images
 While connected to the Internet, download Codenvy's Docker images:
 ```
 codenvy offline
 ```
-The CLI will download images and save them to `/instance/backup/*.tar` with each image saved as its own file. You can optionally save these files to a differnet location by volume mounting a local folder to `:/data/backup`. The version tag of the CLI Docker image will be used to determine which versions of dependent images to download. There is about 1GB of data that will be saved.
+The CLI will download images and save them to `/backup/*.tar` with each image saved as its own file. You can save these files to a differnet location by volume mounting a local folder to `:/data/backup`. The version tag of the CLI Docker image will be used to determine which versions of dependent images to download. There is about 1GB of data that will be saved.
 
-!! Note - this command will download all Codenvy images including all images for all stacks. There are a few dozen stacks for different programming languages and some of them are over 1GB in size. It is unlikely that your users will need all of the stacks, so you do not need to download all of them. You can download a specific stack by running `codenvy offline --image:<image-name>` and you can see the full list of stack images available with `codenvy offline --list`.
+The default execution will download none of the optional stack images, which are needed to launch workspaces of a particular type. There are a few dozen stacks for different programming languages and some of them are over 1GB in size. It is unlikely that your users will need all of the stacks, so you do not need to download all of them. You can get a list of available stack images by running `codenvy offline --list`. You can download a specific stack by running `codenvy offline --image:<image-name>` and the `--image` flag can be repeatedly used on a single command line.
 
-#### 2. Save Codenvy CLI
-```
-docker save codenvy/cli:<version>
-```
-
-#### 3. Start Codenvy In Offline Mode
+#### 2. Start Codenvy In Offline Mode
 Place the TAR files into a folder in the offline computer. If the files are in placed in a folder named `/tmp/offline`, you can run Codenvy in offline mode with: 
 
 ```

--- a/docs/_docs/admin-guide/managing.md
+++ b/docs/_docs/admin-guide/managing.md
@@ -5,14 +5,16 @@ layout: docs
 permalink: /docs/admin-guide/managing/
 ---
 ## Scaling
-Codenvy workspaces can run on different physical nodes that are part of a Codenvy cluster managed by Docker Swarm. This is an essential part of managing large development teams, as workspaces are both RAM and CPU intensive operations, and developers do not like to share their computing power when they have a compilation that they want done. So you will want to allocate enough physical nodes to smartly handle the right number of concurrently *running* workspaces, each of which will have a RAM block.
+Codenvy workspaces can run on different physical nodes that are part of a Codenvy cluster managed by Docker Swarm. This is an essential part of managing large development teams, as workspaces are both RAM and CPU intensive operations, and developers do not like to share their computing power. You will want to allocate enough nodes and resources to handle the number of concurrently *running* workspaces, each of which will have its own RAM and CPU requirements.
 
-Each Codenvy instance generates a configuration on how to add nodes into the cluster. Run `codenvy add-node` for instructions of what to run on each physical node that should be added into the cluster. The physical node runs a script which installs some software from the Codenvy master node, configures its Docker daemon, and then registers itself as a member of the Codenvy cluster.
+Each Codenvy instance generates a configuration for the nodes in its cluster. Run `codenvy add-node` for instructions on what to run on each physical node that should be added to the cluster. A script on the new node will install some software from the Codenvy master node, configure its Docker daemon, and then register itself as a member of the Codenvy cluster.
 
 You can remove nodes with `codenvy remove-node <ip>`.
 
 ## Upgrading
-Upgrading Codenvy is done by downloading a `codenvy/cli:<version>` that is newer than the version you currently have installed. For example, if you have 5.0.0-M2 installed and want to upgrade to 5.0.0-M8, then:
+Upgrading Codenvy is done by downloading a `codenvy/cli:<version>` that is newer than the version you currently have installed. You can run `codenvy version` to see the list of available versions that you can upgrade to.
+
+For example, if you have 5.0.0-M2 installed and want to upgrade to 5.0.0-M8, then:
 ```
 # Get the new version of Codenvy
 docker pull codenvy/cli:5.0.0-M8
@@ -24,15 +26,20 @@ docker run <volume-mounts> codenvy/cli:5.0.0-M8 upgrade
 
 The upgrade command has numerous checks to prevent you from upgrading Codenvy if the new image and the old version are not compatible. In order for the upgrade procedure to advance, the CLI image must be newer that the version in `/instance/codenvy.ver`.
 
-The upgrade process: a) performs a version compatibility check, b) downloads new Docker images that are needed to run the new version of Codenvy, c) stops Codenvy if it is currently running triggering a maintenance window, d) backs up your installation, e) initializes the new version, and f) starts Codenvy.
+The upgrade process:
+1. Performs a version compatibility check
+2. Downloads new Docker images that are needed to run the new version of Codenvy
+3. Stops Codenvy if it is currently running
+4. Triggers a maintenance window
+5. Backs up your installation
+6. Initializes the new version
+7. Starts Codenvy
 
-You can run `codenvy version` to see the list of available versions that you can upgrade to.
-
-## Backup (Backup)
+## Backup
 You can run `codenvy backup` to create a copy of the relevant configuration information, user data, projects, and workspaces. We do not save workspace snapshots as part of a routine backup exercise. You can run `codenvy restore` to recover Codenvy from a particular backup snapshot. The backup is saved as a TAR file that you can keep in your records.
 
 ### Microsoft Windows and NTFS
-Due to differences in file system types between NTFS and what is commonly used in the Linux world, there is no convenient way to directly host mount Postgres database data from within the container onto your host. We store your database data in a Docker named volume inside your boot2docker or Docker for Windows VM. Your data is persisted permanently. If the underlying VM is destroyed, then the data will be lost.
+Due to differences in file system types between NTFS and what is commonly used in the Linux world, there is no convenient way to directly host mount Postgres database data from within the container onto your host. We store your database data in a Docker named volume inside your boot2docker or Docker for Windows VM. Your data is persisted but if the underlying VM is destroyed, then the data will be lost.
 
 However, when you do a `codenvy backup`, we do copy the Postgres data from the container's volume to your host drive, and make it available as part of a `codenvy restore` function. The difference is that if you are browsing your `/instance` folder, you will not see the database data on Windows.
 
@@ -40,4 +47,66 @@ However, when you do a `codenvy backup`, we do copy the Postgres data from the c
 We currently do not support migrating from the puppet-based configuration of Codenvy to the Dockerized version. We do have a manual process which can be followed to move data between the puppet and Dockerized versions. The versions must be identical. Contact us to let our support team perform this migration for you.
 
 ## Disaster Recovery
-We maintain a disaster recovery [policy and best practices](http://codenvy.readme.io/v5.0/docs/disaster-recovery).
+Codenvy is not designed to be a "5-9s" system, however there are steps that can be taken by an operations team responsible for Codenvy to ensure a quick recovery from any crashes.
+
+A secondary Codenvy system should be installed and kept at the same version level as the primary system. On a nightly or more frequent basis the Codenvy data store, Docker images and configuration can be transferred to the secondary system.
+
+In the event of a failure of the primary, the secondary system can be powered on and traffic re-routed to it. Users accounts and workspaces will appear in the state they were in as of the last data transfer.  
+
+### Initial Setup
+#### Create the Secondary System
+Install Codenvy on a secondary system taking care to ensure that the version matches the primary system, remember to include the license file in this system. The secondary system should have the same number and size of nodes as the primary system.
+
+#### Transfer Data from Primary System
+On the primary system's master node:
+
+1. Execute `codenvy backup`.
+2. Run `docker images` to get a list of all the images used in Codenvy.
+3. Run `docker save` for each of the listed images to create a TAR of each image for transfer.
+4. In the `/etc/puppet/manifests/nodes/codenvy/` directory copy the `codenvy.pp` file to a location where it is ready to transfer.
+
+On the secondary system's master node:
+
+1. Execute `codenvy restore`.
+2. Run `docker load` against each of the TARs generated from the primary system.
+3. Replace the `codenvy.pp` file at `/etc/puppet/manifests/nodes/codenvy/` with the version copied from the primary system.
+4. Restart the Codenvy system.
+
+#### Setup Integrations
+Any integrations that are used in the system (like LDAP, JIRA and others) should be configured identically on the secondary system.
+
+#### Setup Network Routing
+Codenvy requires a DNS entry. In the event of a failure traffic will need to be re-routed from the primary to secondary systems. There are a number of ways to accomplish this - consult with your networking team to determine which is most appropriate for your environment.
+
+#### Test the Secondary System
+Log into the secondary system and ensure that it works as expected, including any integrations. The tests should include logging in and instantiating a workspace at minimum. Once everything checks out you can leave the system idle (hot standby) or power it down (cold standby).
+
+#### Encourage Developers to Commit
+The source of truth for code should be the source code repository. Developers should be encouraged to commit their changes nightly (at least) so that the code is up-to-date.
+
+### On-Going Maintenance
+#### Version Updates
+Each time the primary system is updated the secondary system should be updated as well.  Test both systems after update to confirm that they are functioning correctly.
+
+#### Adding / Removing Nodes
+Each time the primary system nodes change (new nodes are added, existing are removed, or node resources are significantly changed) the same changes should be made to the secondary nodes.
+
+#### Nightly Data Transfers
+On a periodic basis (we suggest nightly) the data transfer steps below should be executed. These can be scripted.  This is best done off-hours.
+
+On the primary system's master node:
+
+1. Execute `codenvy backup`.
+2. Run `docker images` to get a list of all the images used in Codenvy.
+3. Run `docker save` for each of the listed images to create a TAR of each image for transfer.
+4. In the `/etc/puppet/manifests/nodes/codenvy/` directory copy the `codenvy.pp` file to a location where it is ready to transfer.
+
+On the secondary system's master node:
+
+1. Execute `codenvy restore`.
+2. Run `docker load` against each of the TARs generated from the primary system.
+3. Replace the `codenvy.pp` file at `/etc/puppet/manifests/nodes/codenvy/` with the version copied from the primary system.
+4. Restart the Codenvy system.
+
+### Triggering Failover
+If there is a failure with the primary system, start the secondary system and log in to ensure that everything is working as expected. Then re-route traffic to the secondary nodes.


### PR DESCRIPTION
Updates content and adds in missing sections to the Admin Guide.

Added in updated syntax for how to run Codenvy in offline mode. These changes require this Eclipse Che PR to be merged.  https://github.com/eclipse/che/pull/3394.  The new offline mode only requires a single step to download everything, and it previously had 4 steps.