### PR TITLE
CODENVY-1392: fix sync agent start check

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/launcher/ExternalRsyncAgentLauncherImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/launcher/ExternalRsyncAgentLauncherImpl.java
@@ -16,6 +16,8 @@ package com.codenvy.machine.agent.launcher;
 
 import org.eclipse.che.api.agent.server.launcher.AbstractAgentLauncher;
 import org.eclipse.che.api.agent.server.launcher.AgentLaunchingChecker;
+import org.eclipse.che.api.agent.server.launcher.CommandExistsAgentChecker;
+import org.eclipse.che.api.agent.server.launcher.CompositeAgentLaunchingChecker;
 import org.eclipse.che.api.agent.shared.model.Agent;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.machine.server.spi.Instance;
@@ -41,7 +43,10 @@ public class ExternalRsyncAgentLauncherImpl extends AbstractAgentLauncher {
     @Inject
     public ExternalRsyncAgentLauncherImpl(@Named("che.agent.dev.max_start_time_ms") long agentMaxStartTimeMs,
                                           @Named("che.agent.dev.ping_delay_ms") long agentPingDelayMs) {
-        super(agentMaxStartTimeMs, agentPingDelayMs, AgentLaunchingChecker.DEFAULT);
+        super(agentMaxStartTimeMs,
+              agentPingDelayMs,
+              new CompositeAgentLaunchingChecker(new CommandExistsAgentChecker("rsync"),
+                                                 AgentLaunchingChecker.DEFAULT));
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Change way of verification that sync agent is launched in machine.

### What issues does this PR fix or reference?
Fixes #1392 

### Previous Behavior
Start of WS sometimes failed when ssh or/and rsync are not installed in container.

### New Behavior
Start of WS finishes successfully when ssh or/and rsync are not installed in container.

### Tests written?
No