### PR TITLE
PG configuration according http://dalibo.github.io/pgbadger/ 

### DIFF
--- a/dockerfiles/init/modules/postgres/templates/postgresql.conf.erb
+++ b/dockerfiles/init/modules/postgres/templates/postgresql.conf.erb
@@ -415,9 +415,10 @@ log_min_duration_statement = 0
 log_checkpoints = on
 log_connections = on
 log_disconnections = on
-#log_duration = off
+log_duration = off
 log_error_verbosity = default		# terse, default, or verbose messages
 #log_hostname = off
+log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d '
 #log_line_prefix = ''			# special values:
 					#   %a = application name
 					#   %u = user name
@@ -439,7 +440,7 @@ log_error_verbosity = default		# terse, default, or verbose messages
 					#   %% = '%'
 					# e.g. '<%u%%%d> '
 log_lock_waits = on			# log lock waits >= deadlock_timeout
-log_statement = 'all'			# none, ddl, mod, all
+log_statement = 'none'			# none, ddl, mod, all
 #log_replication_commands = off
 log_temp_files = 0			# log temporary files equal or larger
 					# than the specified size in kilobytes;


### PR DESCRIPTION



### What does this PR do?

I would like to change postgresql configuration to be able to use pgbadger to analyse postgresql state.
Example of report
https://transfer.sh/itzox/out.html
http://dalibo.github.io/pgbadger/samplev7.html

Also we might think about set ``` log_min_duration_statement = 0```  I think now we already doing that by ```log_statement = 'all'```

### What issues does this PR fix or reference?


#### Changelog
Change postgresql configuration to be able to use pgbadger to generate usage reports
#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->