### PR TITLE
Updated TOC to have white label guide

### DIFF
--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -39,9 +39,8 @@
   - issue-management
   - version-control
   - continuous-integration
-- title: Developer Guide
+- title: White Label Guide
   docs:
-  - rest-api
-  - developing-extensions
-  - dev-java-class-reference
+  - custom-assemblies
+  - introduction-white-labels
   


### PR DESCRIPTION
replaces the old `developer guide` pages with the correct `white label guide`