### PR TITLE
allow override flyway db schema in saas

### DIFF
--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -309,6 +309,10 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
   $codenvy_extra_hosts = getValue("CODENVY_EXTRA_HOSTS","NULL")
 
 ###############################
+#
+  $db_schema_flyway_scripts_locations=getValue("DB_SCHEMA_FLYWAY_SCRIPTS_LOCATIONS","classpath:che-schema,classpath:codenvy-schema")
+
+###############################
 # Include base module
   include base
 }

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -309,7 +309,7 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
   $codenvy_extra_hosts = getValue("CODENVY_EXTRA_HOSTS","NULL")
 
 ###############################
-#
+# DB initialization and migration configuration
   $db_schema_flyway_scripts_locations=getValue("DB_SCHEMA_FLYWAY_SCRIPTS_LOCATIONS","classpath:che-schema,classpath:codenvy-schema")
 
 ###############################

--- a/dockerfiles/init/modules/codenvy/templates/general.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/general.properties.erb
@@ -64,5 +64,5 @@ db.schema.flyway.baseline.version=5.0.0.8.1.2
 db.schema.flyway.scripts.prefix=
 db.schema.flyway.scripts.suffix=.sql
 db.schema.flyway.scripts.version_separator=__
-db.schema.flyway.scripts.locations=classpath:che-schema,classpath:codenvy-schema
+db.schema.flyway.scripts.locations=<%= scope.lookupvar('codenvy::db_schema_flyway_scripts_locations') %>
 db.jndi.datasource.name=java:/comp/env/jdbc/codenvy


### PR DESCRIPTION
today db schema was hardcoded in props because we don't want allow to modify them but now we need ability to change schema for saas