### PR TITLE
Allow to update users while linking

### DIFF
--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/jpa/JpaSystemPermissionsDao.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/jpa/JpaSystemPermissionsDao.java
@@ -114,6 +114,16 @@ public class JpaSystemPermissionsDao extends AbstractJpaPermissionsDao<SystemPer
                               .getResultList();
     }
 
+    @Override
+    public void remove(String userId, String instanceId) throws ServerException, NotFoundException {
+        requireNonNull(userId, "User identifier required");
+        try {
+            doRemove(userId, instanceId);
+        } catch (RuntimeException x) {
+            throw new ServerException(x.getLocalizedMessage(), x);
+        }
+    }
+
     @Singleton
     public static class RemoveSystemPermissionsBeforeUserRemovedEventSubscriber
             extends CascadeEventSubscriber<BeforeUserRemovedEvent> {

--- a/wsmaster/codenvy-hosted-api-permission/src/test/java/com/codenvy/api/permission/server/spi/tck/SystemPermissionsDaoTest.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/test/java/com/codenvy/api/permission/server/spi/tck/SystemPermissionsDaoTest.java
@@ -97,6 +97,11 @@ public class SystemPermissionsDaoTest {
     }
 
     @Test
+    public void doesNotThrowNpeWhenInstanceIsNull() throws Exception {
+        dao.get(users[0].getId(), null);
+    }
+
+    @Test
     public void shouldBeAbleToGetPermissions() throws Exception {
         final SystemPermissionsImpl result1 = dao.get(systemPermissions[0].getUserId(), systemPermissions[0].getInstanceId());
         final SystemPermissionsImpl result2 = dao.get(systemPermissions[1].getUserId(), systemPermissions[1].getInstanceId());

--- a/wsmaster/codenvy-ldap/README.md
+++ b/wsmaster/codenvy-ldap/README.md
@@ -172,8 +172,8 @@ integer value, if it is set to _0_ then synchronization will be performed immedi
 on sever startup.
 
 - __ldap.sync.user_linking_attribute__ _(optional)_ - what attribute to use
-  for linking ldap users and database users. Possible value are: _id_, _email_.
-If this attribute is not configured _id_ will be used
+  for linking ldap users and database users. Possible value are: _id_, _email_, _name_.
+If this attribute is not configured _id_ is used
 
 - __ldap.sync.remove_if_missing__ - whether to remove those users who are present
  in LDAP cache but missing from LDAP storage

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/LdapModule.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/LdapModule.java
@@ -22,8 +22,8 @@ import com.codenvy.ldap.sync.LdapEntrySelector;
 import com.codenvy.ldap.sync.LdapEntrySelectorProvider;
 import com.codenvy.ldap.sync.LdapSynchronizer;
 import com.codenvy.ldap.sync.LdapSynchronizerService;
-import com.codenvy.ldap.sync.DBUserFinder;
-import com.codenvy.ldap.sync.DBUserFinderProvider;
+import com.codenvy.ldap.sync.DBUserLinker;
+import com.codenvy.ldap.sync.DBUserLinkerProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 
@@ -52,7 +52,7 @@ public class LdapModule extends AbstractModule {
 
         bind(EntryResolver.class).toProvider(EntryResolverProvider.class);
 
-        bind(DBUserFinder.class).toProvider(DBUserFinderProvider.class);
+        bind(DBUserLinker.class).toProvider(DBUserLinkerProvider.class);
         bind(LdapEntrySelector.class).toProvider(LdapEntrySelectorProvider.class);
         bind(LdapSynchronizer.class).asEagerSingleton();
         bind(LdapSynchronizerService.class);

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserLinker.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserLinker.java
@@ -23,26 +23,31 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Retrieves user from persistence layer.
+ * Links db users with ldap users by either id, email or name.
  *
  * @author Yevhenii Voevodin
  */
-public abstract class DBUserFinder {
+public abstract class DBUserLinker {
 
     /** Creates a new user finder based on his identifier. */
-    public static DBUserFinder newIdFinder(UserDao userDao, DBHelper dbHelper) {
-        return new ByIdUserFinder(userDao, dbHelper);
+    public static DBUserLinker newIdLinker(UserDao userDao, DBHelper dbHelper) {
+        return new IdLinker(userDao, dbHelper);
     }
 
     /** Creates a new user finder based on his email. */
-    public static DBUserFinder newEmailFinder(UserDao userDao, DBHelper dbHelper) {
-        return new ByEmailUserFinder(userDao, dbHelper);
+    public static DBUserLinker newEmailLinker(UserDao userDao, DBHelper dbHelper) {
+        return new EmailLinker(userDao, dbHelper);
+    }
+
+    /** Creates a new user finder based on his name. */
+    public static DBUserLinker newNameLinker(UserDao userDao, DBHelper dbHelper) {
+        return new NameLinker(userDao, dbHelper);
     }
 
     protected final UserDao  userDao;
     protected final DBHelper dbHelper;
 
-    protected DBUserFinder(UserDao userDao, DBHelper dbHelper) {
+    protected DBUserLinker(UserDao userDao, DBHelper dbHelper) {
         this.userDao = userDao;
         this.dbHelper = dbHelper;
     }
@@ -54,69 +59,93 @@ public abstract class DBUserFinder {
      *         user retrieved from ldap
      * @return an identifier
      */
-    public abstract String extractLinkingId(User ldapUser);
+    public abstract String extractId(User ldapUser);
 
     /**
      * Finds user in persistence layer by specified identifier.
      *
      * @param linkingAttribute
-     *         the value returned from {@link #extractLinkingId(User)}
+     *         the value returned from {@link #extractId(User)}
      * @return user from persistence layer
      * @throws NotFoundException
      *         when there is no such user
      * @throws ServerException
      *         when any other error occurs
      */
-    public abstract User findOne(String linkingAttribute) throws NotFoundException, ServerException;
+    public abstract User findUser(String linkingAttribute) throws NotFoundException, ServerException;
 
     /** Returns linking attribute values for those users who exist in persistence layer. */
-    public abstract Set<String> findLinkingIds();
+    public abstract Set<String> findIds();
 
     /** Retrieves user by his id. */
-    private static class ByIdUserFinder extends DBUserFinder {
+    private static class IdLinker extends DBUserLinker {
 
-        private ByIdUserFinder(UserDao userDao, DBHelper dbHelper) {
+        private IdLinker(UserDao userDao, DBHelper dbHelper) {
             super(userDao, dbHelper);
         }
 
         @Override
-        public String extractLinkingId(User ldapUser) {
+        public String extractId(User ldapUser) {
             return ldapUser.getId();
         }
 
         @Override
-        public User findOne(String id) throws NotFoundException, ServerException {
+        public User findUser(String id) throws NotFoundException, ServerException {
             return userDao.getById(id);
         }
 
         @Override
         @SuppressWarnings("unchecked") // user id is always string
-        public Set<String> findLinkingIds() {
+        public Set<String> findIds() {
             return new HashSet<>(dbHelper.executeNativeQuery("SELECT id FROM Usr"));
         }
     }
 
     /** Retrieves user by his email. */
-    private static class ByEmailUserFinder extends DBUserFinder {
+    private static class EmailLinker extends DBUserLinker {
 
-        protected ByEmailUserFinder(UserDao userDao, DBHelper dbHelper) {
+        protected EmailLinker(UserDao userDao, DBHelper dbHelper) {
             super(userDao, dbHelper);
         }
 
         @Override
-        public String extractLinkingId(User ldapUser) {
+        public String extractId(User ldapUser) {
             return ldapUser.getEmail();
         }
 
         @Override
-        public User findOne(String email) throws NotFoundException, ServerException {
+        public User findUser(String email) throws NotFoundException, ServerException {
             return userDao.getByEmail(email);
         }
 
         @Override
         @SuppressWarnings("unchecked") // user email is always string
-        public Set<String> findLinkingIds() {
+        public Set<String> findIds() {
             return new HashSet<>(dbHelper.executeNativeQuery("SELECT email FROM Usr"));
+        }
+    }
+
+    /** Links & retrieves user by his name. */
+    private static class NameLinker extends DBUserLinker {
+
+        protected NameLinker(UserDao userDao, DBHelper dbHelper) {
+            super(userDao, dbHelper);
+        }
+
+        @Override
+        public String extractId(User ldapUser) {
+            return ldapUser.getName();
+        }
+
+        @Override
+        public User findUser(String name) throws NotFoundException, ServerException {
+            return userDao.getByName(name);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked") // user name is always string
+        public Set<String> findIds() {
+            return new HashSet<>(dbHelper.executeNativeQuery("SELECT name FROM Usr"));
         }
     }
 }

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserLinkerProvider.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/DBUserLinkerProvider.java
@@ -21,11 +21,11 @@ import javax.inject.Named;
 import javax.inject.Provider;
 
 /**
- * Provides {@link DBUserFinder} instances based on configuration.
+ * Provides {@link DBUserLinker} instances based on configuration.
  *
  * @author Yevhenii Voevodin
  */
-public class DBUserFinderProvider implements Provider<DBUserFinder> {
+public class DBUserLinkerProvider implements Provider<DBUserLinker> {
 
     @Inject
     private UserDao userDao;
@@ -38,13 +38,17 @@ public class DBUserFinderProvider implements Provider<DBUserFinder> {
     private String linkAttr;
 
     @Override
-    public DBUserFinder get() {
+    public DBUserLinker get() {
         if (linkAttr == null || linkAttr.equals("id")) {
-            return DBUserFinder.newIdFinder(userDao, dbHelper);
+            return DBUserLinker.newIdLinker(userDao, dbHelper);
         }
         if (linkAttr.equals("email")) {
-            return DBUserFinder.newEmailFinder(userDao, dbHelper);
+            return DBUserLinker.newEmailLinker(userDao, dbHelper);
         }
-        throw new IllegalStateException("Supported values for the property 'ldap.sync.user_linking_attribute' are 'id' or 'email'");
+        if (linkAttr.equals("name")) {
+            return DBUserLinker.newNameLinker(userDao, dbHelper);
+        }
+        throw new IllegalStateException("Supported values for the property 'ldap.sync.user_linking_attribute' " +
+                                        "are 'id', 'email' or 'name");
     }
 }

--- a/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizationFlowTest.java
+++ b/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizationFlowTest.java
@@ -97,6 +97,7 @@ public class LdapSynchronizationFlowTest {
         assertEquals(syncResult.getUpdated(), 0);
         assertEquals(syncResult.getRemoved(), 0);
         assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getFetched(), 3);
         assertEquals(userDao.getTotalCount(), 3);
         assertEquals(userDao.getAll(3, 0).fill(new HashSet<>()), new HashSet<>(asList(user1, user2, user3)));
 
@@ -110,6 +111,7 @@ public class LdapSynchronizationFlowTest {
         assertEquals(syncResult.getUpdated(), 0);
         assertEquals(syncResult.getRemoved(), 0);
         assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getFetched(), 4);
         assertEquals(user4, userDao.getById(user4.getId()));
 
         // remove user from ldap
@@ -122,6 +124,7 @@ public class LdapSynchronizationFlowTest {
         assertEquals(syncResult.getUpdated(), 0);
         assertEquals(syncResult.getRemoved(), 1);
         assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getFetched(), 3);
         assertEquals(userDao.getAll(3, 0).fill(new HashSet<>()), new HashSet<>(asList(user2, user3, user4)));
 
         // modify ldap user
@@ -134,6 +137,7 @@ public class LdapSynchronizationFlowTest {
         assertEquals(syncResult.getUpdated(), 1);
         assertEquals(syncResult.getRemoved(), 0);
         assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getFetched(), 3);
 
         // cleanup ldap user entries
         server.removeDefaultUser(user2.getId());
@@ -163,6 +167,7 @@ public class LdapSynchronizationFlowTest {
         assertEquals(syncResult.getUpToDate(), 1);
         assertEquals(syncResult.getRemoved(), 1);
         assertEquals(syncResult.getFailed(), 1);
+        assertEquals(syncResult.getFetched(), 2);
 
         // sync second time, and check that failed synchronization is resolved
         syncResult = synchronizer.syncAll();
@@ -171,6 +176,7 @@ public class LdapSynchronizationFlowTest {
         assertEquals(syncResult.getUpdated(), 1);
         assertEquals(syncResult.getRemoved(), 0);
         assertEquals(syncResult.getFailed(), 0);
+        assertEquals(syncResult.getFetched(), 2);
         assertEquals(userDao.getAll(2, 0).fill(new HashSet<>()), new HashSet<>(asList(user2, user3)));
 
 
@@ -210,7 +216,7 @@ public class LdapSynchronizationFlowTest {
 
             // configure synchronizer
             bind(LdapEntrySelector.class).toProvider(LdapEntrySelectorProvider.class);
-            bind(DBUserFinder.class).toProvider(DBUserFinderProvider.class);
+            bind(DBUserLinker.class).toProvider(DBUserLinkerProvider.class);
             bind(ConnectionFactory.class).toInstance(server.getConnectionFactory());
             bindConstant().annotatedWith(Names.named("ldap.sync.initial_delay_ms")).to(0L);
             bindConstant().annotatedWith(Names.named("ldap.sync.period_ms")).to(-1L);


### PR DESCRIPTION
Allows to update users while linking attribute is different from 'id'.
FIxes NPE when LDAP synchronization is on and default admin user is removed.
Introduces a few new updates:
- `LOG.debug` the entities which are going to be synchronized 
- Added `SyncResult.fetched` field which shows how many users were fetched from ldap
- Added an ability to link users by their names