### PR TITLE
[cli] Fix #1564 : Invalid name for sync command

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -22,7 +22,7 @@ cli_parse () {
   COMMAND="cmd_$1"
 
   case $1 in
-      init|config|start|stop|restart|backup|restore|info|offline|add-node|list-nodes|remove-node|destroy|download|rmi|upgrade|version|ssh|mount|action|test|compile|help)
+      init|config|start|stop|restart|backup|restore|info|offline|add-node|list-nodes|remove-node|destroy|download|rmi|upgrade|version|ssh|sync|action|test|compile|dir|help)
       ;;
       *)
          error "You passed an unknown command."


### PR DESCRIPTION
### What does this PR do?
Fix #1564 : Invalid name for sync command

### What issues does this PR fix or reference?
 #1564

### Previous Behavior
It was still "mount" while command has been renamed to "sync"

### New Behavior
Use correct "sync" command

### Tests written?
No

### Docs requirements?
no (bugfix)

Change-Id: I5c0cafcf358db2a753a8b0a675ae58b4a2f69358
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>




