### PR TITLE
Fix NPE when using getByNamespace to fetch runtimes

### DIFF
--- a/wsmaster/codenvy-hosted-api-audit/src/main/java/com/codenvy/api/audit/server/AuditManager.java
+++ b/wsmaster/codenvy-hosted-api-audit/src/main/java/com/codenvy/api/audit/server/AuditManager.java
@@ -213,12 +213,12 @@ public class AuditManager {
             for (UserImpl user : currentPage.getItems()) {
                 List<WorkspaceImpl> workspaces;
                 try {
-                    workspaces = workspaceManager.getWorkspaces(user.getId());
+                    workspaces = workspaceManager.getWorkspaces(user.getId(), false);
                     Set<String> workspaceIds = workspaces.stream()
                                                          .map(WorkspaceImpl::getId)
                                                          .collect(Collectors.toSet());
                     //add workspaces witch are belong to user, but user doesn't have permissions for them.
-                    workspaceManager.getByNamespace(user.getName())
+                    workspaceManager.getByNamespace(user.getName(), false)
                                     .stream()
                                     .filter(workspace -> !workspaceIds.contains(workspace.getId()))
                                     .forEach(workspaces::add);

--- a/wsmaster/codenvy-hosted-api-audit/src/test/java/com/codenvy/api/audit/server/AuditManagerTest.java
+++ b/wsmaster/codenvy-hosted-api-audit/src/test/java/com/codenvy/api/audit/server/AuditManagerTest.java
@@ -125,8 +125,8 @@ public class AuditManagerTest {
         when(workspace2.getId()).thenReturn("Workspace2Id");
         when(workspace1.getConfig()).thenReturn(ws1config);
         when(workspace2.getConfig()).thenReturn(ws2config);
-        when(workspaceManager.getWorkspaces("User1Id")).thenReturn(asList(workspace1, workspace2));
-        when(workspaceManager.getWorkspaces("User2Id")).thenReturn(singletonList(workspace2));
+        when(workspaceManager.getWorkspaces(eq("User1Id"), eq(false))).thenReturn(asList(workspace1, workspace2));
+        when(workspaceManager.getWorkspaces(eq("User2Id"), eq(false))).thenReturn(singletonList(workspace2));
         //Permissions
         AbstractPermissions ws1User1Permissions = mock(AbstractPermissions.class);
         AbstractPermissions ws2User1Permissions = mock(AbstractPermissions.class);
@@ -218,8 +218,8 @@ public class AuditManagerTest {
         workspaces.add(workspace2);
         when(workspace1.getNamespace()).thenReturn("User2");
         when(workspace2.getNamespace()).thenReturn("User2");
-        when(workspaceManager.getWorkspaces("User2Id")).thenReturn(workspaces);
-        when(workspaceManager.getByNamespace("User2")).thenReturn(asList(workspace1, workspace2));
+        when(workspaceManager.getWorkspaces(eq("User2Id"), eq(false))).thenReturn(workspaces);
+        when(workspaceManager.getByNamespace(eq("User2"), eq(false))).thenReturn(asList(workspace1, workspace2));
 
         when(ACCEPT_FAIR_SOURCE_LICENSE_ACTION.getAttributes()).thenReturn(Collections.singletonMap("email", "admin@codenvy.com"));
         when(ACCEPT_FAIR_SOURCE_LICENSE_ACTION.getActionTimestamp())
@@ -296,7 +296,7 @@ public class AuditManagerTest {
         when(systemLicenseActionHandler.findAction(PRODUCT_LICENSE, EXPIRED)).thenThrow(NotFoundException.class);
         when(systemLicenseActionHandler.findAction(PRODUCT_LICENSE, REMOVED)).thenThrow(NotFoundException.class);
 
-        when(workspaceManager.getWorkspaces(eq("User1Id"))).thenThrow(new ServerException("Failed to retrieve workspaces"));
+        when(workspaceManager.getWorkspaces(eq("User1Id"), eq(false))).thenThrow(new ServerException("Failed to retrieve workspaces"));
 
         //when
         auditReport = auditManager.generateAuditReport();

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTracker.java
@@ -52,7 +52,7 @@ public class RamResourceUsageTracker implements ResourceUsageTracker {
     public Optional<ResourceImpl> getUsedResource(String accountId) throws NotFoundException, ServerException {
         final Account account = accountManager.getById(accountId);
         final long currentlyUsedRamMB = workspaceManagerProvider.get()
-                                                                .getByNamespace(account.getName())
+                                                                .getByNamespace(account.getName(), true)
                                                                 .stream()
                                                                 .filter(ws -> STOPPED != ws.getStatus())
                                                                 .map(ws -> ws.getRuntime().getMachines())

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTracker.java
@@ -52,7 +52,7 @@ public class RuntimeResourceUsageTracker implements ResourceUsageTracker {
     public Optional<ResourceImpl> getUsedResource(String accountId) throws NotFoundException, ServerException {
         final Account account = accountManager.getById(accountId);
         final long currentlyUsedRuntimes = workspaceManagerProvider.get()
-                                                                   .getByNamespace(account.getName())
+                                                                   .getByNamespace(account.getName(), false)
                                                                    .stream()
                                                                    .filter(ws -> STOPPED != ws.getStatus())
                                                                    .count();

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTracker.java
@@ -50,7 +50,7 @@ public class WorkspaceResourceUsageTracker implements ResourceUsageTracker {
     @Override
     public Optional<ResourceImpl> getUsedResource(String accountId) throws NotFoundException, ServerException {
         final Account account = accountManager.getById(accountId);
-        final List<WorkspaceImpl> accountWorkspaces = workspaceManagerProvider.get().getByNamespace(account.getName());
+        final List<WorkspaceImpl> accountWorkspaces = workspaceManagerProvider.get().getByNamespace(account.getName(), false);
         if (!accountWorkspaces.isEmpty()) {
             return Optional.of(new ResourceImpl(WorkspaceResourceType.ID, accountWorkspaces.size(), WorkspaceResourceType.UNIT));
         } else {

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTrackerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTrackerTest.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -87,7 +88,7 @@ public class RamResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString()))
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean()))
                 .thenReturn(singletonList(createWorkspace(WorkspaceStatus.STOPPED, 1000, 500, 500)));
 
         Optional<ResourceImpl> usedRamOpt = ramUsageTracker.getUsedResource("account123");
@@ -100,7 +101,7 @@ public class RamResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString()))
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean()))
                 .thenReturn(singletonList(createWorkspace(WorkspaceStatus.RUNNING, 1000, 500, 500)));
 
         Optional<ResourceImpl> usedRamOpt = ramUsageTracker.getUsedResource("account123");
@@ -111,7 +112,7 @@ public class RamResourceUsageTrackerTest {
         assertEquals(usedRam.getAmount(), 2000L);
         assertEquals(usedRam.getUnit(), RamResourceType.UNIT);
         verify(accountManager).getById(eq("account123"));
-        verify(workspaceManager).getByNamespace(eq("testAccount"));
+        verify(workspaceManager).getByNamespace(eq("testAccount"), eq(true));
     }
 
     @Test
@@ -119,14 +120,14 @@ public class RamResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString()))
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean()))
                 .thenReturn(singletonList(createWorkspace(WorkspaceStatus.STOPPED, 1000, 500, 500)));
 
         Optional<ResourceImpl> usedRamOpt = ramUsageTracker.getUsedResource("account123");
 
         assertFalse(usedRamOpt.isPresent());
         verify(accountManager).getById(eq("account123"));
-        verify(workspaceManager).getByNamespace(eq("testAccount"));
+        verify(workspaceManager).getByNamespace(eq("testAccount"), eq(true));
     }
 
     /** Creates users workspace object based on the status and machines RAM. */

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTrackerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTrackerTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -82,7 +83,7 @@ public class RuntimeResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString())).thenReturn(singletonList(createWorkspace(WorkspaceStatus.STOPPED)));
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean())).thenReturn(singletonList(createWorkspace(WorkspaceStatus.STOPPED)));
 
         Optional<ResourceImpl> usedRuntimesOpt = runtimeResourceUsageTracker.getUsedResource("account123");
 
@@ -94,7 +95,7 @@ public class RuntimeResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString()))
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean()))
                 .thenReturn(Stream.of(WorkspaceStatus.values())
                                   .map(RuntimeResourceUsageTrackerTest::createWorkspace)
                                   .collect(Collectors.toList()));
@@ -107,7 +108,7 @@ public class RuntimeResourceUsageTrackerTest {
         assertEquals(usedRuntimes.getAmount(), WorkspaceStatus.values().length - 1); //except stopped workspaces
         assertEquals(usedRuntimes.getUnit(), RuntimeResourceType.UNIT);
         verify(accountManager).getById(eq("account123"));
-        verify(workspaceManager).getByNamespace(eq("testAccount"));
+        verify(workspaceManager).getByNamespace(eq("testAccount"), eq(false));
     }
 
     /** Creates users workspace object based on the status. */

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTrackerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTrackerTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -79,7 +80,7 @@ public class WorkspaceResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString())).thenReturn(Collections.emptyList());
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean())).thenReturn(Collections.emptyList());
 
         Optional<ResourceImpl> usedWorkspacesOpt = workspaceResourceUsageTracker.getUsedResource("account123");
 
@@ -91,7 +92,7 @@ public class WorkspaceResourceUsageTrackerTest {
         when(accountManager.getById(any())).thenReturn(account);
         when(account.getName()).thenReturn("testAccount");
 
-        when(workspaceManager.getByNamespace(anyString()))
+        when(workspaceManager.getByNamespace(anyString(), anyBoolean()))
                 .thenReturn(Arrays.asList(new WorkspaceImpl(), new WorkspaceImpl(), new WorkspaceImpl()));
 
         Optional<ResourceImpl> usedWorkspacesOpt = workspaceResourceUsageTracker.getUsedResource("account123");
@@ -102,6 +103,6 @@ public class WorkspaceResourceUsageTrackerTest {
         assertEquals(usedWorkspaces.getAmount(), 3);
         assertEquals(usedWorkspaces.getUnit(), WorkspaceResourceType.UNIT);
         verify(accountManager).getById(eq("account123"));
-        verify(workspaceManager).getByNamespace(eq("testAccount"));
+        verify(workspaceManager).getByNamespace(eq("testAccount"), eq(false));
     }
 }

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -222,7 +222,6 @@ public class LimitsCheckingWorkspaceManagerTest {
     public void shouldNotBeAbleToStartNewWorkspaceIfSystemRamLimitIsExceeded() throws Exception {
         when(systemRamInfoProvider.getSystemRamInfo()).thenReturn(new SystemRamInfo(parseSize("2.95 GiB"), parseSize("3 GiB")));
         final LimitsCheckingWorkspaceManager manager = managerBuilder().setSystemRamInfoProvider(systemRamInfoProvider).build();
-        doReturn(emptyList()).when(manager).getByNamespace(anyString());
 
         manager.checkSystemRamLimitAndPropagateStart(null);
     }
@@ -231,7 +230,6 @@ public class LimitsCheckingWorkspaceManagerTest {
     public void shouldCallStartCallbackIfEverythingIsOkayWithSystemRamLimits() throws Exception {
         final WorkspaceCallback callback = mock(WorkspaceCallback.class);
         final LimitsCheckingWorkspaceManager manager = managerBuilder().build();
-        doReturn(singletonList(createRuntime("1gb", "1gb"))).when(manager).getByNamespace(anyString());
 
         manager.checkSystemRamLimitAndPropagateStart(callback);
 
@@ -268,8 +266,6 @@ public class LimitsCheckingWorkspaceManagerTest {
         Semaphore semaphore = mock(Semaphore.class);
         WorkspaceCallback callback = mock(WorkspaceCallback.class);
         manager.startSemaphore = semaphore;
-        doReturn(singletonList(createRuntime("256mb", "256mb", null))).when(manager)
-                                                                      .getByNamespace(anyString());
 
         manager.checkSystemRamLimitAndPropagateLimitedThroughputStart(callback);
 
@@ -296,7 +292,6 @@ public class LimitsCheckingWorkspaceManagerTest {
         final LimitsCheckingWorkspaceManager manager = managerBuilder().setMaxSameTimeStartWSRequests(0)
                                                                        .build();
         WorkspaceCallback callback = mock(WorkspaceCallback.class);
-        doReturn(singletonList(createRuntime("256mb", "256mb", null))).when(manager).getByNamespace(anyString());
 
         manager.checkSystemRamLimitAndPropagateLimitedThroughputStart(callback);
 
@@ -307,8 +302,6 @@ public class LimitsCheckingWorkspaceManagerTest {
     public void shouldSetSemaphoreToNullIfThroughputPropertyIsLessThenZero() throws Exception {
         final LimitsCheckingWorkspaceManager manager = managerBuilder().setMaxSameTimeStartWSRequests(-1).build();
         WorkspaceCallback callback = mock(WorkspaceCallback.class);
-        doReturn(singletonList(createRuntime("256mb", "256mb", null))).when(manager)
-                                                                      .getByNamespace(anyString());
 
         manager.checkSystemRamLimitAndPropagateLimitedThroughputStart(callback);
 
@@ -318,7 +311,6 @@ public class LimitsCheckingWorkspaceManagerTest {
     @Test(timeOut = 3000)
     public void shouldPermitToCheckRamOnlyForFiveThreadsAtTheSameTime() throws Exception {
         final LimitsCheckingWorkspaceManager manager = managerBuilder().setMaxSameTimeStartWSRequests(5).build();
-        doReturn(singletonList(createRuntime("1gb", "1gb"))).when(manager).getByNamespace(anyString()); // <- currently running 2gb
         /*
           The count-down latch is needed to reach the throughput limit by acquiring RAM check permits.
           The lath is configured to 6 invocations: 5 (number of allowed same time requests) + 1 for main thread


### PR DESCRIPTION
### What does this PR do?
Fix NPE where runtimes were fetched by WorkspaceService#getByNamespace method.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1506

Then needs to revert https://github.com/eclipse/che/pull/3661 after merge