### PR TITLE
Add property about che.docker.ip.external with a default null value

### DIFF
--- a/assembly/onpremises-ide-packaging-war-platform-api/src/main/webapp/WEB-INF/classes/codenvy/codenvy-api-configuration.properties
+++ b/assembly/onpremises-ide-packaging-war-platform-api/src/main/webapp/WEB-INF/classes/codenvy/codenvy-api-configuration.properties
@@ -55,3 +55,8 @@ stop.workspace.scheduler.period=60
 che.workspace.ssh_connection_timeout_ms=3000
 
 system.ram.limit_check_period_sec=60
+
+# The hostname that a browser should use to connect to a workspace container.
+# Only set this if your workspace containers are not directly pingable.
+# This is unusual, but happens for example in Docker for Mac when containers are in a VM.
+che.docker.ip.external=NULL


### PR DESCRIPTION
This optional property is defined only on Mac and Windows by default
On linux a default value is also required.

### Changelog and Release Note Information
**Changelog**: add default empty che.docker.ip.external value

**Release Notes**: bug

### Docs Pull Request
bugfix

Change-Id: If7ad1af2cb6a9b492d8926dfe1598f18737d2c19
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>

