### PR TITLE
[WIP] CHE-3920: make rsync agent installation scripts respect environment variables

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/MachineInnerRsyncAgent.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/MachineInnerRsyncAgent.java
@@ -44,7 +44,7 @@ public class MachineInnerRsyncAgent extends AgentImpl {
               "#\n\n" +
               "unset SUDO\n" +
               "unset PACKAGES\n" +
-              "test \"$(id -u)\" = 0 || SUDO=\"sudo\"\n\n" +
+              "test \"$(id -u)\" = 0 || SUDO=\"sudo -E\"\n\n" +
               "LINUX_TYPE=$(cat /etc/os-release | grep ^ID= | tr '[:upper:]' '[:lower:]')\n" +
               "LINUX_VERSION=$(cat /etc/os-release | grep ^VERSION_ID=)\n\n" +
               "###############################\n" +


### PR DESCRIPTION
### What does this PR do?
Replaces "sudo" with "sudo -E" which preserves user's environment
variables which may contain proxy settings.

### What issues does this PR fix or reference?
Related to eclipse/che#3927

### Previous Behavior
sudo used environment of root, so proxy variables weren't respected

### New Behavior
sudo respects user's environment including proxy settings

### Tests written?
No

### Docs requirements?
Can someone point me to place where docs should be updated?