### PR TITLE
Fix compose containers ordering issue.

### DIFF
--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -195,6 +195,7 @@ services:
       - postgres
       - agents
       - swarm
+      - registry
     env_file:
 <% if @compose_file_for_containers == true -%>
       - '<%= ENV["CHE_CONTAINER_ROOT"] %>/instance/config/codenvy/codenvy.env'

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -106,6 +106,7 @@ services:
     restart: always
     depends_on:
       - rsyslog
+      - zookeeper
     logging:
       driver: syslog
       options:
@@ -193,6 +194,7 @@ services:
       - haproxy
       - postgres
       - agents
+      - swarm
     env_file:
 <% if @compose_file_for_containers == true -%>
       - '<%= ENV["CHE_CONTAINER_ROOT"] %>/instance/config/codenvy/codenvy.env'


### PR DESCRIPTION
this is partial solution for https://github.com/codenvy/codenvy/issues/1554

stopping oder before fix

```
Stopping codenvy_registry_1 ... done
Stopping codenvy_zookeeper_1 ... done
Stopping codenvy_codenvy_1 ... done
Stopping codenvy_swarm_1 ... done
Stopping codenvy_haproxy_1 ... done
Stopping codenvy_postgres_1 ... done
Stopping codenvy_socat_1 ... done
Stopping codenvy_rsyslog_1 ... done
Stopping codenvy_nginx_1 ... done
Stopping codenvy_agents_1 ... done
```

stopping order after fix

```
Stopping codenvy_registry_1 ... done
Stopping codenvy_codenvy_1 ... done
Stopping codenvy_swarm_1 ... done
Stopping codenvy_haproxy_1 ... done
Stopping codenvy_postgres_1 ... done
Stopping codenvy_socat_1 ... done
Stopping codenvy_agents_1 ... done
Stopping codenvy_zookeeper_1 ... done
Stopping codenvy_nginx_1 ... done
Stopping codenvy_rsyslog_1 ... done
```

as we can see after fix zookeeper stopped afte codenvy and swarm.