### PR TITLE
CODENVY-1662: improve rsync configurability

### DIFF
--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -303,6 +303,12 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
   $db_schema_flyway_scripts_locations=getValue("DB_SCHEMA_FLYWAY_SCRIPTS_LOCATIONS","classpath:che-schema,classpath:codenvy-schema")
 
 ###############################
+# Rsync backup/restore configuration
+  $rsync_restore_bwlimit=getValue("RSYNC_RESTORE_BWLIMIT","7000")
+  $rsync_backup_bwlimit=getValue("RSYNC_BACKUP_BWLIMIT","7000")
+  $rsync_ssh_log_level=getValue("RSYNC_SSH_LOG_LEVEL","INFO")
+
+###############################
 # Include base module
   include base
 }

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -304,8 +304,12 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
 
 ###############################
 # Rsync backup/restore configuration
+# Throughput of rsync connection for workspace files restoring in KiB. Value may include dot, unit suffix, e.g. 1.5m.
   $rsync_restore_bwlimit=getValue("RSYNC_RESTORE_BWLIMIT","7000")
+# Throughput of rsync connection for workspace files backup in KiB.
   $rsync_backup_bwlimit=getValue("RSYNC_BACKUP_BWLIMIT","7000")
+# Sets log level of ssh connection used by rsync for workspace syncing. Value may include dot, unit suffix, e.g. 1.5m.
+# Default value INFO. Possible values: QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG1, DEBUG2, and DEBUG3
   $rsync_ssh_log_level=getValue("RSYNC_SSH_LOG_LEVEL","INFO")
 
 ###############################

--- a/dockerfiles/init/modules/codenvy/templates/rsyncbackup.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncbackup.sh.erb
@@ -25,12 +25,16 @@ if [[ $(stat -c %a /opt/rsync_key) != 600 ]]; then
     chmod 0600 /opt/rsync_key
 fi
 
-RSYNC_COMMAND=$(ssh -i /opt/rsync_key -l ${SRC_USER_NAME} -o StrictHostKeyChecking=no -p ${SRC_PORT} ${SRC_HOST} \
+RSYNC_BACKUP_BWLIMIT=<%= scope.lookupvar('codenvy::rsync_backup_bwlimit') %>
+SSH_LOG_LEVEL=<%= scope.lookupvar('codenvy::rsync_ssh_log_level') %>
+SSH_OPTIONS="-i /opt/rsync_key -l ${SRC_USER_NAME} -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o LogLevel=${SSH_LOG_LEVEL} -p ${SRC_PORT}"
+
+RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${SRC_HOST} \
             "if hash sudo 2>/dev/null;then echo 'sudo rsync';else echo 'rsync';fi")
 
-rsync --quiet --delete --partial --links --safe-links --recursive --times --human-readable --bwlimit=7000 --executability \
+rsync --quiet --delete --partial --links --safe-links --recursive --times --human-readable --bwlimit=${RSYNC_BACKUP_BWLIMIT} --executability \
               --include='.codenvy/' \
               --filter=':- .gitignore' \
-              --rsh="ssh -i /opt/rsync_key -l ${SRC_USER_NAME} -o StrictHostKeyChecking=no -p ${SRC_PORT}" \
+              --rsh="ssh ${SSH_OPTIONS}" \
               --rsync-path="${RSYNC_COMMAND}" \
               ${SRC_HOST}:${SRC_FOLDER} ${DST_FOLDER}

--- a/dockerfiles/init/modules/codenvy/templates/rsyncrestore.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncrestore.sh.erb
@@ -26,13 +26,17 @@ if [[ $(stat -c %a /opt/rsync_key) != 600 ]]; then
     chmod 0600 /opt/rsync_key
 fi
 
-RSYNC_COMMAND=$(ssh -i /opt/rsync_key -l ${SRC_USER_NAME} -o StrictHostKeyChecking=no -p ${DST_PORT} ${DST_HOST} \
+RSYNC_RESTORE_BWLIMIT=<%= scope.lookupvar('codenvy::rsync_restore_bwlimit') %>
+SSH_LOG_LEVEL=<%= scope.lookupvar('codenvy::rsync_ssh_log_level') %>
+SSH_OPTIONS="-i /opt/rsync_key -l ${SRC_USER_NAME} -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o LogLevel=${SSH_LOG_LEVEL} -p ${DST_PORT}"
+
+RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${DST_HOST} \
             "if hash sudo 2>/dev/null;then echo 'sudo rsync';else echo 'rsync';fi")
 
-rsync --quiet --delete --partial --links --safe-links --owner --group --recursive --times --human-readable --bwlimit=7000 --executability \
+rsync --quiet --delete --partial --links --safe-links --owner --group --recursive --times --human-readable --bwlimit=${RSYNC_RESTORE_BWLIMIT} --executability \
       --include='.codenvy/' \
       --filter=':- .gitignore' \
-      --rsh="ssh -i /opt/rsync_key -l ${SRC_USER_NAME} -o StrictHostKeyChecking=no -p ${DST_PORT}" \
+      --rsh="ssh ${SSH_OPTIONS}" \
       --rsync-path="${RSYNC_COMMAND}" \
       --chown ${DST_USR_ID}:${DST_GRP_ID} \
       ${SRC_FOLDER} ${DST_HOST}:${DST_FOLDER}

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
@@ -223,7 +223,8 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
                                     syncPort);
         } catch (IOException e) {
             LOG.error(e.getLocalizedMessage(), e);
-            throw new ServerException("Can't restore workspace file system");
+            throw new ServerException(format("Can't restore file system of workspace %s in container %s",
+                                             workspaceId, containerId));
         }
     }
 
@@ -326,7 +327,7 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
                                                       destGroupId,
                                                       destUserName);
 
-            executeCommand(commandLine.asArray(), restoreDuration, destAddress);
+            executeCommand(commandLine.asArray(), restoreDuration, destAddress, workspaceId);
             restored = true;
         } catch (TimeoutException e) {
             throw new ServerException(
@@ -365,7 +366,7 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
                                                   srcUserName);
 
         try {
-            executeCommand(commandLine.asArray(), maxBackupDuration, srcAddress);
+            executeCommand(commandLine.asArray(), maxBackupDuration, srcAddress, workspaceId);
         } catch (TimeoutException e) {
             throw new ServerException("Backup of workspace " + workspaceId + " filesystem terminated due to timeout on "
                                       + srcAddress + " node.");
@@ -530,15 +531,19 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
     }
 
     @VisibleForTesting
-    void executeCommand(String[] commandLine, int timeout, String address) throws TimeoutException,
-                                                                                  IOException,
-                                                                                  InterruptedException {
+    void executeCommand(String[] commandLine,
+                        int timeout,
+                        String address,
+                        String workspaceId) throws TimeoutException,
+                                                   IOException,
+                                                   InterruptedException {
         final ListLineConsumer outputConsumer = new ListLineConsumer();
         Process process = ProcessUtil.executeAndWait(commandLine, timeout, SECONDS, outputConsumer);
 
         if (process.exitValue() != 0) {
-            LOG.error("Error occurred during backup/restore on '{}' : {}", address, outputConsumer.getText());
-            throw new IOException("Process failed. Exit code " + process.exitValue());
+            LOG.error("Error occurred during backup/restore of workspace '{}' on node '{}' : {}",
+                      workspaceId, address, outputConsumer.getText());
+            throw new IOException("Synchronization process failed. Exit code " + process.exitValue());
         }
     }
 

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/DockerEnvironmentBackupManagerTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/DockerEnvironmentBackupManagerTest.java
@@ -20,7 +20,6 @@ import org.eclipse.che.api.core.model.machine.MachineStatus;
 import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineRuntimeInfoImpl;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
-import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceRuntimeImpl;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
@@ -175,7 +174,7 @@ public class DockerEnvironmentBackupManagerTest {
         when(workspaceFolderPathProvider.getPath(WORKSPACE_ID)).thenReturn(SRC_PATH);
         when(workspaceIdHashLocationFinder.calculateDirPath(any(File.class), any(String.class)))
                 .thenReturn(new File(ABSOLUTE_PATH_TO_WORKSPACE_DIR));
-        doNothing().when(backupManager).executeCommand(anyObject(), anyInt(), anyString());
+        doNothing().when(backupManager).executeCommand(anyObject(), anyInt(), anyString(), anyString());
         Exec getUserIdsExecMock = mock(Exec.class);
         when(getUserIdsExecMock.getId()).thenReturn("getUserIdsExecMockId");
         Exec getUserNameExecMock = mock(Exec.class);
@@ -219,7 +218,8 @@ public class DockerEnvironmentBackupManagerTest {
 
         backupManager.backupWorkspace(WORKSPACE_ID);
 
-        verify(backupManager).executeCommand(cmdCaptor.capture(), eq(MAX_BACKUP_DURATION_SEC), eq(NODE_HOST));
+        verify(backupManager).executeCommand(cmdCaptor.capture(), eq(MAX_BACKUP_DURATION_SEC), eq(NODE_HOST),
+                                             anyString());
 
         String[] command = cmdCaptor.getValue();
         assertArrayEquals(BACKUP_WORKSPACE_COMMAND, command);
@@ -234,7 +234,7 @@ public class DockerEnvironmentBackupManagerTest {
 
         backupManager.backupWorkspace(WORKSPACE_ID);
 
-        verify(backupManager).executeCommand(anyObject(), anyInt(), anyString());
+        verify(backupManager).executeCommand(anyObject(), anyInt(), anyString(), anyString());
     }
 
     @Test
@@ -244,7 +244,7 @@ public class DockerEnvironmentBackupManagerTest {
 
         backupManager.backupWorkspace(WORKSPACE_ID);
 
-        verify(backupManager, never()).executeCommand(any(String[].class), anyInt(), anyString());
+        verify(backupManager, never()).executeCommand(any(String[].class), anyInt(), anyString(), anyString());
         verifyNoMoreInteractions(docker,
                                  dockerInstance,
                                  dockerNode,
@@ -261,7 +261,7 @@ public class DockerEnvironmentBackupManagerTest {
 
         backupManager.backupWorkspace(WORKSPACE_ID);
 
-        verify(backupManager, never()).executeCommand(any(String[].class), anyInt(), anyString());
+        verify(backupManager, never()).executeCommand(any(String[].class), anyInt(), anyString(), anyString());
         verify(workspaceManager).getWorkspace(eq(WORKSPACE_ID));
         verifyNoMoreInteractions(docker,
                                  dockerInstance,
@@ -287,7 +287,7 @@ public class DockerEnvironmentBackupManagerTest {
 
         backupManager.backupWorkspace(WORKSPACE_ID);
 
-        verify(backupManager, never()).executeCommand(any(String[].class), anyInt(), anyString());
+        verify(backupManager, never()).executeCommand(any(String[].class), anyInt(), anyString(), anyString());
     }
 
     @Test
@@ -297,7 +297,8 @@ public class DockerEnvironmentBackupManagerTest {
                                                 CONTAINER_ID,
                                                 NODE_HOST);
 
-        verify(backupManager).executeCommand(cmdCaptor.capture(), eq(MAX_BACKUP_DURATION_SEC), eq(NODE_HOST));
+        verify(backupManager).executeCommand(cmdCaptor.capture(), eq(MAX_BACKUP_DURATION_SEC), eq(NODE_HOST),
+                                             anyString());
 
         String[] command = cmdCaptor.getValue();
         assertArrayEquals(BACKUP_WORKSPACE_WITH_CLEANUP_COMMAND, command);
@@ -305,13 +306,14 @@ public class DockerEnvironmentBackupManagerTest {
 
     @Test
     public void shouldBeAbleRestoreWorkspace() throws Exception {
-        doNothing().when(backupManager).executeCommand(anyObject(), anyInt(), anyString());
+        doNothing().when(backupManager).executeCommand(anyObject(), anyInt(), anyString(), anyString());
 
         backupManager.restoreWorkspaceBackup(WORKSPACE_ID,
                                              CONTAINER_ID,
                                              NODE_HOST);
 
-        verify(backupManager).executeCommand(cmdCaptor.capture(), eq(MAX_RESTORE_DURATION_SEC), eq(NODE_HOST));
+        verify(backupManager).executeCommand(cmdCaptor.capture(), eq(MAX_RESTORE_DURATION_SEC), eq(NODE_HOST),
+                                             anyString());
 
         String[] command = cmdCaptor.getValue();
         assertArrayEquals(RESTORE_WORKSPACE_COMMAND, command);
@@ -330,7 +332,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString(), anyString());
     }
 
     @Test
@@ -346,7 +348,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString(), anyString());
     }
 
     @Test(expectedExceptions = ServerException.class,
@@ -367,7 +369,7 @@ public class DockerEnvironmentBackupManagerTest {
             // then
             restoreFreezer.unfreeze();
             awaitFinalization();
-            verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString());
+            verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString(), anyString());
         }
     }
 
@@ -401,7 +403,7 @@ public class DockerEnvironmentBackupManagerTest {
             // complete waiting answer
             restoreFreezer.unfreeze();
             awaitFinalization();
-            verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString());
+            verify(backupManager, times(1)).executeCommand(anyObject(), anyInt(), anyString(), anyString());
         }
     }
 
@@ -410,7 +412,7 @@ public class DockerEnvironmentBackupManagerTest {
                                             " failed. Another restore process of the same workspace is in progress")
     public void throwsExceptionOnNewRestoreAfterSuccessfulFirstOne() throws Exception {
         // given
-        doNothing().when(backupManager).executeCommand(anyVararg(), anyInt(), anyString());
+        doNothing().when(backupManager).executeCommand(anyVararg(), anyInt(), anyString(), anyString());
 
         // start restore process
         backupManager.restoreWorkspaceBackup(WORKSPACE_ID,
@@ -431,7 +433,7 @@ public class DockerEnvironmentBackupManagerTest {
                                             " failed. Another restore process of the same workspace is in progress")
     public void throwsExceptionAfterFailingRestoreThatFollowsSuccessfulOne() throws Exception {
         // given
-        doNothing().when(backupManager).executeCommand(anyVararg(), anyInt(), anyString());
+        doNothing().when(backupManager).executeCommand(anyVararg(), anyInt(), anyString(), anyString());
 
         // start restore process
         backupManager.restoreWorkspaceBackup(WORKSPACE_ID,
@@ -470,7 +472,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
     }
 
@@ -494,7 +496,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
     }
 
@@ -518,7 +520,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], RESTORE_SCRIPT);
     }
 
@@ -534,7 +536,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], RESTORE_SCRIPT);
     }
 
@@ -551,7 +553,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(1)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
     }
 
@@ -578,7 +580,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(2)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(2)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
     }
 
@@ -590,7 +592,7 @@ public class DockerEnvironmentBackupManagerTest {
         backupManager.backupWorkspaceAndCleanup(WORKSPACE_ID,
                                                 CONTAINER_ID,
                                                 NODE_HOST);
-        verify(backupManager, times(2)).executeCommand(anyObject(), anyInt(), eq(NODE_HOST));
+        verify(backupManager, times(2)).executeCommand(anyObject(), anyInt(), eq(NODE_HOST), anyString());
     }
 
     @Test
@@ -609,7 +611,7 @@ public class DockerEnvironmentBackupManagerTest {
 
         backupManager.backupWorkspace(WORKSPACE_ID);
 
-        verify(backupManager, times(2)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(2)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
 
         assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
     }
@@ -638,7 +640,7 @@ public class DockerEnvironmentBackupManagerTest {
         awaitFinalization();
 
         // then
-        verify(backupManager, times(2)).executeCommand(cmdCaptor.capture(), anyInt(), anyString());
+        verify(backupManager, times(2)).executeCommand(cmdCaptor.capture(), anyInt(), anyString(), anyString());
         assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
     }
 
@@ -779,12 +781,12 @@ public class DockerEnvironmentBackupManagerTest {
                 releaseProcessLatch.await();
             }
             return null;
-        }).when(backupManager).executeCommand(anyVararg(), anyInt(), anyString());
+        }).when(backupManager).executeCommand(anyVararg(), anyInt(), anyString(), anyString());
 
         executor.execute(backupType);
 
         invokeProcessLatch.await();
-        doNothing().when(backupManager).executeCommand(anyVararg(), anyInt(), anyString());
+        doNothing().when(backupManager).executeCommand(anyVararg(), anyInt(), anyString(), anyString());
 
         return new ThreadFreezer(releaseProcessLatch);
     }


### PR DESCRIPTION
### What does this PR do?
Allow to configure rsync log level.
Disable attempts of password authentication by rsync.
Allow to configure rsync backup/restore throughput limit.

Adds possibility to set next env vars in codenvy.env (but they are not exposed in codenvy.env as commented lines):
RSYNC_RESTORE_BWLIMIT
RSYNC_BACKUP_BWLIMIT
RSYNC_SSH_LOG_LEVEL

Default values for RSYNC_RESTORE_BWLIMIT and RSYNC_BACKUP_BWLIMIT 7000KiB/s. Value without unit suffix interpreted in KiB per second. 
Default value of RSYNC_SSH_LOG_LEVEL is INFO. Possible values: QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG1, DEBUG2, and DEBUG3

### What issues does this PR fix or reference?
Fixes #1728 
Fixes #1713 
Provides possibility to get helpful logs for cases like in #1662 

#### Changelog
Adds logging for project synchronization errors.
Adds throughput limits for project synchronization.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
n/a

#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
n/a