### PR TITLE
Fix license error message in case of license doesn't expire

### DIFF
--- a/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/helper/NodeManagerHelperCodenvy4Impl.java
+++ b/cdec/installation-manager-core/src/main/java/com/codenvy/im/managers/helper/NodeManagerHelperCodenvy4Impl.java
@@ -371,7 +371,7 @@ public class NodeManagerHelperCodenvy4Impl extends NodeManagerHelper {
             SystemLicense systemLicense = codenvy4xLicenseManager.load();
 
             SystemLicense.LicenseType licenseType = systemLicense.getLicenseType();
-            if (systemLicense.isExpiredCompletely()) {
+            if (systemLicense.isTimeForRenewExpired()) {
                 switch (licenseType) {
                     case EVALUATION_PRODUCT_KEY:
                         throw new IllegalStateException("Your Codenvy subscription only allows a single server.");

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/SystemLicenseWorkspaceFilter.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/SystemLicenseWorkspaceFilter.java
@@ -43,7 +43,7 @@ public class SystemLicenseWorkspaceFilter extends CheMethodInvokerFilter {
             case "startFromConfig":
             case "startById":
                 if (!licenseManager.canStartWorkspace()) {
-                    throw new ForbiddenException(licenseManager.getMessageForLicenseCompletelyExpired());
+                    throw new ForbiddenException(licenseManager.getMessageWhenUserCannotStartWorkspace());
                 }
 
                 break;

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseManager.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseManager.java
@@ -299,7 +299,7 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
 
     /**
      * Returns error message when license completely expired (including additional time for renew license) with different content
-     * depending on if current user is admin, and if there is existed license in the system.
+     * depending on if current user is admin.
      * @throws ServerException
      */
     public String getMessageForLicenseCompletelyExpired() throws ServerException {
@@ -308,12 +308,33 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
                           userManager.getTotalCount(),
                           SystemLicense.MAX_NUMBER_OF_FREE_USERS);
         } else {
-            try {
-                load();
                 return LICENSE_COMPLETELY_EXPIRED_MESSAGE_FOR_NON_ADMIN;
-            } catch (SystemLicenseException e) {
-                return LICENSE_HAS_REACHED_ITS_USER_LIMIT_MESSAGE_FOR_WORKSPACE;
+        }
+    }
+
+    /**
+     * Returns error message when license completely expired (including additional time for renew license) with different content
+     * depending on if current user is admin, and if there is existed license in the system.
+     * @throws ServerException
+     */
+    public String getMessageWhenUserCannotStartWorkspace() throws ServerException {
+        try {
+            // when license exists
+            SystemLicense license = load();   // check if license exists
+            if (license.isExpiredCompletely()) {
+                return getMessageForLicenseCompletelyExpired();
             }
+        } catch (SystemLicenseException e) {
+            // do nothing
+        }
+
+        // when license absent, invalid or non-completely-expired
+        if (isAdmin()) {
+            return format(LICENSE_COMPLETELY_EXPIRED_MESSAGE_FOR_ADMIN_TEMPLATE,
+                          userManager.getTotalCount(),
+                          SystemLicense.MAX_NUMBER_OF_FREE_USERS);
+        } else {
+            return LICENSE_HAS_REACHED_ITS_USER_LIMIT_MESSAGE_FOR_WORKSPACE;
         }
     }
 

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseManager.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseManager.java
@@ -210,7 +210,7 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
     public long getAllowedUserNumber() {
         try {
             SystemLicense systemLicense = load();
-            if (!systemLicense.isExpiredCompletely()) {
+            if (!systemLicense.isTimeForRenewExpired()) {
                 return systemLicense.getNumberOfUsers();
             } else {
                 return SystemLicense.MAX_NUMBER_OF_FREE_USERS;
@@ -240,7 +240,7 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
             if (isPaidLicenseExpiring()) {
                 issues.add(newDto(IssueDto.class).withStatus(Issue.Status.LICENSE_EXPIRING)
                                                  .withMessage(getMessageForLicenseExpiring()));
-            } else if (isPaidLicenseCompletelyExpired() && ! isSystemUsageLegal()) {
+            } else if (isTimeForPaidLicenseRenewExpired() && ! isSystemUsageLegal()) {
                 issues.add(newDto(IssueDto.class).withStatus(Issue.Status.LICENSE_EXPIRED)
                                                  .withMessage(getMessageForLicenseCompletelyExpired()));
             }
@@ -294,7 +294,7 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
     public String getMessageForLicenseExpiring() {
         return format(LICENSE_EXPIRING_MESSAGE_TEMPLATE,
                       SystemLicense.MAX_NUMBER_OF_FREE_USERS,
-                      load().daysBeforeCompleteExpiration());
+                      load().daysBeforeTimeForRenewExpires());
     }
 
     /**
@@ -321,7 +321,7 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
         try {
             // when license exists
             SystemLicense license = load();   // check if license exists
-            if (license.isExpiredCompletely()) {
+            if (license.isTimeForRenewExpired()) {
                 return getMessageForLicenseCompletelyExpired();
             }
         } catch (SystemLicenseException e) {
@@ -362,9 +362,9 @@ public class SystemLicenseManager implements SystemLicenseManagerObservable {
     }
 
     @VisibleForTesting
-    boolean isPaidLicenseCompletelyExpired() throws ServerException, ConflictException {
+    boolean isTimeForPaidLicenseRenewExpired() throws ServerException, ConflictException {
         SystemLicense license = load();
-        if (license.isExpiredCompletely()) {
+        if (license.isTimeForRenewExpired()) {
             revertToFairSourceLicense(license);
             return true;
         } else {

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseService.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseService.java
@@ -146,7 +146,7 @@ public class SystemLicenseService {
                 .stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().toString(), Map.Entry::getValue));
 
-            boolean licenseExpired = systemLicense.isExpiredCompletely();
+            boolean licenseExpired = systemLicense.isExpired();
             properties.put(CODENVY_LICENSE_PROPERTY_IS_EXPIRED, valueOf(licenseExpired));
 
             return status(OK).entity(new JsonStringMapImpl<>(properties)).build();

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/SystemLicenseFactoryTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/SystemLicenseFactoryTest.java
@@ -127,14 +127,14 @@ public class SystemLicenseFactoryTest {
     public void testCheckExpirationDateShouldReturnFalse() throws Exception {
         SystemLicense systemLicense = systemLicenseFactory.create(LICENCE_TEXT);
 
-        assertFalse(systemLicense.isExpiredCompletely());
+        assertFalse(systemLicense.isExpired());
     }
 
     @Test
     public void testCheckExpirationDateShouldReturnTrueLicenseExpired() throws Exception {
         SystemLicense systemLicense = systemLicenseFactory.create(LICENSE_TEXT_EXPIRED);
 
-        assertTrue(systemLicense.isExpiredCompletely());
+        assertTrue(systemLicense.isExpired());
     }
 
     @Test

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/SystemLicenseWorkspaceFilterTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/SystemLicenseWorkspaceFilterTest.java
@@ -67,7 +67,7 @@ public class SystemLicenseWorkspaceFilterTest {
         filter.filter(genericResourceMethod, null);
 
         //then
-        verify(licenseManager, never()).getMessageForLicenseCompletelyExpired();
+        verify(licenseManager, never()).getMessageWhenUserCannotStartWorkspace();
     }
 
     @Test(dataProvider = "testData", expectedExceptions = ForbiddenException.class, expectedExceptionsMessageRegExp = "License expired")
@@ -79,7 +79,7 @@ public class SystemLicenseWorkspaceFilterTest {
         doReturn(WorkspaceService.class.getMethod(workspaceServiceMethodName, workspaceServiceMethodParameters)).when(genericResourceMethod).getMethod();
 
         doReturn(false).when(licenseManager).canStartWorkspace();
-        doReturn("License expired").when(licenseManager).getMessageForLicenseCompletelyExpired();
+        doReturn("License expired").when(licenseManager).getMessageWhenUserCannotStartWorkspace();
 
         //when
         filter.filter(genericResourceMethod, null);

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseManagerTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseManagerTest.java
@@ -309,7 +309,7 @@ public class SystemLicenseManagerTest {
     @Test
     public void shouldReturnAllowedUserNumberDueToLicense() {
         doReturn((int)USER_NUMBER).when(license).getNumberOfUsers();
-        doReturn(false).when(license).isExpiredCompletely();
+        doReturn(false).when(license).isTimeForRenewExpired();
 
         assertEquals(licenseManager.getAllowedUserNumber(), USER_NUMBER);
     }
@@ -322,7 +322,7 @@ public class SystemLicenseManagerTest {
 
     @Test
     public void shouldReturnAllowedUserNumberDueToFreeUsageTermsWhenLicenseCompletelyExpired() {
-        doReturn(true).when(license).isExpiredCompletely();
+        doReturn(true).when(license).isTimeForRenewExpired();
         assertEquals(licenseManager.getAllowedUserNumber(), MAX_NUMBER_OF_FREE_USERS);
     }
 
@@ -346,7 +346,7 @@ public class SystemLicenseManagerTest {
         doReturn(false).when(licenseManager).canUserBeAdded();
         doReturn(false).when(licenseManager).isFairSourceLicenseAccepted();
         doReturn(false).when(licenseManager).isPaidLicenseExpiring();
-        doReturn(true).when(licenseManager).isPaidLicenseCompletelyExpired();
+        doReturn(true).when(licenseManager).isTimeForPaidLicenseRenewExpired();
         doReturn(false).when(licenseManager).isSystemUsageLegal();
         doReturn("License expired").when(licenseManager).getMessageForLicenseCompletelyExpired();
         assertEquals(licenseManager.getLicenseIssues(),
@@ -363,7 +363,7 @@ public class SystemLicenseManagerTest {
         doReturn(true).when(licenseManager).canUserBeAdded();
         doReturn(true).when(licenseManager).isFairSourceLicenseAccepted();
         doReturn(false).when(licenseManager).isPaidLicenseExpiring();
-        doReturn(false).when(licenseManager).isPaidLicenseCompletelyExpired();
+        doReturn(false).when(licenseManager).isTimeForPaidLicenseRenewExpired();
         assertEquals(licenseManager.getLicenseIssues(), ImmutableList.of());
     }
 
@@ -418,7 +418,7 @@ public class SystemLicenseManagerTest {
     @Test
     public void shouldReturnMessageForLicenseExpiring() {
         // given
-        doReturn(5).when(license).daysBeforeCompleteExpiration();
+        doReturn(5).when(license).daysBeforeTimeForRenewExpires();
 
         // when
         String result = licenseManager.getMessageForLicenseExpiring();
@@ -430,10 +430,10 @@ public class SystemLicenseManagerTest {
     @Test
     public void shouldReturnExpiredStatus() throws ServerException, ConflictException {
         // given
-        doReturn(true).when(license).isExpiredCompletely();
+        doReturn(true).when(license).isTimeForRenewExpired();
 
         // when
-        Boolean result = licenseManager.isPaidLicenseCompletelyExpired();
+        Boolean result = licenseManager.isTimeForPaidLicenseRenewExpired();
 
         // then
         assertTrue(result);
@@ -443,10 +443,10 @@ public class SystemLicenseManagerTest {
     @Test
     public void shouldReturnNonExpiredStatus() throws ServerException, ConflictException {
         // given
-        doReturn(false).when(license).isExpiredCompletely();
+        doReturn(false).when(license).isTimeForRenewExpired();
 
         // when
-        Boolean result = licenseManager.isPaidLicenseCompletelyExpired();
+        Boolean result = licenseManager.isTimeForPaidLicenseRenewExpired();
 
         // then
         assertFalse(result);
@@ -457,7 +457,7 @@ public class SystemLicenseManagerTest {
     public void testGetMessageWhenAdminCannotStartWorkspaceWhenLicenseExpired() throws ServerException {
         // given
         doReturn(true).when(subject).hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
-        doReturn(true).when(license).isExpiredCompletely();
+        doReturn(true).when(license).isTimeForRenewExpired();
 
         // when
         String result = licenseManager.getMessageWhenUserCannotStartWorkspace();
@@ -470,7 +470,7 @@ public class SystemLicenseManagerTest {
     public void testGetMessageWhenNonAdminCannotStartWorkspaceWhenLicenseExpired() throws ServerException {
         // given
         doReturn(false).when(subject).hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
-        doReturn(true).when(license).isExpiredCompletely();
+        doReturn(true).when(license).isTimeForRenewExpired();
 
         // when
         String result = licenseManager.getMessageWhenUserCannotStartWorkspace();

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseManagerTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseManagerTest.java
@@ -454,38 +454,52 @@ public class SystemLicenseManagerTest {
     }
 
     @Test
-    public void testGetMessageForLicenseExpiredForAdmin() throws ServerException {
+    public void testGetMessageWhenAdminCannotStartWorkspaceWhenLicenseExpired() throws ServerException {
         // given
         doReturn(true).when(subject).hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+        doReturn(true).when(license).isExpiredCompletely();
 
         // when
-        String result = licenseManager.getMessageForLicenseCompletelyExpired();
+        String result = licenseManager.getMessageWhenUserCannotStartWorkspace();
 
         // then
         assertEquals(result, "There are currently 4 users registered in Codenvy but your license only allows 3. Users cannot start workspaces.");
-        verify(licenseManager, never()).load();
     }
 
     @Test
-    public void testGetMessageForLicenseExpiredForNonAdmin() throws ServerException {
+    public void testGetMessageWhenNonAdminCannotStartWorkspaceWhenLicenseExpired() throws ServerException {
         // given
-        EnvironmentContext.getCurrent().setSubject(null);
+        doReturn(false).when(subject).hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+        doReturn(true).when(license).isExpiredCompletely();
 
         // when
-        String result = licenseManager.getMessageForLicenseCompletelyExpired();
+        String result = licenseManager.getMessageWhenUserCannotStartWorkspace();
 
         // then
         assertEquals(result, "The Codenvy license is expired - you can access the user dashboard but not the IDE.");
     }
 
     @Test
-    public void testGetMessageForLicenseExpiredWhenLicenseAbsentForNonAdmin() throws ServerException {
+    public void testGetMessageWhenAdminCannotStartWorkspaceWhenThereIsNoLicense() throws ServerException {
         // given
-        doReturn(false).when(subject).hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+        doReturn(true).when(subject).hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
         doThrow(SystemLicenseException.class).when(licenseManager).load();
 
         // when
-        String result = licenseManager.getMessageForLicenseCompletelyExpired();
+        String result = licenseManager.getMessageWhenUserCannotStartWorkspace();
+
+        // then
+        assertEquals(result, "There are currently 4 users registered in Codenvy but your license only allows 3. Users cannot start workspaces.");
+    }
+
+    @Test
+    public void testGetMessageWhenNonAdminCannotStartWorkspaceWhenThereIsNoLicense() throws ServerException {
+        // given
+        EnvironmentContext.getCurrent().setSubject(null);
+        doThrow(SystemLicenseException.class).when(licenseManager).load();
+
+        // when
+        String result = licenseManager.getMessageWhenUserCannotStartWorkspace();
 
         // then
         assertEquals(result, "The Codenvy license has reached its user limit - you can access the user dashboard but not the IDE.");

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseServiceTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseServiceTest.java
@@ -14,15 +14,15 @@
  */
 package com.codenvy.api.license.server;
 
+import com.codenvy.api.license.SystemLicense;
+import com.codenvy.api.license.SystemLicenseFactory;
+import com.codenvy.api.license.SystemLicenseFeature;
+import com.codenvy.api.license.exception.InvalidSystemLicenseException;
+import com.codenvy.api.license.exception.SystemLicenseException;
+import com.codenvy.api.license.exception.SystemLicenseNotFoundException;
 import com.codenvy.api.license.shared.dto.IssueDto;
 import com.codenvy.api.license.shared.dto.LegalityDto;
 import com.codenvy.api.license.shared.model.Issue;
-import com.codenvy.api.license.SystemLicense;
-import com.codenvy.api.license.SystemLicenseFactory;
-import com.codenvy.api.license.exception.InvalidSystemLicenseException;
-import com.codenvy.api.license.exception.SystemLicenseException;
-import com.codenvy.api.license.SystemLicenseFeature;
-import com.codenvy.api.license.exception.SystemLicenseNotFoundException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.Response;
@@ -174,7 +174,7 @@ public class SystemLicenseServiceTest {
         doReturn(ImmutableMap.of(SystemLicenseFeature.TYPE, "type",
                                  SystemLicenseFeature.EXPIRATION, "2015/10/10",
                                  SystemLicenseFeature.USERS, "15")).when(mockSystemLicense).getFeatures();
-        doReturn(Boolean.FALSE).when(mockSystemLicense).isExpiredCompletely();
+        doReturn(true).when(mockSystemLicense).isExpired();
 
         Response response = given()
                 .auth().basic(JettyHttpServer.ADMIN_USER_NAME, JettyHttpServer.ADMIN_USER_PASSWORD).when()
@@ -189,7 +189,7 @@ public class SystemLicenseServiceTest {
         assertEquals(m.get(SystemLicenseFeature.TYPE.toString()), "type");
         assertEquals(m.get(SystemLicenseFeature.EXPIRATION.toString()), "2015/10/10");
         assertEquals(m.get(SystemLicenseFeature.USERS.toString()), "15");
-        assertEquals(m.get(SystemLicenseService.CODENVY_LICENSE_PROPERTY_IS_EXPIRED), "false");
+        assertEquals(m.get(SystemLicenseService.CODENVY_LICENSE_PROPERTY_IS_EXPIRED), "true");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>

### What does this PR do?
Fix error message on start of workspace by non-admin user in case of number of registered users more than license allows, but license hasn't expired yet.

Previous misleading message:
> The Codenvy license is expired - you can access the user dashboard but not the IDE.

Fixed message
> The Codenvy license has reached its user limit - you can access the user dashboard but not the IDE.

@tolusha: please, review this request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codenvy/codenvy/1446)
<!-- Reviewable:end -->
