### PR TITLE
Decouple testing framework API from Java test specific frameworks

### DIFF
--- a/assembly/onpremises-ide-compiling-war-ide/pom.xml
+++ b/assembly/onpremises-ide-compiling-war-ide/pom.xml
@@ -118,6 +118,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-testing-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-user</artifactId>
         </dependency>
         <dependency>
@@ -131,26 +139,6 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-ide-app</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-core-ide</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-core-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-junit-ide</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-junit-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-testng-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -291,6 +279,18 @@
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-svn-ext-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-junit-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-testng-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>

--- a/assembly/onpremises-ide-compiling-war-ide/src/main/resources/com/codenvy/ide/IDE.gwt.xml
+++ b/assembly/onpremises-ide-compiling-war-ide/src/main/resources/com/codenvy/ide/IDE.gwt.xml
@@ -74,7 +74,9 @@
     <inherits name='org.eclipse.che.plugin.nodejs.NodeJs'/>
     <inherits name='org.eclipse.che.plugin.docker.client.dto.Dto'/>
     <inherits name='org.eclipse.che.plugin.languageserver.LanguageServer'/>
-    <inherits name="org.eclipse.che.ide.ext.java.testing.core.TestExtension"/>
+    <inherits name="org.eclipse.che.plugin.testing.TestingExtension"/>
+    <inherits name="org.eclipse.che.plugin.testing.junit.JUnit"/>
+    <inherits name="org.eclipse.che.plugin.testing.testng.TestNG"/>
 
     <!-- Platform API GWT client dependencies                       -->
     <inherits name='org.eclipse.che.api.core.model.Model'/>
@@ -86,6 +88,7 @@
     <inherits name='org.eclipse.che.api.user.User'/>
     <inherits name='org.eclipse.che.api.factory.Factory'/>
     <inherits name="org.eclipse.che.api.workspace.Workspace"/>
+    <inherits name="org.eclipse.che.api.testing.Testing"/>
     <inherits name="org.eclipse.che.api.ssh.Ssh"/>
     <inherits name="org.eclipse.che.api.debug.Debug"/>
     <inherits name="org.eclipse.che.api.languageserver.LanguageServer"/>

--- a/assembly/onpremises-ide-packaging-war-ext-server/pom.xml
+++ b/assembly/onpremises-ide-packaging-war-ext-server/pom.xml
@@ -124,6 +124,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-testing-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
@@ -141,30 +149,6 @@
         <dependency>
             <groupId>org.eclipse.che.lib</groupId>
             <artifactId>che-swagger-module</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-classpath-maven-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-core-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-core-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-junit-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-junit-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-java-testing-testng-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -271,6 +255,22 @@
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-svn-ext-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-classpath-maven-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-classpath-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-junit-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-testing-testng-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>


### PR DESCRIPTION
### What does this PR do?

This PR is a proposal for decoupling testing framework core API from Java specific testing frameworks.

### What issues does this PR fix or reference?

[#3452](https://github.com/eclipse/che/issues/3452)

### Previous behavior

In current state all of the testing frameworks that are Java specific are tightly coupled with the testing framework core API, which complicates "straight-forward" adding of new testing frameworks (i.e. PHPUnit). 

### New behavior

- Testing core framework API was moved to Che Core API packages (I was using the debugger API analogy)
- All code in testing framework core API that was tightly coupled to Java specific testing frameworks (i.e. JUnit, TestNG) was unbound and moved to related plug-ins 

That's more or less the general description of the changes that I have made. I am eager to answer all of the possible questions related to the details.


### Changelog:

Decoupling of testing framework core API from Java specific testing frameworks implementation.

### Release Notes:

N/A refactoring of existing code.

### Docs PR:

None : same behavior than before
