### PR TITLE
Adapt CHE-3581 - Enhance CLI to separate debugging from local repo mount

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -129,22 +129,34 @@ cmd_start_check_ports() {
   fi
 
   PORT_BREAK="no" 
-  text   "         port 80 (http):        $(port_open 80 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
-  text   "         port 443 (https):      $(port_open 443 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
-  text   "         port 2181 (zookeeper): $(port_open 2181 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
-  text   "         port 5000 (registry):  $(port_open 5000 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
-  text   "         port 23750 (socat):    $(port_open 23750 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
-  text   "         port 23751 (swarm):    $(port_open 23751 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
+  text   "         port 80 (http):        $(port_open 80 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 443 (https):      $(port_open 443 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 2181 (zookeeper): $(port_open 2181 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 5000 (registry):  $(port_open 5000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 23750 (socat):    $(port_open 23750 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 23751 (swarm):    $(port_open 23751 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   if debug_server; then
-    text   "         port ${CODENVY_DEBUG_PORT} (debug):     $(port_open ${CODENVY_DEBUG_PORT} && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
-    text   "         port 9000 (lighttpd):  $(port_open 9000 && echo "${GREEN}[AVAILABLE]${NC}" || $(echo "${RED}[ALREADY IN USE]${NC}"; PORT_BREAK="yes")) \n"
+    text   "         port ${CODENVY_DEBUG_PORT} (debug):     $(port_open ${CODENVY_DEBUG_PORT} && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+    text   "         port 9000 (lighttpd):  $(port_open 9000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   fi
 
-  if [[ "${PORT_BREAK}" = "yes" ]]; then
-    echo ""
-    error "Ports required to run $CHE_MINI_PRODUCT_NAME are used by another program."
-    return 2;
+  if ! $(port_open 80) || \
+     ! $(port_open 443) || \
+     ! $(port_open 2181) || \
+     ! $(port_open 5000) || \
+     ! $(port_open 23750) || \
+     ! $(port_open 23751); then
+     echo ""
+     error "Ports required to run $CHE_MINI_PRODUCT_NAME are used by another program."
+     return 2;
   fi
+  if debug_server; then
+    if ! $(port_open ${CODENVY_DEBUG_PORT}) || ! $(port_open 9000); then
+      echo ""
+      error "Ports required to run $CHE_MINI_PRODUCT_NAME are used by another program."
+      return 1;
+    fi
+  fi  
 }
 
 cmd_config_post_action() {

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -223,6 +223,7 @@ generate_configuration_with_puppet() {
 
   else
     CHE_REPO="off"
+    WRITE_PARAMETERS=""
   fi
 
   GENERATE_CONFIG_COMMAND="docker_run \

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -120,9 +120,11 @@ cmd_start_check_ports() {
     if [[ "$USER_DEBUG_PORT" = "" ]]; then
       # If the user has not set a debug port, then use the default
       CODENVY_DEBUG_PORT=8000
+      CHE_DEBUG_PORT=8000
     else 
       # Otherwise, this is the value set by the user
       CODENVY_DEBUG_PORT=$USER_DEBUG_PORT
+      CHE_DEBUG_PORT=$USER_DEBUG_PORT
     fi
   fi
 
@@ -267,6 +269,4 @@ generate_configuration_with_puppet() {
   log ${GENERATE_CONFIG_COMMAND}
   eval ${GENERATE_CONFIG_COMMAND}
 }
-
-
 

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -299,6 +299,8 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
   $codenvy_debug_port = getValue("CODENVY_DEBUG_PORT","8000")
 # codenvy debug suspend
   $codenvy_debug_suspend = getValue("CODENVY_DEBUG_SUSPEND","false")
+# use local repository flag on / off
+  $codenvy_repo = getValue("CHE_REPO","off")
 
 ###############################
 # Include base module

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -167,9 +167,11 @@ services:
     image: <%= ENV["IMAGE_AGENTS"] %>
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/lighttpd/lighttpd.conf:/etc/lighttpd/lighttpd.conf'
-<% if scope.lookupvar('compose::env') != 'production' -%>
+<% if scope.lookupvar('compose::codenvy_repo') == 'on' -%>
       - '<%= scope.lookupvar('compose::codenvy_development_ws_agent') -%>:/data/ws-agent.tar.gz'
       - '<%= scope.lookupvar('compose::codenvy_development_terminal_agent') -%>:/data/linux_amd64/terminal/websocket-terminal-linux_amd64.tar.gz'
+<% end -%>
+<% if scope.lookupvar('compose::env') != 'production' -%>
     ports:
       - '9000:9000'
 <% end -%>
@@ -204,7 +206,7 @@ services:
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/codenvy/che-machines/:/opt/codenvy-data/che-machines/'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/conf:/opt/codenvy-data/conf'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/conf/server.xml:/opt/codenvy-tomcat/conf/server.xml'
-<% if scope.lookupvar('codenvy::env') != 'production' -%>
+<% if scope.lookupvar('codenvy::codenvy_repo') == 'on' -%>
        - '<%= scope.lookupvar('compose::codenvy_development_tomcat') -%>:/opt/codenvy-tomcat'
 <% end -%>
     links:


### PR DESCRIPTION
### What does this PR do?
Adapts the Codenvy CLI to make use of debug_server() and local_repo(), so that users can now use local assemblies in production mode, and also debug embedded binaries in an existing Docker image.

Do not merge this until the Che changes have been merged.

https://github.com/eclipse/che/pull/3581

Also, adds in support for additional port checks for socat & swarm, along with simplifying the port check mechanism so that we avoid doing certain port checks twice.  This has improvements that would allow @riuvshin to close this PR:  https://github.com/codenvy/codenvy/pull/1471.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codenvy/codenvy/1458)
<!-- Reviewable:end -->
