### PR TITLE
CODENVY-1495: make codenvy work on OSX without network alias on host

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -252,6 +252,12 @@ generate_configuration_with_puppet() {
     WRITE_PARAMETERS=""
   fi
 
+  if is_docker_for_windows || is_docker_for_mac; then
+    local HOST_IS_MAC_OR_WINDOWS=true
+  else
+    local HOST_IS_MAC_OR_WINDOWS=false
+  fi
+
   GENERATE_CONFIG_COMMAND="docker_run \
                   --env-file=\"${REFERENCE_CONTAINER_ENVIRONMENT_FILE}\" \
                   --env-file=/version/$CHE_VERSION/images \
@@ -264,6 +270,7 @@ generate_configuration_with_puppet() {
                   -e \"CHE_CONFIG=${CHE_HOST_INSTANCE}\" \
                   -e \"CHE_INSTANCE=${CHE_HOST_INSTANCE}\" \
                   -e \"CHE_REPO=${CHE_REPO}\" \
+                  -e \"HOST_IS_MAC_OR_WINDOWS=${HOST_IS_MAC_OR_WINDOWS}\"
                   --entrypoint=/usr/bin/puppet \
                       $IMAGE_INIT \
                           apply --modulepath \

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -12,6 +12,8 @@ node default {
 #    DNS entry provided by the provider.
   $host_url = getValue("CODENVY_HOST","codenvy.onprem")
 
+  $host_is_mac_or_windows = getValue("HOST_IS_MAC_OR_WINDOWS","false")
+
 ###############################
 # Docker IP adress on host
   $docker_ip = getValue("CODENVY_DOCKER_IP","172.17.0.1")

--- a/dockerfiles/init/modules/codenvy/templates/machine.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/machine.properties.erb
@@ -63,10 +63,16 @@ che.docker.tcp_connection_read_timeout_ms=600000
 che.docker.always_pull_image=true
 che.docker.api=1.20
 
-# https support
-machine.proxy_wsagent_server_url_template=<%= scope.lookupvar('codenvy::host_protocol') %>://<%= scope.lookupvar('codenvy::host_url') %>/%3$s_%2$s/%4$s
-machine.proxy_terminal_server_url_template=<%= scope.lookupvar('codenvy::host_protocol') %>://<%= scope.lookupvar('codenvy::host_url') %>/%3$s_%2$s/%4$s
-
+# Handle https and port mapping by adding proxy on wsagent and terminal endpoints.
+# string format arguments available are:
+# %1 - Server reference
+# %2 - Server location hostname
+# %3 - Server location external port
+# %4 - Server path (without leading slash if present)
+machine.proxy_wsagent_server_external_url_template=<%= scope.lookupvar('codenvy::host_protocol') %>://<% if scope.lookupvar('codenvy::host_is_mac_or_windows') == "true" %>localhost<% else -%><%= scope.lookupvar('codenvy::host_url') %><% end -%>/%3$s_%2$s/%4$s
+machine.proxy_wsagent_server_internal_url_template=<%= scope.lookupvar('codenvy::host_protocol') %>://<%= scope.lookupvar('codenvy::host_url') %>/%3$s_%2$s/%4$s
+machine.proxy_terminal_server_external_url_template=<%= scope.lookupvar('codenvy::host_protocol') %>://<% if scope.lookupvar('codenvy::host_is_mac_or_windows') == "true" %>localhost<% else -%><%= scope.lookupvar('codenvy::host_url') %><% end -%>/%3$s_%2$s/%4$s
+machine.proxy_terminal_server_internal_url_template=<%= scope.lookupvar('codenvy::host_protocol') %>://<%= scope.lookupvar('codenvy::host_url') %>/%3$s_%2$s/%4$s
 
 # If true, then all docker machines will start in privilege mode.
 che.docker.privileged=<%= scope.lookupvar('codenvy::machine_docker_privileged') %>

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/TerminalServerProxyTransformer.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/TerminalServerProxyTransformer.java
@@ -24,7 +24,8 @@ import javax.inject.Named;
  */
 public class TerminalServerProxyTransformer extends UriTemplateServerProxyTransformer {
     @Inject
-    public TerminalServerProxyTransformer(@Named("machine.proxy_terminal_server_url_template") String serverUrlTemplate) {
-        super(serverUrlTemplate);
+    public TerminalServerProxyTransformer(@Named("machine.proxy_terminal_server_external_url_template") String serverExternalUrlTemplate,
+                                          @Named("machine.proxy_terminal_server_internal_url_template") String serverInternalUrlTemplate) {
+        super(serverExternalUrlTemplate, serverInternalUrlTemplate);
     }
 }

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/WsAgentServerProxyTransformer.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/WsAgentServerProxyTransformer.java
@@ -24,7 +24,8 @@ import javax.inject.Named;
  */
 public class WsAgentServerProxyTransformer extends UriTemplateServerProxyTransformer {
     @Inject
-    public WsAgentServerProxyTransformer(@Named("machine.proxy_wsagent_server_url_template") String serverUrlTemplate) {
-        super(serverUrlTemplate);
+    public WsAgentServerProxyTransformer(@Named("machine.proxy_wsagent_server_external_url_template") String serverExternalUrlTemplate,
+                                         @Named("machine.proxy_wsagent_server_internal_url_template") String serverInternalUrlTemplate) {
+        super(serverExternalUrlTemplate, serverInternalUrlTemplate);
     }
 }

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedServersInstanceRuntimeInfoTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedServersInstanceRuntimeInfoTest.java
@@ -72,7 +72,8 @@ public class HostedServersInstanceRuntimeInfoTest {
                 prepareHostedServersInstanceRuntimeInfo(originServers,
                                                         singletonMap("otherreference",
                                                                      new UriTemplateServerProxyTransformer(
-                                                                             "http://host:9090/path") {}));
+                                                                             "http://host:9090/path",
+                                                                             "http://host2:9090/path") {}));
 
         Map<String, ServerImpl> modifiedServers = runtimeInfo.getServers();
 
@@ -105,13 +106,14 @@ public class HostedServersInstanceRuntimeInfoTest {
                                                        "host:9090",
                                                        "http://host:9090/path",
                                                        new ServerPropertiesImpl("/path",
-                                                                                "host:9090",
-                                                                                "http://host:9090/path")));
+                                                                                "host2:9090",
+                                                                                "http://host2:9090/path")));
 
         HostedServersInstanceRuntimeInfo runtimeInfo =
                 prepareHostedServersInstanceRuntimeInfo(originServers,
                                                         singletonMap("ref2", new UriTemplateServerProxyTransformer(
-                                                                "http://host:9090/path") {}));
+                                                                "http://host:9090/path",
+                                                                "http://host2:9090/path") {}));
 
         Map<String, ServerImpl> modifiedServers = runtimeInfo.getServers();
 

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/UriTemplateServerProxyTransformerTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/UriTemplateServerProxyTransformerTest.java
@@ -28,7 +28,8 @@ public class UriTemplateServerProxyTransformerTest {
 
     @Test
     public void shouldBeAbleToNotChangeServer() throws Exception {
-        serverModifier = new UriTemplateServerProxyTransformer("http://%2$s:%3$s/%4$s") {};
+        serverModifier = new UriTemplateServerProxyTransformer("http://%2$s:%3$s/%4$s",
+                                                               "https://%2$s.ua:%3$s/%4$s/1") {};
         ServerImpl originServer = new ServerImpl("myRef",
                                                  "http",
                                                  "my-server.com:32589",
@@ -42,8 +43,8 @@ public class UriTemplateServerProxyTransformerTest {
                                                    "http://my-server.com:32589/some/path",
                                                    new ServerPropertiesImpl(
                                                            '/' + originServer.getProperties().getPath(),
-                                                           originServer.getAddress(),
-                                                           "http://my-server.com:32589/some/path"));
+                                                           "my-server.com.ua:32589",
+                                                           "https://my-server.com.ua:32589/some/path/1"));
 
         ServerImpl modifiedServer = serverModifier.transform(originServer);
 
@@ -52,7 +53,8 @@ public class UriTemplateServerProxyTransformerTest {
 
     @Test
     public void shouldRemoveLeadingSlashFromArgumentServerPath() throws Exception {
-        serverModifier = new UriTemplateServerProxyTransformer("http://%2$s:%3$s/%4$s") {};
+        serverModifier = new UriTemplateServerProxyTransformer("http://%2$s:%3$s/%4$s",
+                                                               "https://%2$s.ca:%3$s/%4$s") {};
         ServerImpl originServer = new ServerImpl("myRef",
                                                  "http",
                                                  "my-server.com:32589",
@@ -61,14 +63,23 @@ public class UriTemplateServerProxyTransformerTest {
                                                                           "my-server.com:32589",
                                                                           "http://my-server.com:32589/some/path"));
 
+        ServerImpl expectedServer = new ServerImpl("myRef",
+                                                   "http",
+                                                   "my-server.com:32589",
+                                                   "http://my-server.com:32589/some/path",
+                                                   new ServerPropertiesImpl("/some/path",
+                                                                            "my-server.com.ca:32589",
+                                                                            "https://my-server.com.ca:32589/some/path"));
+
         ServerImpl modifiedServer = serverModifier.transform(originServer);
 
-        assertEquals(modifiedServer.getUrl(), originServer.getUrl());
+        assertEquals(modifiedServer, expectedServer);
     }
 
     @Test
-    public void shouldReturnUnchangedServerIfCreatedUriIsInvalid() throws Exception {
-        serverModifier = new UriTemplateServerProxyTransformer(":::://:%3$s`%4$s") {};
+    public void shouldReturnUnchangedServerIfCreatedExternalUriIsInvalid() throws Exception {
+        serverModifier = new UriTemplateServerProxyTransformer(":::://:%3$s`%4$s",
+                                                               "https://%2$s.fr:%3$s/%4$s") {};
         ServerImpl originServer = new ServerImpl("myRef",
                                                  "http",
                                                  "my-server.com:32589",
@@ -83,8 +94,26 @@ public class UriTemplateServerProxyTransformerTest {
     }
 
     @Test
-    public void shouldNotAdd80PortToUrl() throws Exception {
-        serverModifier = new UriTemplateServerProxyTransformer("http://transform-host/%4$s") {};
+    public void shouldReturnUnchangedServerIfCreatedInternalUriIsInvalid() throws Exception {
+        serverModifier = new UriTemplateServerProxyTransformer("https://%2$s.fr:%3$s/%4$s",
+                                                               ":::://:%3$s`%4$s") {};
+        ServerImpl originServer = new ServerImpl("myRef",
+                                                 "http",
+                                                 "my-server.com:32589",
+                                                 "http://my-server.com:32589/some/path",
+                                                 new ServerPropertiesImpl("/some/path",
+                                                                          "my-server.com:32589",
+                                                                          "http://my-server.com:32589/some/path"));
+
+        ServerImpl modifiedServer = serverModifier.transform(originServer);
+
+        assertEquals(modifiedServer, originServer);
+    }
+
+    @Test
+    public void shouldNotAdd80PortToExternalUrl() throws Exception {
+        serverModifier = new UriTemplateServerProxyTransformer("http://transform-host/%4$s",
+                                                               "http://%2$s:%3$s/%4$s") {};
         ServerImpl originServer = new ServerImpl("myRef",
                                                  "http",
                                                  "my-server.com:32589",
@@ -99,8 +128,26 @@ public class UriTemplateServerProxyTransformerTest {
     }
 
     @Test
-    public void shouldBeAbleToChangeServerAttributes() throws Exception {
-        serverModifier = new UriTemplateServerProxyTransformer("https://%3$s-%2$s.transform-host:444/%1$s/%4$s") {};
+    public void shouldNotAdd80PortToInternalUrl() throws Exception {
+        serverModifier = new UriTemplateServerProxyTransformer("http://%2$s:%3$s/%4$s",
+                                                               "http://transform-host/%4$s") {};
+        ServerImpl originServer = new ServerImpl("myRef",
+                                                 "http",
+                                                 "my-server.com:32589",
+                                                 "http://my-server.com:32589/some/path",
+                                                 new ServerPropertiesImpl("/some/path",
+                                                                          "my-server.com:32589",
+                                                                          "http://my-server.com:32589/some/path"));
+
+        ServerImpl modifiedServer = serverModifier.transform(originServer);
+
+        assertEquals(modifiedServer.getProperties().getInternalUrl(), "http://transform-host/some/path");
+    }
+
+    @Test
+    public void shouldBeAbleToChangeExternalUrl() throws Exception {
+        serverModifier = new UriTemplateServerProxyTransformer("https://%3$s-%2$s.transform-host:444/%1$s/%4$s",
+                                                               "http://%2$s:%3$s/%4$s") {};
         ServerImpl originServer = new ServerImpl("myRef",
                                                  "http",
                                                  "my-server.com:32589",
@@ -113,6 +160,30 @@ public class UriTemplateServerProxyTransformerTest {
                                                    "32589-my-server.com.transform-host:444",
                                                    "https://32589-my-server.com.transform-host:444/myRef/some/path",
                                                    new ServerPropertiesImpl("/myRef/some/path",
+                                                                            "my-server.com:32589",
+                                                                            "http://my-server.com:32589/some/path"));
+
+        ServerImpl modifiedServer = serverModifier.transform(originServer);
+
+        assertEquals(modifiedServer, expectedServer);
+    }
+
+    @Test
+    public void shouldBeAbleToChangeInternalUrl() throws Exception {
+        serverModifier = new UriTemplateServerProxyTransformer("http://%2$s:%3$s/%4$s",
+                                                               "https://%3$s-%2$s.transform-host:444/%1$s/%4$s") {};
+        ServerImpl originServer = new ServerImpl("myRef",
+                                                 "http",
+                                                 "my-server.com:32589",
+                                                 "http://my-server.com:32589/some/path",
+                                                 new ServerPropertiesImpl("/some/path",
+                                                                          "my-server.com:32589",
+                                                                          "http://my-server.com:32589/some/path"));
+        ServerImpl expectedServer = new ServerImpl("myRef",
+                                                   "http",
+                                                   "my-server.com:32589",
+                                                   "http://my-server.com:32589/some/path",
+                                                   new ServerPropertiesImpl("/some/path",
                                                                             "32589-my-server.com.transform-host:444",
                                                                             "https://32589-my-server.com.transform-host:444/myRef/some/path"));
 
@@ -123,7 +194,8 @@ public class UriTemplateServerProxyTransformerTest {
 
     @Test
     public void shouldWorkProperlyIfPathIsNull() throws Exception {
-        serverModifier = new UriTemplateServerProxyTransformer("https://%3$s-%2$s.transform-host:444/%4$s") {};
+        serverModifier = new UriTemplateServerProxyTransformer("https://%3$s-%2$s.transform-host:444/%4$s",
+                                                               "http://%2$s:%3$s/%4$s") {};
         ServerImpl originServer = new ServerImpl("myRef",
                                                  "http",
                                                  "my-server.com:32589",
@@ -136,8 +208,8 @@ public class UriTemplateServerProxyTransformerTest {
                                                    "32589-my-server.com.transform-host:444",
                                                    "https://32589-my-server.com.transform-host:444/",
                                                    new ServerPropertiesImpl("/",
-                                                                            "32589-my-server.com.transform-host:444",
-                                                                            "https://32589-my-server.com.transform-host:444/"));
+                                                                            "my-server.com:32589",
+                                                                            "http://my-server.com:32589/"));
 
         ServerImpl modifiedServer = serverModifier.transform(originServer);
 


### PR DESCRIPTION
### What does this PR do?
Make codenvy work on OSX without network alias on host.
Alternative implementation of #1495 to #1542 
Some docs are have gotten from @benoitf 's PR.

### What issues does this PR fix or reference?
Fixes #1495

### Previous Behavior
Creation of network alias on host is needed on OSX

### New Behavior
Codenvy works without workarounds on OSX

### Tests written?
Yes

### Docs requirements?
If we have section with creation of network alias it should point that in version 5.<set correct version> that it not needed anymore.