### PR TITLE
Make single docker image layer when adding tomcat

### DIFF
--- a/assembly/onpremises-ide-packaging-tomcat-codenvy-allinone/src/assembly/assembly.xml
+++ b/assembly/onpremises-ide-packaging-tomcat-codenvy-allinone/src/assembly/assembly.xml
@@ -18,7 +18,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <id>tomcat-zip</id>
     <formats>
-        <format>dir</format>
+        <format>tar.gz</format>
         <format>zip</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>

--- a/dockerfiles/codenvy/Dockerfile
+++ b/dockerfiles/codenvy/Dockerfile
@@ -95,5 +95,4 @@ CMD [ "postfix", "-c", "/etc/postfix", "start" ]
 COPY dockerfiles/codenvy/entrypoint.sh /
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-ADD assembly/onpremises-ide-packaging-tomcat-codenvy-allinone/target/onpremises-ide-packaging-tomcat-codenvy-allinone-*.zip /
-RUN unzip -q onpremises-ide-packaging-tomcat-codenvy-allinone-*.zip -d /opt/codenvy-tomcat && rm onpremises-ide-packaging-tomcat-codenvy-allinone-*.zip
+ADD assembly/onpremises-ide-packaging-tomcat-codenvy-allinone/target/onpremises-ide-packaging-tomcat-codenvy-allinone-*.tar.gz /opt/codenvy-tomcat


### PR DESCRIPTION
Reduce image size from 552Mb to 355Mb.
Instead of copy zip file with one command and extract archive in next I've used tar.gz archive in combination with docker ADD command. 