### PR TITLE
CLI - Adapt to Che CLI changes for custom assembly, faster port check

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -7,7 +7,7 @@
 #
 
 cli_pre_init() {
-  GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host eclipse/che-ip:nightly)}
+  GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host ${UTILITY_IMAGE_CHEIP})}
   DEFAULT_CODENVY_HOST=$GLOBAL_HOST_IP
   CODENVY_HOST=${CODENVY_HOST:-${DEFAULT_CODENVY_HOST}}
   CODENVY_PORT=80

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -229,9 +229,12 @@ generate_configuration_with_puppet() {
     WRITE_LOGS=">> \"${LOGS}\""
   fi
 
-  if local_repo; then
+  if local_repo || local_assembly; then
     CHE_REPO="on"
     WRITE_PARAMETERS=" -e \"PATH_TO_CHE_ASSEMBLY=${CHE_ASSEMBLY}\""
+  fi
+
+  if local_repo; then
     WRITE_PARAMETERS+=" -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${WS_AGENT_ASSEMBLY}\""
     WRITE_PARAMETERS+=" -e \"PATH_TO_TERMINAL_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${TERMINAL_AGENT_ASSEMBLY}\""
 
@@ -247,9 +250,6 @@ generate_configuration_with_puppet() {
     if [[ -d "/repo/dockerfiles/init/addon/" ]]; then
       WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/addon/addon.pp\":/etc/puppet/manifests/addon.pp:ro"
     fi
-  else
-    CHE_REPO="off"
-    WRITE_PARAMETERS=""
   fi
 
   GENERATE_CONFIG_COMMAND="docker_run \

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -41,6 +41,7 @@ OPTIONAL DOCKER PARAMETERS:
   -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}/backup         Where backup files will be saved
   -v <LOCAL_PATH>:/cli                 Where the CLI trace log is saved
   -v <LOCAL_PATH>:/repo                ${CHE_FORMAL_PRODUCT_NAME} git repo to activate dev mode
+  -v <LOCAL_PATH>:/assembly            ${CHE_FORMAL_PRODUCT_NAME} local assembly (for development)
   -v <LOCAL_PATH>:/sync                Where remote ws files will be copied with sync command
   -v <LOCAL_PATH>:/unison              Where unison profile for optimzing sync command resides
     


### PR DESCRIPTION
### What does this PR do?
1. Adds in ability to mount `:/assembly` so that it mounts a Tomcat binary directly without mounting the entire repository.
2. Adds in a refactoring of the preflight checks to test all ports at the same time.  This makes overall performance faster.  If any of the ports fail, then we iterate through each port check one at a time.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1550

### Changelog
Adapt to Eclipse Che #1550 - adds `:/assembly` volume mount

### Release Notes
N/A

### Docs PR
N/A