### PR TITLE
pick prop value depending on scope

### DIFF
--- a/dockerfiles/init/modules/codenvy/templates/general.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/general.properties.erb
@@ -64,5 +64,9 @@ db.schema.flyway.baseline.version=5.0.0.8.1.2
 db.schema.flyway.scripts.prefix=
 db.schema.flyway.scripts.suffix=.sql
 db.schema.flyway.scripts.version_separator=__
+<% if has_variable?('addon::db_schema_flyway_scripts_locations') -%>
+db.schema.flyway.scripts.locations=<%= scope.lookupvar('addon::db_schema_flyway_scripts_locations') %>
+<% else -%>
 db.schema.flyway.scripts.locations=<%= scope.lookupvar('codenvy::db_schema_flyway_scripts_locations') %>
+<% end -%>
 db.jndi.datasource.name=java:/comp/env/jdbc/codenvy


### PR DESCRIPTION
to be able to override default value of `db_schema_flyway_scripts_locations` for saas we need pick var value depending on scope where it is declared.
this approach needed for some rare cases where we want override default value, it was possible to change it by modifying `codenvy.env` but for saas that prop must be always different.

### Changelog and Release Note Information
**Changelog**: set `db_schema_flyway_scripts_locations` property value depending on scope.
