### PR TITLE
CODENVY-1302 Add super privileges for users who have manageSystem permission

### DIFF
--- a/dockerfiles/init/manifests/codenvy.env
+++ b/dockerfiles/init/manifests/codenvy.env
@@ -37,6 +37,12 @@
 #     admin is permitted to create new accounts.
 #CODENVY_USER_SELF_CREATION_ALLOWED=true
 
+# System super privileged mode
+#
+#     When super privileged mode is enabled users who have manageSystem permission will have extra opportunities.
+#
+#CODENVY_SYSTEM_SUPER_PRIVILEGED_MODE=false
+
 # Proxies
 #     Codenvy's internal system services such as HAProxy and its internal JVMs
 #     need to have system level properties applied so that they can reach the 

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -277,6 +277,11 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
 
 ###############################
 #
+# System super privileged mode
+  $system_super_privileged_mode = getValue("CODENVY_SYSTEM_SUPER_PRIVILEGED_MODE","false")
+
+###############################
+#
 # Codenvy folders on host machine
   $codenvy_folder = getValue("CHE_INSTANCE","/tmp/codenvy")
 

--- a/dockerfiles/init/modules/codenvy/templates/general.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/general.properties.erb
@@ -73,3 +73,6 @@ db.schema.flyway.scripts.locations=<%= scope.lookupvar('addon::db_schema_flyway_
 db.schema.flyway.scripts.locations=<%= scope.lookupvar('codenvy::db_schema_flyway_scripts_locations') %>
 <% end -%>
 db.jndi.datasource.name=java:/comp/env/jdbc/codenvy
+
+# Super privileged mode
+system.super_privileged_mode=<%= scope.lookupvar('codenvy::system_super_privileged_mode') %>

--- a/wsmaster/codenvy-hosted-api-machine/src/test/java/com/codenvy/api/machine/server/jpa/JpaRecipePermissionsDaoTest.java
+++ b/wsmaster/codenvy-hosted-api-machine/src/test/java/com/codenvy/api/machine/server/jpa/JpaRecipePermissionsDaoTest.java
@@ -15,7 +15,6 @@
 package com.codenvy.api.machine.server.jpa;
 
 import com.codenvy.api.machine.server.recipe.RecipePermissionsImpl;
-import com.codenvy.api.permission.server.PermissionsModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -34,16 +33,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.persistence.EntityManager;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.eclipse.che.commons.test.db.H2TestHelper.inMemoryDefault;
-import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_DRIVER;
-import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_PASSWORD;
-import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_URL;
-import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_USER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -72,7 +65,7 @@ public class JpaRecipePermissionsDaoTest {
         recipes = new RecipeImpl[] {new RecipeImpl("recipe1", "rc1", null, null, null, null, null),
                                     new RecipeImpl("recipe2", "rc2", null, null, null, null, null)};
 
-        Injector injector = Guice.createInjector(new TestModule(), new OnPremisesJpaMachineModule(), new PermissionsModule());
+        Injector injector = Guice.createInjector(new TestModule(), new OnPremisesJpaMachineModule());
         manager = injector.getInstance(EntityManager.class);
         dao = injector.getInstance(JpaRecipePermissionsDao.class);
     }

--- a/wsmaster/codenvy-hosted-api-organization/pom.xml
+++ b/wsmaster/codenvy-hosted-api-organization/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>com.codenvy.onpremises.wsmaster</groupId>
+            <artifactId>codenvy-hosted-api-permission-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.codenvy.onpremises.wsmaster</groupId>
             <artifactId>codenvy-hosted-api-resource</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationApiModule.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationApiModule.java
@@ -14,8 +14,10 @@
  */
 package com.codenvy.organization.api;
 
-import com.codenvy.api.permission.server.SystemDomain;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
+import com.codenvy.api.permission.shared.model.PermissionsDomain;
 import com.codenvy.organization.api.permissions.OrganizationCreatorPermissionsProvider;
+import com.codenvy.organization.api.permissions.OrganizationDomain;
 import com.codenvy.organization.api.permissions.OrganizationPermissionsFilter;
 import com.codenvy.organization.api.permissions.OrganizationResourceDistributionServicePermissionsFilter;
 import com.codenvy.organization.api.resource.DefaultOrganizationResourcesProvider;
@@ -44,11 +46,6 @@ public class OrganizationApiModule extends AbstractModule {
 
         bind(OrganizationCreatorPermissionsProvider.class).asEagerSingleton();
 
-        Multibinder.newSetBinder(binder(),
-                                 String.class,
-                                 Names.named(SystemDomain.SYSTEM_DOMAIN_ACTIONS))
-                   .addBinding().toInstance(OrganizationPermissionsFilter.MANAGE_ORGANIZATIONS_ACTION);
-
         Multibinder.newSetBinder(binder(), DefaultResourcesProvider.class)
                    .addBinding().to(DefaultOrganizationResourcesProvider.class);
 
@@ -66,5 +63,8 @@ public class OrganizationApiModule extends AbstractModule {
 
         bind(OrganizationResourcesDistributionService.class);
         bind(OrganizationResourceDistributionServicePermissionsFilter.class);
+
+        Multibinder.newSetBinder(binder(), PermissionsDomain.class, Names.named(SuperPrivilegesChecker.SUPER_PRIVILEGED_DOMAINS))
+                   .addBinding().to(OrganizationDomain.class);
     }
 }

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/permissions/OrganizationResourceDistributionServicePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/permissions/OrganizationResourceDistributionServicePermissionsFilter.java
@@ -14,7 +14,7 @@
  */
 package com.codenvy.organization.api.permissions;
 
-import com.codenvy.api.permission.server.SystemDomain;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 import com.codenvy.organization.api.OrganizationManager;
 import com.codenvy.organization.api.resource.OrganizationResourcesDistributionService;
 
@@ -45,7 +45,9 @@ public class OrganizationResourceDistributionServicePermissionsFilter extends Ch
     static final String RESET_DISTRIBUTED_RESOURCES      = "reset";
 
     @Inject
-    private OrganizationManager organizationManager;
+    private OrganizationManager    organizationManager;
+    @Inject
+    private SuperPrivilegesChecker superPrivilegesChecker;
 
     @Override
     protected void filter(GenericResourceMethod genericMethodResource, Object[] arguments) throws ApiException {
@@ -68,7 +70,7 @@ public class OrganizationResourceDistributionServicePermissionsFilter extends Ch
                 organizationId = (String)arguments[0];
                 // get organization to ensure that organization exists
                 organizationManager.getById(organizationId);
-                if (currentSubject.hasPermission(SystemDomain.DOMAIN_ID, null, OrganizationPermissionsFilter.MANAGE_ORGANIZATIONS_ACTION)) {
+                if (superPrivilegesChecker.hasSuperPrivileges()) {
                     //user is able to see information about all organizations
                     return;
                 }

--- a/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/api/permissions/OrganizationPermissionsFilterTest.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/api/permissions/OrganizationPermissionsFilterTest.java
@@ -14,7 +14,7 @@
  */
 package com.codenvy.organization.api.permissions;
 
-import com.codenvy.api.permission.server.SystemDomain;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 import com.codenvy.organization.api.OrganizationManager;
 import com.codenvy.organization.api.OrganizationService;
 import com.codenvy.organization.shared.dto.OrganizationDto;
@@ -36,7 +36,6 @@ import org.everrest.core.RequestFilter;
 import org.everrest.core.resource.GenericResourceMethod;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -53,7 +52,6 @@ import static com.codenvy.organization.api.permissions.OrganizationDomain.DELETE
 import static com.codenvy.organization.api.permissions.OrganizationDomain.DOMAIN_ID;
 import static com.codenvy.organization.api.permissions.OrganizationDomain.MANAGE_SUBORGANIZATIONS;
 import static com.codenvy.organization.api.permissions.OrganizationDomain.UPDATE;
-import static com.codenvy.organization.api.permissions.OrganizationPermissionsFilter.MANAGE_ORGANIZATIONS_ACTION;
 import static com.jayway.restassured.RestAssured.given;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
@@ -86,16 +84,18 @@ public class OrganizationPermissionsFilterTest {
     private static final String USER_ID = "user123";
 
     @Mock
+    private static Subject subject;
+
+    @Mock
     private OrganizationService service;
 
     @Mock
     private OrganizationManager manager;
 
     @Mock
-    private static Subject subject;
+    private SuperPrivilegesChecker superPrivilegesChecker;
 
     @InjectMocks
-    @Spy
     private OrganizationPermissionsFilter permissionsFilter;
 
     @BeforeMethod
@@ -159,7 +159,7 @@ public class OrganizationPermissionsFilterTest {
                .get(SECURE_PATH + "/organization");
 
         verify(service).getOrganizations(eq(null), anyInt(), anyInt());
-        verify(subject, never()).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(subject, never()).hasPermission(anyString(), anyString(), anyString());
     }
 
     @Test
@@ -173,12 +173,12 @@ public class OrganizationPermissionsFilterTest {
                .get(SECURE_PATH + "/organization?user=" + USER_ID);
 
         verify(service).getOrganizations(eq(USER_ID), anyInt(), anyInt());
-        verify(subject, never()).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(subject, never()).hasPermission(anyString(), anyString(), anyString());
     }
 
     @Test
-    public void shouldCheckPermissionsOnOrganizationsFetchingIfUserSpecifiesForeignId() throws Exception {
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(true);
+    public void shouldCheckSuperPrivilegesOnOrganizationsFetchingIfUserSpecifiesForeignId() throws Exception {
+        when(superPrivilegesChecker.hasSuperPrivileges()).thenReturn(true);
 
         given().auth()
                .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
@@ -189,13 +189,13 @@ public class OrganizationPermissionsFilterTest {
                .get(SECURE_PATH + "/organization?user=user321");
 
         verify(service).getOrganizations(eq("user321"), anyInt(), anyInt());
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker).hasSuperPrivileges();
     }
 
     @Test
-    public void shouldThrowForbiddenExceptionOnOrganizationsFetchingIfUserSpecifiesForeignIdAndDoesNotHaveRequiredPermission()
+    public void shouldThrowForbiddenExceptionOnOrganizationsFetchingIfUserSpecifiesForeignIdAndDoesNotHaveSuperPrivileges()
             throws Exception {
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(false);
+        when(superPrivilegesChecker.hasSuperPrivileges()).thenReturn(false);
 
         final Response response = given().auth()
                                          .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
@@ -206,13 +206,12 @@ public class OrganizationPermissionsFilterTest {
                                          .get(SECURE_PATH + "/organization?user=user321");
 
         assertEquals(unwrapError(response), "The user is able to specify only his own id");
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker).hasSuperPrivileges();
         verifyZeroInteractions(service);
     }
 
     @Test
     public void shouldCheckPermissionsOnOrganizationUpdating() throws Exception {
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(false);
         when(subject.hasPermission(DOMAIN_ID, "organization123", UPDATE)).thenReturn(true);
 
         final Response response = given().auth()
@@ -224,7 +223,7 @@ public class OrganizationPermissionsFilterTest {
         assertEquals(response.getStatusCode(), 204);
         verify(service).update(eq("organization123"), any());
         verify(subject).hasPermission(DOMAIN_ID, "organization123", UPDATE);
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker, never()).hasSuperPrivileges();
         verifyNoMoreInteractions(subject);
     }
 
@@ -242,7 +241,7 @@ public class OrganizationPermissionsFilterTest {
         assertEquals(response.getStatusCode(), 204);
         verify(service).update(eq("organization123"), any());
         verify(subject).hasPermission(DOMAIN_ID, "parent123", MANAGE_SUBORGANIZATIONS);
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker, never()).hasSuperPrivileges();
         verifyNoMoreInteractions(subject);
     }
 
@@ -267,7 +266,6 @@ public class OrganizationPermissionsFilterTest {
     @Test
     public void shouldCheckPermissionsOnOrganizationRemoving() throws Exception {
         when(subject.hasPermission(DOMAIN_ID, "organization123", DELETE)).thenReturn(true);
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(false);
 
         final Response response = given().auth()
                                          .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
@@ -278,23 +276,7 @@ public class OrganizationPermissionsFilterTest {
         assertEquals(response.getStatusCode(), 204);
         verify(service).remove(eq("organization123"));
         verify(subject).hasPermission(DOMAIN_ID, "organization123", DELETE);
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
-        verifyNoMoreInteractions(subject);
-    }
-
-    @Test
-    public void shouldNotCheckPermissionsOnOrganizationLevelWhenUserHasManageOrganizationsAction() throws Exception {
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(true);
-
-        final Response response = given().auth()
-                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
-                                         .contentType("application/json")
-                                         .when()
-                                         .delete(SECURE_PATH + "/organization/organization123");
-
-        assertEquals(response.getStatusCode(), 204);
-        verify(service).remove(eq("organization123"));
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker, never()).hasSuperPrivileges();
         verifyNoMoreInteractions(subject);
     }
 
@@ -302,7 +284,6 @@ public class OrganizationPermissionsFilterTest {
     public void shouldCheckPermissionsOnParentOrgLevelOnChildOrganizationRemoving() throws Exception {
         when(manager.getById(anyString())).thenReturn(new OrganizationImpl("organization123", "test", "parent123"));
         when(subject.hasPermission(DOMAIN_ID, "parent123", MANAGE_SUBORGANIZATIONS)).thenReturn(true);
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(false);
 
         final Response response = given().auth()
                                          .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
@@ -313,14 +294,13 @@ public class OrganizationPermissionsFilterTest {
         assertEquals(response.getStatusCode(), 204);
         verify(service).remove(eq("organization123"));
         verify(subject).hasPermission(DOMAIN_ID, "parent123", MANAGE_SUBORGANIZATIONS);
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker, never()).hasSuperPrivileges();
         verifyNoMoreInteractions(subject);
     }
 
     @Test
     public void shouldCheckPermissionsOnChildOrganizationRemovingWhenUserDoesNotHavePermissionsOnParentOrgLevel() throws Exception {
         when(manager.getById(anyString())).thenReturn(new OrganizationImpl("organization123", "test", "parent123"));
-        when(subject.hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION)).thenReturn(false);
         when(subject.hasPermission(DOMAIN_ID, "parent123", MANAGE_SUBORGANIZATIONS)).thenReturn(false);
         when(subject.hasPermission(DOMAIN_ID, "organization123", DELETE)).thenReturn(true);
 
@@ -334,7 +314,7 @@ public class OrganizationPermissionsFilterTest {
         verify(service).remove(eq("organization123"));
         verify(subject).hasPermission(DOMAIN_ID, "parent123", MANAGE_SUBORGANIZATIONS);
         verify(subject).hasPermission(DOMAIN_ID, "organization123", DELETE);
-        verify(subject).hasPermission(SystemDomain.DOMAIN_ID, null, MANAGE_ORGANIZATIONS_ACTION);
+        verify(superPrivilegesChecker, never()).hasSuperPrivileges();
         verifyNoMoreInteractions(subject);
     }
 

--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/SuperPrivilegesChecker.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/SuperPrivilegesChecker.java
@@ -1,0 +1,114 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.api.permission.server;
+
+import com.codenvy.api.permission.shared.model.PermissionsDomain;
+
+import org.eclipse.che.commons.env.EnvironmentContext;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Checks that current subject has privileges to perform some operation without required permissions.
+ *
+ * <p>Super privileges is designed to give some extra abilities
+ * for users who have permission to perform {@link SystemDomain#MANAGE_SYSTEM_ACTION manage system}.<br>
+ * Super privileges are optional, they can be disabled by configuration.
+ *
+ * <p>User has super privileges if he has {@link SystemDomain#MANAGE_SYSTEM_ACTION manage system} permission and
+ * system configuration property {@link #SYSTEM_SUPER_PRIVILEGED_MODE} is true.
+ *
+ * <p>It is required to perform {@link #hasSuperPrivileges()} checks manually before permissions checking
+ * if user should be able to perform some operation.
+ * <pre>
+ * public class ExamplePermissionsFilter extends CheMethodInvokerFilter {
+ *     &#064;Inject
+ *     private SuperPrivilegesChecker superPrivilegesChecker;
+ *
+ *     &#064;Override
+ *     protected void filter(GenericResourceMethod genericMethodResource, Object[] arguments) throws ApiException {
+ *         if (superPrivilegesChecker.hasSuperPrivileges()) {
+ *             return;
+ *         }
+ *         EnvironmentContext.getCurrent().getSubject().checkPermissions("domain", "domain123", "action");
+ *     }
+ * }
+ * </pre>
+ *
+ * If user should be able to manage permissions for some permission domain then
+ * this domain should be present in multibinder named with {@link #SUPER_PRIVILEGED_DOMAINS}.<br>
+ * Binding example:
+ * <pre>
+ * public class ExampleModule extends AbstractModule {
+ *     &#064;Override
+ *     protected void configure() {
+ *         Multibinder.newSetBinder(binder(), PermissionsDomain.class, Names.named(SuperPrivilegesChecker.SUPER_PRIVILEGED_DOMAINS))
+ *                    .addBinding().to(ExampleDomain.class);
+ *     }
+ * }
+ * </pre>
+ *
+ * @author Sergii Leschenko
+ */
+public class SuperPrivilegesChecker {
+    /**
+     * Configuration parameter that indicates extended abilities for users
+     * who have {@link SystemDomain#MANAGE_SYSTEM_ACTION manageSytem} permission.
+     */
+    public static final String SYSTEM_SUPER_PRIVILEGED_MODE = "system.super_privileged_mode";
+
+    /** Permissions of these domains can be managed by any user who has super privileges. */
+    public static final String SUPER_PRIVILEGED_DOMAINS = "system.super_privileged_domains";
+
+    private final boolean     superPrivilegedMode;
+    private final Set<String> privilegesDomainsIds;
+
+    @Inject
+    public SuperPrivilegesChecker(@Named(SYSTEM_SUPER_PRIVILEGED_MODE) boolean superPrivilegedMode,
+                                  @Named(SUPER_PRIVILEGED_DOMAINS) Set<PermissionsDomain> domains) {
+        this.superPrivilegedMode = superPrivilegedMode;
+        this.privilegesDomainsIds = domains.stream()
+                                           .map(PermissionsDomain::getId)
+                                           .collect(Collectors.toSet());
+    }
+
+    /**
+     * Checks that current subject has super privileges.
+     *
+     * @return true if current subject has super privileges, false otherwise
+     */
+    public boolean hasSuperPrivileges() {
+        return superPrivilegedMode
+               && EnvironmentContext.getCurrent().getSubject().hasPermission(SystemDomain.DOMAIN_ID,
+                                                                             null,
+                                                                             SystemDomain.MANAGE_SYSTEM_ACTION);
+    }
+
+    /**
+     * Checks that current subject is privileged to manage permissions of specified domain.
+     *
+     * @return true if current subject is privileged to manage permissions of specified domain, false otherwise
+     */
+    public boolean isPrivilegedToManagePermissions(String domainId) {
+        return superPrivilegedMode
+               && privilegesDomainsIds.contains(domainId)
+               && EnvironmentContext.getCurrent().getSubject().hasPermission(SystemDomain.DOMAIN_ID,
+                                                                             null,
+                                                                             SystemDomain.MANAGE_SYSTEM_ACTION);
+    }
+}

--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/filter/GetPermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/filter/GetPermissionsFilter.java
@@ -16,6 +16,7 @@ package com.codenvy.api.permission.server.filter;
 
 import com.codenvy.api.permission.server.InstanceParameterValidator;
 import com.codenvy.api.permission.server.PermissionsManager;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.ConflictException;
@@ -50,6 +51,9 @@ public class GetPermissionsFilter extends CheMethodInvokerFilter {
     private PermissionsManager permissionsManager;
 
     @Inject
+    private SuperPrivilegesChecker superPrivilegesChecker;
+
+    @Inject
     private InstanceParameterValidator instanceValidator;
 
     @Override
@@ -59,6 +63,9 @@ public class GetPermissionsFilter extends CheMethodInvokerFilter {
         final String methodName = genericResourceMethod.getMethod().getName();
         if (methodName.equals("getUsersPermissions")) {
             instanceValidator.validate(domain, instance);
+            if (superPrivilegesChecker.isPrivilegedToManagePermissions(domain)) {
+                return;
+            }
             final String userId = EnvironmentContext.getCurrent().getSubject().getUserId();
             try {
                 permissionsManager.get(userId, domain, instance);

--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/filter/RemovePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/filter/RemovePermissionsFilter.java
@@ -15,6 +15,7 @@
 package com.codenvy.api.permission.server.filter;
 
 import com.codenvy.api.permission.server.InstanceParameterValidator;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.ForbiddenException;
@@ -47,6 +48,9 @@ public class RemovePermissionsFilter extends CheMethodInvokerFilter {
     private String instance;
 
     @Inject
+    private SuperPrivilegesChecker superPrivilegesChecker;
+
+    @Inject
     private InstanceParameterValidator instanceValidator;
 
     @Override
@@ -55,6 +59,9 @@ public class RemovePermissionsFilter extends CheMethodInvokerFilter {
         final String methodName = genericResourceMethod.getMethod().getName();
         if (methodName.equals("removePermissions")) {
             instanceValidator.validate(domain, instance);
+            if (superPrivilegesChecker.isPrivilegedToManagePermissions(domain)) {
+                return;
+            }
             if (!EnvironmentContext.getCurrent().getSubject().hasPermission(domain, instance, SET_PERMISSIONS)) {
                 throw new ForbiddenException("User can't edit permissions for this instance");
             }

--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/filter/SetPermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/filter/SetPermissionsFilter.java
@@ -15,6 +15,7 @@
 package com.codenvy.api.permission.server.filter;
 
 import com.codenvy.api.permission.server.InstanceParameterValidator;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 import com.codenvy.api.permission.shared.dto.PermissionsDto;
 
 import org.eclipse.che.api.core.BadRequestException;
@@ -41,6 +42,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @Path("/permissions/")
 public class SetPermissionsFilter extends CheMethodInvokerFilter {
     @Inject
+    private SuperPrivilegesChecker superPrivilegesChecker;
+
+    @Inject
     private InstanceParameterValidator instanceValidator;
 
     @Override
@@ -52,6 +56,10 @@ public class SetPermissionsFilter extends CheMethodInvokerFilter {
             checkArgument(permissions != null, "Permissions descriptor required");
             checkArgument(!isNullOrEmpty(permissions.getDomainId()), "Domain required");
             instanceValidator.validate(permissions.getDomainId(), permissions.getInstanceId());
+
+            if (superPrivilegesChecker.isPrivilegedToManagePermissions(permissions.getDomainId())) {
+                return;
+            }
 
             if (!EnvironmentContext.getCurrent().getSubject().hasPermission(permissions.getDomainId(),
                                                                             permissions.getInstanceId(),

--- a/wsmaster/codenvy-hosted-api-permission/src/test/java/com/codenvy/api/permission/server/filter/RemovePermissionsFilterTest.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/test/java/com/codenvy/api/permission/server/filter/RemovePermissionsFilterTest.java
@@ -16,7 +16,7 @@ package com.codenvy.api.permission.server.filter;
 
 import com.codenvy.api.permission.server.InstanceParameterValidator;
 import com.codenvy.api.permission.server.PermissionsService;
-import com.codenvy.api.permission.shared.dto.PermissionsDto;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 import com.jayway.restassured.response.Response;
 
 import org.eclipse.che.api.core.BadRequestException;
@@ -35,14 +35,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
-
 import static com.codenvy.api.permission.server.AbstractPermissionsDomain.SET_PERMISSIONS;
 import static com.jayway.restassured.RestAssured.given;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -64,9 +63,13 @@ public class RemovePermissionsFilterTest {
     private static Subject subject;
 
     @Mock
-    private PermissionsService         permissionsService;
+    private PermissionsService permissionsService;
+
     @Mock
     private InstanceParameterValidator instanceValidator;
+
+    @Mock
+    private SuperPrivilegesChecker superPrivilegesChecker;
 
     @InjectMocks
     private RemovePermissionsFilter permissionsFilter;
@@ -123,6 +126,22 @@ public class RemovePermissionsFilterTest {
         assertEquals(response.getStatusCode(), 204);
         verify(permissionsService).removePermissions(eq("test"), eq("test123"), eq("user123"));
         verify(instanceValidator).validate("test", "test123");
+    }
+
+    @Test
+    public void shouldDoChainIfUserDoesNotHavePermissionToSetPermissionsButHasSuperPrivileges() throws Exception {
+        when(superPrivilegesChecker.isPrivilegedToManagePermissions(anyString())).thenReturn(true);
+        when(subject.hasPermission("test", "test123", SET_PERMISSIONS)).thenReturn(false);
+
+        final Response response = given().auth()
+                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+                                         .contentType("application/json")
+                                         .when()
+                                         .delete(SECURE_PATH + "/permissions/test?instance=test123&user=user123");
+
+        assertEquals(response.getStatusCode(), 204);
+        verify(permissionsService).removePermissions(eq("test"), eq("test123"), eq("user123"));
+        verify(superPrivilegesChecker).isPrivilegedToManagePermissions("test");
     }
 
     private static String unwrapError(Response response) {

--- a/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/WorkspaceApiModule.java
+++ b/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/WorkspaceApiModule.java
@@ -16,12 +16,16 @@ package com.codenvy.api.workspace.server;
 
 import com.codenvy.api.machine.server.filters.RecipePermissionsFilter;
 import com.codenvy.api.machine.server.recipe.RecipeCreatorPermissionsProvider;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
+import com.codenvy.api.permission.shared.model.PermissionsDomain;
 import com.codenvy.api.workspace.server.filters.RecipeScriptDownloadPermissionFilter;
 import com.codenvy.api.workspace.server.filters.SetPublicPermissionsFilter;
 import com.codenvy.api.workspace.server.filters.StackPermissionsFilter;
 import com.codenvy.api.workspace.server.filters.WorkspacePermissionsFilter;
 import com.codenvy.api.workspace.server.stack.StackCreatorPermissionsProvider;
 import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 
 /**
  * @author Sergii Leschenko
@@ -38,5 +42,8 @@ public class WorkspaceApiModule extends AbstractModule {
         bind(WorkspaceCreatorPermissionsProvider.class).asEagerSingleton();
         bind(StackCreatorPermissionsProvider.class).asEagerSingleton();
         bind(RecipeCreatorPermissionsProvider.class).asEagerSingleton();
+
+        Multibinder.newSetBinder(binder(), PermissionsDomain.class, Names.named(SuperPrivilegesChecker.SUPER_PRIVILEGED_DOMAINS))
+                   .addBinding().to(WorkspaceDomain.class);
     }
 }

--- a/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/WorkspacePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/WorkspacePermissionsFilter.java
@@ -14,7 +14,7 @@
  */
 package com.codenvy.api.workspace.server.filters;
 
-import com.codenvy.api.permission.server.SystemDomain;
+import com.codenvy.api.permission.server.SuperPrivilegesChecker;
 import com.codenvy.organization.api.permissions.OrganizationDomain;
 import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
 
@@ -58,13 +58,17 @@ import static com.codenvy.organization.spi.impl.OrganizationImpl.ORGANIZATIONAL_
 @Filter
 @Path("/workspace{path:(/.*)?}")
 public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
-    private final WorkspaceManager workspaceManager;
-    private final AccountManager   accountManager;
+    private final WorkspaceManager       workspaceManager;
+    private final AccountManager         accountManager;
+    private final SuperPrivilegesChecker superPrivilegesChecker;
 
     @Inject
-    public WorkspacePermissionsFilter(WorkspaceManager workspaceManager, AccountManager accountManager) {
+    public WorkspacePermissionsFilter(WorkspaceManager workspaceManager,
+                                      AccountManager accountManager,
+                                      SuperPrivilegesChecker superPrivilegesChecker) {
         this.workspaceManager = workspaceManager;
         this.accountManager = accountManager;
+        this.superPrivilegesChecker = superPrivilegesChecker;
     }
 
     @Override
@@ -84,7 +88,7 @@ public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
                 return;
 
             case "getByNamespace": {
-                if (currentSubject.hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION)) {
+                if (superPrivilegesChecker.hasSuperPrivileges()) {
                     return;
                 }
                 checkManageNamespaceAccess(currentSubject, ((String)arguments[1]));
@@ -107,7 +111,7 @@ public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
                 break;
 
             case "stop":
-                if (currentSubject.hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION)) {
+                if (superPrivilegesChecker.hasSuperPrivileges()) {
                     return;
                 }
             case "startById":
@@ -122,7 +126,7 @@ public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
                 break;
 
             case "getByKey":
-                if (currentSubject.hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION)) {
+                if (superPrivilegesChecker.hasSuperPrivileges()) {
                     return;
                 }
             case "checkAgentHealth":

--- a/wsmaster/codenvy-hosted-api-workspace/src/test/java/com/codenvy/api/workspace/server/jpa/OnPremisesJpaWorkspaceDaoTest.java
+++ b/wsmaster/codenvy-hosted-api-workspace/src/test/java/com/codenvy/api/workspace/server/jpa/OnPremisesJpaWorkspaceDaoTest.java
@@ -14,9 +14,6 @@
  */
 package com.codenvy.api.workspace.server.jpa;
 
-import com.codenvy.api.machine.server.jpa.OnPremisesJpaMachineModule;
-import com.codenvy.api.permission.server.PermissionsModule;
-import com.codenvy.api.permission.server.jpa.SystemPermissionsJpaModule;
 import com.codenvy.api.workspace.server.model.impl.WorkerImpl;
 import com.codenvy.api.workspace.server.spi.jpa.OnPremisesJpaStackDao;
 import com.codenvy.api.workspace.server.spi.jpa.OnPremisesJpaWorkspaceDao;
@@ -72,9 +69,7 @@ public class OnPremisesJpaWorkspaceDaoTest {
                 new WorkspaceImpl("ws1", users[0].getAccount(), new WorkspaceConfigImpl("wrksp1", "", "cfg1", null, null, null)),
                 new WorkspaceImpl("ws2", users[0].getAccount(), new WorkspaceConfigImpl("wrksp2", "", "cfg2", null, null, null)),
                 new WorkspaceImpl("ws3", users[0].getAccount(), new WorkspaceConfigImpl("wrksp3", "", "cfg3", null, null, null))};
-        Injector injector =
-                Guice.createInjector(new TestModule(), new OnPremisesJpaMachineModule(), new PermissionsModule(),
-                                     new SystemPermissionsJpaModule());
+        Injector injector = Guice.createInjector(new TestModule());
         manager = injector.getInstance(EntityManager.class);
         dao = injector.getInstance(OnPremisesJpaWorkspaceDao.class);
     }

--- a/wsmaster/codenvy-sql-schema/src/main/resources/codenvy-schema/5.3.0/0.1__remove_manageorganizations_action.sql
+++ b/wsmaster/codenvy-sql-schema/src/main/resources/codenvy-schema/5.3.0/0.1__remove_manageorganizations_action.sql
@@ -1,0 +1,17 @@
+--
+--  [2012] - [2017] Codenvy, S.A.
+--  All Rights Reserved.
+--
+-- NOTICE:  All information contained herein is, and remains
+-- the property of Codenvy S.A. and its suppliers,
+-- if any.  The intellectual and technical concepts contained
+-- herein are proprietary to Codenvy S.A.
+-- and its suppliers and may be covered by U.S. and Foreign Patents,
+-- patents in process, and are protected by trade secret or copyright law.
+-- Dissemination of this information or reproduction of this material
+-- is strictly forbidden unless prior written permission is obtained
+-- from Codenvy S.A..
+--
+
+DELETE FROM systempermissions_actions
+WHERE actions='manageOrganizations';


### PR DESCRIPTION
### What does this PR do?
Adds configuration parameter `system.super_privileged_mode` that allow to extend default opportunities for users who have `manageSystem` permission.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1302

### Previous Behavior
Users who have `manageSystem` permission is able to perform following operations with workspaces: getByKey, getByNamespace, stop.

### New Behavior
If corresponding configuration parameter is `true` then users who have `manageSystem` can getByKey, getByNamespace, stop workspaces and getResourcesInformation, getByParent, getByUser organizations. If user needs to perform any other action with workspace or organization, he is able to add permissions there for himself.

### Tests written?
Yes

### Docs PR
Issue link [https://github.com/codenvy/codenvy-docs/issues/41](https://github.com/codenvy/codenvy-docs/issues/41). No PR yet.
