### PR TITLE
Add postflight check of swarm nodes

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -6,7 +6,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
-cli_post_init() {
+post_init() {
   GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host ${UTILITY_IMAGE_CHEIP})}
   DEFAULT_CODENVY_HOST=$GLOBAL_HOST_IP
   CODENVY_HOST=${CODENVY_HOST:-${DEFAULT_CODENVY_HOST}}

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -13,6 +13,8 @@ cli_post_init() {
   CODENVY_PORT=80
   CHE_PORT=80
   CHE_SERVER_CONTAINER_NAME="${CHE_MINI_PRODUCT_NAME}_${CHE_MINI_PRODUCT_NAME}_1"
+  CHE_MIN_RAM=1.5
+  CHE_MIN_DISK=100
 }
 
 cli_parse () {
@@ -119,17 +121,17 @@ cmd_start_check_ports() {
   fi
 
   PORT_BREAK="no" 
-  text   "         port 80 (http):        $(port_open 80 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 443 (https):      $(port_open 443 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 2181 (zookeeper): $(port_open 2181 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 5000 (registry):  $(port_open 5000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 23750 (socat):    $(port_open 23750 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 23751 (swarm):    $(port_open 23751 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 32001 (jmx):      $(port_open 32001 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-  text   "         port 32101 (jmx):      $(port_open 32101 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 80 (http):          $(port_open 80 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 443 (https):        $(port_open 443 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 2181 (zookeeper):   $(port_open 2181 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 5000 (registry):    $(port_open 5000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 23750 (socat):      $(port_open 23750 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 23751 (swarm):      $(port_open 23751 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 32001 (jmx):        $(port_open 32001 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+  text   "         port 32101 (jmx):        $(port_open 32101 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   if debug_server; then
-    text   "         port ${CODENVY_DEBUG_PORT} (debug):     $(port_open ${CODENVY_DEBUG_PORT} && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
-    text   "         port 9000 (lighttpd):  $(port_open 9000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+    text   "         port ${CODENVY_DEBUG_PORT} (debug):       $(port_open ${CODENVY_DEBUG_PORT} && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
+    text   "         port 9000 (lighttpd):    $(port_open 9000 && echo "${GREEN}[AVAILABLE]${NC}" || echo "${RED}[ALREADY IN USE]${NC}") \n"
   fi
 
   if ! $(port_open 80) || \

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -246,6 +246,9 @@ generate_configuration_with_puppet() {
     # Handle override/addon
     if [[ -d "/repo/dockerfiles/init/addon/" ]]; then
       WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/addon/addon.pp\":/etc/puppet/manifests/addon.pp:ro"
+      if [ -d "/repo/dockerfiles/init/addon/modules" ]; then
+        WRITE_PARAMETERS+=" -v \"${CHE_HOST_DEVELOPMENT_REPO}/dockerfiles/init/addon/modules/\":/etc/puppet/addon/:ro"
+      fi
     fi
   else
     CHE_REPO="off"
@@ -267,7 +270,7 @@ generate_configuration_with_puppet() {
                   --entrypoint=/usr/bin/puppet \
                       $IMAGE_INIT \
                           apply --modulepath \
-                                /etc/puppet/modules/ \
+                                /etc/puppet/modules/:/etc/puppet/addon/ \
                                 /etc/puppet/manifests/ --show_diff ${WRITE_LOGS}"
 
   log ${GENERATE_CONFIG_COMMAND}

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -11,6 +11,7 @@ cli_post_init() {
   DEFAULT_CODENVY_HOST=$GLOBAL_HOST_IP
   CODENVY_HOST=${CODENVY_HOST:-${DEFAULT_CODENVY_HOST}}
   CODENVY_PORT=80
+  CHE_PORT=80
   CHE_SERVER_CONTAINER_NAME="${CHE_MINI_PRODUCT_NAME}_${CHE_MINI_PRODUCT_NAME}_1"
 }
 
@@ -31,14 +32,6 @@ cli_parse () {
 
 get_boot_url() {
   echo "$CODENVY_HOST/api/"
-}
-
-get_display_url() {
-  if ! is_docker_for_mac; then
-    echo "http://${CODENVY_HOST}"
-  else
-    echo "http://localhost"
-  fi
 }
 
 cmd_backup_extra_args() {

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -108,14 +108,14 @@ cmd_start_check_ports() {
   # Develop array of port #, description.
   # Format of array is "<port>;<port_string>" where the <port_string> is the text to appear in console
   local PORT_ARRAY=(
-     "80;port 80 (http):        "
-     "443;port 443 (https):      "
-     "2181;port 2181 (zookeeper): "
-     "5000;port 5000 (registry):  "
-     "23750;port 23750 (socat):    "
-     "23751;port 23751 (swarm):    "
-     "32000;port 32000 (jmx):      "
-     "32001;port 32001 (jmx):      "
+     "80;port 80 (http):         "
+     "443;port 443 (https):       "
+     "2181;port 2181 (zookeeper):  "
+     "5000;port 5000 (registry):   "
+     "23750;port 23750 (socat):     "
+     "23751;port 23751 (swarm):     "
+     "32000;port 32000 (jmx):       "
+     "32001;port 32001 (jmx):       "
     )
 
   # If dev mode is on, then we also need to check the debug port set by the user for availability
@@ -132,8 +132,8 @@ cmd_start_check_ports() {
       CHE_DEBUG_PORT=$USER_DEBUG_PORT
     fi
 
-    PORT_ARRAY+=("$CODENVY_DEBUG_PORT;port ${CODENVY_DEBUG_PORT} (debug):      ")
-    PORT_ARRAY+=("9000;port 9000 (lighttpd):  ")
+    PORT_ARRAY+=("$CODENVY_DEBUG_PORT;port ${CODENVY_DEBUG_PORT} (debug):       ")
+    PORT_ARRAY+=("9000;port 9000 (lighttpd):   ")
   fi
 
   if check_all_ports "${PORT_ARRAY[@]}"; then
@@ -141,6 +141,33 @@ cmd_start_check_ports() {
   else
     find_and_print_ports_as_notok "${PORT_ARRAY[@]}"
   fi
+}
+
+cmd_start_check_postflight() {
+  info "start" "Postflight checks"
+  SWARM_NODE_CONFIG=$(get_value_of_var_from_env_file CODENVY_SWARM_NODES)
+
+  POSTFLIGHT=""
+  IFS=$','
+  for SINGLE_SWARM_NODE in ${SWARM_NODE_CONFIG}; do
+    CURL_CODE=$(curl -s $SINGLE_SWARM_NODE/info -o /dev/null --write-out %{http_code} || true)
+    if [[ "${CURL_CODE}" = "200" ]]; then
+      text "         ($SINGLE_SWARM_NODE/info):  ${GREEN}[OK]${NC}\n"
+    else
+      text "         ($SINGLE_SWARM_NODE/info):  ${RED}[NOT OK]${NC}\n"
+      POSTFLIGHT="fail"
+    fi
+  done
+
+  if [ "${POSTFLIGHT}" = "fail" ]; then 
+    text "\n"
+    error "Could not reach all Swarm nodes - workspaces may not start."
+    error "  1. Are the swarm ports open on your firewall?"
+    error "  2. Did the Docker daemon fail to start on any node?"
+    error "  3. Are the swarm entries entered properly in codenvy.env?"
+  fi
+
+  text "\n"
 }
 
 cmd_config_post_action() {

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -6,7 +6,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
-cli_pre_init() {
+cli_post_init() {
   GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host ${UTILITY_IMAGE_CHEIP})}
   DEFAULT_CODENVY_HOST=$GLOBAL_HOST_IP
   CODENVY_HOST=${CODENVY_HOST:-${DEFAULT_CODENVY_HOST}}

--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -6,14 +6,11 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
-cli_pre_init() {
+cli_post_init() {
   GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host eclipse/che-ip:nightly)}
   DEFAULT_CODENVY_HOST=$GLOBAL_HOST_IP
   CODENVY_HOST=${CODENVY_HOST:-${DEFAULT_CODENVY_HOST}}
   CODENVY_PORT=80
-}
-
-cli_post_init() {
   CHE_SERVER_CONTAINER_NAME="${CHE_MINI_PRODUCT_NAME}_${CHE_MINI_PRODUCT_NAME}_1"
 }
 

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -27,7 +27,7 @@ CHE_LICENSE_URL="https://codenvy.com/legal/fair-source/"
 CHE_SERVER_CONTAINER_NAME="${CHE_MINI_PRODUCT_NAME}_${CHE_MINI_PRODUCT_NAME}_1"
 CHE_IMAGE_FULLNAME="codenvy/cli:<version>"
 
-cli_pre_init() {
+pre_init() {
   ADDITIONAL_MANDATORY_PARAMETERS=""
   ADDITIONAL_OPTIONAL_DOCKER_PARAMETERS="
   -e CODENVY_HOST=<YOUR_HOST>          IP address or hostname where codenvy will serve its users"

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -27,47 +27,16 @@ CHE_LICENSE_URL="https://codenvy.com/legal/fair-source/"
 CHE_SERVER_CONTAINER_NAME="${CHE_MINI_PRODUCT_NAME}_${CHE_MINI_PRODUCT_NAME}_1"
 CHE_IMAGE_FULLNAME="codenvy/cli:<version>"
 
-init_usage() {
-  USAGE="
-USAGE: 
-  docker run -it --rm <DOCKER_PARAMETERS> ${CHE_IMAGE_FULLNAME} [COMMAND]
-
-MANDATORY DOCKER PARAMETERS:
-  -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}                Where user, instance, and log data saved
-
-OPTIONAL DOCKER PARAMETERS:
-  -e CODENVY_HOST=<YOUR_HOST>          IP address or hostname where ${CHE_FORMAL_PRODUCT_NAME} will serve its users
-  -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}/instance       Where instance, user, log data will be saved
-  -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}/backup         Where backup files will be saved
-  -v <LOCAL_PATH>:/cli                 Where the CLI trace log is saved
-  -v <LOCAL_PATH>:/repo                ${CHE_FORMAL_PRODUCT_NAME} git repo to activate dev mode
-  -v <LOCAL_PATH>:/sync                Where remote ws files will be copied with sync command
-  -v <LOCAL_PATH>:/unison              Where unison profile for optimzing sync command resides
-    
-COMMANDS:
-  action <action-name>                 Start action on ${CHE_FORMAL_PRODUCT_NAME} instance
+cli_pre_init() {
+  ADDITIONAL_MANDATORY_PARAMETERS=""
+  ADDITIONAL_OPTIONAL_DOCKER_PARAMETERS="
+  -e CODENVY_HOST=<YOUR_HOST>          IP address or hostname where codenvy will serve its users"
+  ADDITIONAL_OPTIONAL_DOCKER_MOUNTS=""
+  ADDITIONAL_COMMANDS="
   add-node                             Adds a physical node to serve workspaces intto the ${CHE_FORMAL_PRODUCT_NAME} cluster
-  backup                               Backups ${CHE_FORMAL_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
-  config                               Generates a ${CHE_FORMAL_PRODUCT_NAME} config from vars; run on any start / restart
-  destroy                              Stops services, and deletes ${CHE_FORMAL_PRODUCT_NAME} instance data
-  download                             Pulls Docker images for the current ${CHE_FORMAL_PRODUCT_NAME} version
-  help                                 This message
-  info                                 Displays info about ${CHE_FORMAL_PRODUCT_NAME} and the CLI
-  init                                 Initializes a directory with a ${CHE_FORMAL_PRODUCT_NAME} install
   list-nodes                           Lists all physical nodes that are part of the ${CHE_FORMAL_PRODUCT_NAME} cluster
-  offline                              Saves ${CHE_FORMAL_PRODUCT_NAME} Docker images into TAR files for offline install
-  remove-node <ip>                     Removes the physical node from the ${CHE_FORMAL_PRODUCT_NAME} cluster
-  restart                              Restart ${CHE_FORMAL_PRODUCT_NAME} services
-  restore                              Restores ${CHE_FORMAL_PRODUCT_NAME} configuration and data from ${CHE_CONTAINER_ROOT}/backup mount
-  rmi                                  Removes the Docker images for <version>, forcing a repull
-  ssh <wksp-name> [machine-name]       SSH to a workspace if SSH agent enabled
-  start                                Starts ${CHE_FORMAL_PRODUCT_NAME} services
-  stop                                 Stops ${CHE_FORMAL_PRODUCT_NAME} services
-  sync <wksp-name>                     Synchronize workspace with current working directory
-  test <test-name>                     Start test on ${CHE_FORMAL_PRODUCT_NAME} instance
-  upgrade                              Upgrades ${CHE_FORMAL_PRODUCT_NAME} from one version to another with migrations and backups
-  version                              Installed version and upgrade paths
-"
+  remove-node <ip>                     Removes the physical node from the ${CHE_FORMAL_PRODUCT_NAME} cluster"
+  ADDITIONAL_GLOBAL_OPTIONS=""
 }
 
 source /scripts/base/startup.sh

--- a/dockerfiles/init/modules/codenvy/templates/general.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/general.properties.erb
@@ -58,12 +58,6 @@ che.auth.reserved_user_names=api,dashboard,factory,ide-resources,main,site,swagg
 # SSO
 auth.sso.client_allow_anonymous=false
 
-# braintree configurations, must be empty for on premise installations.
-braintree.merchant_id=<% if has_variable?('codenvy::braintree_merchant_id') %><%= scope.lookupvar('codenvy::braintree_merchant_id') %><% else %><% end %>
-braintree.public_key=<% if has_variable?('codenvy::braintree_public_key') %><%= scope.lookupvar('codenvy::braintree_public_key') %><% else %><% end %>
-braintree.private_key=<% if has_variable?('codenvy::braintree_private_key') %><%= scope.lookupvar('codenvy::braintree_private_key') %><% else %><% end %>
-braintree.environment=<% if has_variable?('codenvy::braintree_environment') %><%= scope.lookupvar('codenvy::braintree_environment') %><% else %><% end %>
-
 # DB initialization and migration configuration
 db.schema.flyway.baseline.enabled=true
 db.schema.flyway.baseline.version=5.0.0.8.1.2


### PR DESCRIPTION
Signed-off-by: Tyler Jewell <tjewell@codenvy.com>

### What does this PR do?
This PR adapts changes made to Eclipse Che to allow the inherited CLI to inherit its `usage()` statement from the core CLI so that as the base CLI makes improvements, the new CLI will have it inherited automatically.

Also provides a first implementation of a postflight check, which pulls the list of Swarm nodes from `codenvy.env` and then uses `curl` to ping each one's `/info` URL to see if it is reachable.

Must merge this at the same time as we merge: https://github.com/eclipse/che/pull/3940

### Changelog
Adapt CLI to changes in Eclipse Che #3940
Add postflight check of Swarm nodes as a test

### Release Notes
We are working to make sure Codenvy starts in any environment perfectly every time. We've added some additional preflight checks related to mandatory minimums for disk and memory available from the host. If the minimums are not enough to start at least one workspace, then Codenvy bootup will be interrupted. Preflight checks can now be skipped with either `--fast` or `--skip:preflight` on the command line.

We have also introduced postflight checks. We parse `codenvy.env` to get a list of Swarm nodes for your cluster. We then check that each is reachable using curl and that their `/info` URL is returning valid data. A failure of this command is an early indicator that firewalls were not configured correctly.  You can skip this check with `--fast` or `--skip:postflight`.

### Docs PR
https://github.com/codenvy/codenvy-docs/pull/59