### PR TITLE
Docker Configuration Docs

### DIFF
--- a/dockerfiles/init/manifests/codenvy.env
+++ b/dockerfiles/init/manifests/codenvy.env
@@ -235,18 +235,51 @@
 #     By default this is set to "bridge".
 #CODENVY_MACHINE_DOCKER_NETWORK_DRIVER=overlay
 
-# Auto Snapshot / Restore
-#     Enables automatic snapshots of workspaces when users stop them or when they go idle. Default = "false".
-#     The default Codenvy registry is not secure and this only works if Docker daemon configured
-#     to work with insecure registries or you provide your own private secure registry.
-#     More info: https://docs.docker.com/registry/insecure/
+# Workspace Snapshots
+#     By default, when a workspace is stopped, we snapshot its state, create a Docker image 
+#     of it, and then save that image in a private Docker registry that is started when
+#     Codenvy starts. Codenvy's built-in registry  is not secure and only works 
+#     if your Docker daemon is configured to work with insecure registries, which it typically
+#     is. More info: https://docs.docker.com/registry/insecure/
+#
+#     You can replace Codenvy's internal insecure registry with your own, such as JFrog
+#     Artifactor or Docker Enterprise Registry.
+#CODENVY_DOCKER_REGISTRY_FOR_WORKSPACE_SNAPSHOTS=<your_private_registry_url>:<port>
+#
+#     You can change whether snapshots happen automatically when users stop their workspace.
 #CODENVY_WORKSPACE_AUTO_SNAPSHOT=true
 #
-# If a snapshot exists, then the workspace will be loaded from the snapshot instead of a base image.
+#     If a snapshot exists, workspace will start form the snapshot using the snapshot image.
+#     If false, then the workspace will always start from the base stack image, instead.
 #CODENVY_WORKSPACE_AUTO_RESTORE=true
+
+# Private Images
+#      If your stacks need to pull images that are private, which require authenticated
+#      access by the Docker client. Or, if you have Codenvy configured to save workspace
+#      snapshots to a private registry that requires authentication before an image can
+#      be pushed, then you need to add that registry's authentication credentials.
 #
-# Custom Docker registry to store workspace snapshots <DNS>:<PORT>
-#CODENVY_DOCKER_REGISTRY_FOR_WORKSPACE_SNAPSHOTS=<your_private_registry_url>:5000
+#      Once these registries are configured, you can create stacks that use recipes
+#      with Dockerfiles that reference private images using the
+#      'FROM <your-registry>/<your-repo> syntax.
+#
+#      We have separate configurations for AWS EC2 vs. a Docker registry. You can add
+#      as many registries for authentication as necessary by appending REGISTRY[n] ID to
+#      each entry.
+#       Example:
+#            CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY2_URL=url2
+#            CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY2_USERNAME=username2
+#            CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY2_PASSWORD=password2
+#
+#CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY1_URL=url1
+#CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY1_USERNAME=username1
+#CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY1_PASSWORD=password1
+#
+#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_ID=id1
+#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_REGION=region1
+#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_ACCESS__KEY__ID=key_id1
+#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_SECRET__ACCESS__KEY=secret1
+
 
 ############################################################
 #####                                                  #####
@@ -430,31 +463,3 @@
 #     an expanded list of nodes. You should not have to configure this as we
 #     manage it with the CLI.
 #CODENVY_SWARM_NODES=172.17.0.1:2375
-#
-# Private Registries
-#      Some enterprises use a trusted Docker registry to store their Docker images.
-#      If you want your workspace stacks and machines to be powered by these images,
-#      then you need to configure each registry and the credentialed access. Once these
-#      registries are configured, then you can have users or team leaders create stacks
-#      that use recipes with Dockerfiles or images using the
-#      'FROM <your-registry>/<your-repo> syntax.
-#
-#      We have separate configuration for AWS EC2 vs. Docker registry.
-#      In case of adding several registries just copy set of properties
-#      and append REGISTRY[n] ID for each ENV var.
-#       Example:
-#            CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY2_URL=url2
-#            CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY2_USERNAME=username2
-#            CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY2_PASSWORD=password2
-#
-#
-# Docker Private Registry, uncomment to configure
-#CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY1_URL=url1
-#CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY1_USERNAME=username1
-#CODENVY_DOCKER_REGISTRY_AUTH_REGISTRY1_PASSWORD=password1
-#
-# Docker Private Registry AWS ECR, uncomment to configure
-#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_ID=id1
-#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_REGION=region1
-#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_ACCESS__KEY__ID=key_id1
-#CODENVY_DOCKER_REGISTRY_AWS_REGISTRY1_SECRET__ACCESS__KEY=secret1


### PR DESCRIPTION
### What does this PR do?
1. Improves the docuemntation around how to setup a private registry for snaps.
2. Copies over Che documentation for configuring various Docker items like mirroring, private registry authentication, and Docker in Docker.
3. Moves some stuff around in the default codevy.env to make configuration easier.
