### PR TITLE
expose codenvy jmx ports

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -135,6 +135,8 @@ cmd_start_check_ports() {
   text   "         port 5000 (registry):  $(port_open 5000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   text   "         port 23750 (socat):    $(port_open 23750 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   text   "         port 23751 (swarm):    $(port_open 23751 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 32001 (Codenvy JMX):    $(port_open 32001 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 32101 (Codenvy JMX):    $(port_open 32101 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   if debug_server; then
     text   "         port ${CODENVY_DEBUG_PORT} (debug):     $(port_open ${CODENVY_DEBUG_PORT} && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
     text   "         port 9000 (lighttpd):  $(port_open 9000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
@@ -145,7 +147,9 @@ cmd_start_check_ports() {
      ! $(port_open 2181) || \
      ! $(port_open 5000) || \
      ! $(port_open 23750) || \
-     ! $(port_open 23751); then
+     ! $(port_open 23751) || \
+     ! $(port_open 32001) || \
+     ! $(port_open 32101); then
      echo ""
      error "Ports required to run $CHE_MINI_PRODUCT_NAME are used by another program."
      return 2;

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -214,8 +214,10 @@ services:
     links:
       - 'postgres:codenvy-postgres'
       - 'swarm:codenvy-swarm'
-<% if scope.lookupvar('compose::env') != 'production' -%>
     ports:
+      - '32001:32001'
+      - '32101:32101'
+<% if scope.lookupvar('compose::env') != 'production' -%>
       - '8000:8000'
 <% end -%>
     ulimits:


### PR DESCRIPTION
we have to expose JMX ports for codenvy API to be able to connect and analyze JVM state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codenvy/codenvy/1484)
<!-- Reviewable:end -->
