### PR TITLE
SAAS-101 : Allow cli inheritance without dockerfiles manifests 

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -231,12 +231,22 @@ generate_configuration_with_puppet() {
 
   if local_repo; then
     CHE_REPO="on"
-    WRITE_PARAMETERS="-v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/manifests\":/etc/puppet/manifests:ro \
-                      -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/modules\":/etc/puppet/modules:ro \
-                      -e \"PATH_TO_CHE_ASSEMBLY=${CHE_ASSEMBLY}\" \
-                      -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${WS_AGENT_ASSEMBLY}\" \
-                      -e \"PATH_TO_TERMINAL_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${TERMINAL_AGENT_ASSEMBLY}\""
+    WRITE_PARAMETERS=" -e \"PATH_TO_CHE_ASSEMBLY=${CHE_ASSEMBLY}\""
+    WRITE_PARAMETERS+=" -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${WS_AGENT_ASSEMBLY}\""
+    WRITE_PARAMETERS+=" -e \"PATH_TO_TERMINAL_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${TERMINAL_AGENT_ASSEMBLY}\""
 
+    # add local mounts only if they are present
+    if [[ -d "/repo/dockerfiles/init/manifests" ]]; then
+      WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/manifests\":/etc/puppet/manifests:ro"
+    fi
+    if [[ -d "/repo/dockerfiles/init/modules" ]]; then
+      WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/modules\":/etc/puppet/modules:ro"
+    fi
+
+    # Handle override/addon
+    if [[ -d "/repo/dockerfiles/init/addon/" ]]; then
+      WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/addon/addon.pp\":/etc/puppet/manifests/addon.pp:ro"
+    fi
   else
     CHE_REPO="off"
     WRITE_PARAMETERS=""
@@ -258,7 +268,7 @@ generate_configuration_with_puppet() {
                       $IMAGE_INIT \
                           apply --modulepath \
                                 /etc/puppet/modules/ \
-                                /etc/puppet/manifests/${CHE_MINI_PRODUCT_NAME}.pp --show_diff ${WRITE_LOGS}"
+                                /etc/puppet/manifests/ --show_diff ${WRITE_LOGS}"
 
   log ${GENERATE_CONFIG_COMMAND}
   eval ${GENERATE_CONFIG_COMMAND}


### PR DESCRIPTION
https://github.com/codenvy/customer-saas/issues/101
use of mounting init files only if they're present in the repository

Also, do not specify pp file but use directory puppet manifest mode instead
and if there are extra manifests addon, mount them in the manifests folder. It allows to adds extra settings

Change-Id: I2191624f1bb12ce243fdc46eeb8b33ee0c99e32f
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>
