### PR TITLE
CHE-3426: fix problem with regexp for api requests

### DIFF
--- a/assembly/onpremises-ide-packaging-war-ext-server/src/main/java/com/codenvy/ext/java/server/MachineServletModule.java
+++ b/assembly/onpremises-ide-packaging-war-ext-server/src/main/java/com/codenvy/ext/java/server/MachineServletModule.java
@@ -41,7 +41,7 @@ public class MachineServletModule extends ServletModule {
 
         //servlets
         install(new com.codenvy.auth.sso.client.deploy.SsoClientServletModule());
-        serveRegex("/.*/api((?!(/(ws|eventbus)($|/.*)))/.*)").with(org.everrest.guice.servlet.GuiceEverrestServlet.class);
+        serveRegex("/[^/]+/api((?!(/(ws|eventbus)($|/.*)))/.*)").with(org.everrest.guice.servlet.GuiceEverrestServlet.class);
 
         bind(io.swagger.jaxrs.config.DefaultJaxrsConfig.class).asEagerSingleton();
         serve("/swaggerinit").with(io.swagger.jaxrs.config.DefaultJaxrsConfig.class, ImmutableMap


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with creating request url to ws-agent

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3426

### Previous Behavior
The URL `port_host/api/path1/.../pathn1/api/pathn2` was modified `/api/pathn2`

### New Behavior
The URL `port_host/api/path1/.../pathn1/api/pathn2` will be modified `/api/path1/.../pathn1/api/pathn2`
