### PR TITLE
INFRA-68; add 'classes' classifier for IDE war compiling

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -478,12 +478,10 @@
                             <targetPath>WEB-INF/lib</targetPath>
                         </resource>
                     </webResources>
-                    <packagingExcludes>
-                        WEB-INF/lib/*gwt*.jar,
+                    <packagingExcludes>WEB-INF/lib/*gwt*.jar,
                         WEB-INF/lib/gin-*.jar,
                         WEB-INF/lib/*codemirror-resources*.jar,
-                        WEB-INF/lib/jsr305*.jar
-                    </packagingExcludes>
+                        WEB-INF/lib/jsr305*.jar</packagingExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/assembly/compiling-ide-war/pom.xml
+++ b/assembly/compiling-ide-war/pom.xml
@@ -466,6 +466,7 @@
                         WEB-INF/classes/META-INF/,
                         _app/**</packagingIncludes>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <attachClasses>true</attachClasses>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,12 @@
                 <groupId>com.codenvy.onpremises</groupId>
                 <artifactId>compiling-ide-war</artifactId>
                 <version>${project.version}</version>
+                <classifier>classes</classifier>
+            </dependency>
+            <dependency>
+                <groupId>com.codenvy.onpremises</groupId>
+                <artifactId>compiling-ide-war</artifactId>
+                <version>${project.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>


### PR DESCRIPTION
### What does this PR do?
Adds 'classes' classifier for IDE war compiling, to allow archetypes  make dependency on it.

### What issues does this PR fix or reference?
INFRA-68

#### Changelog
Added 'classes' classifier for IDE war compiling, to allow archetypes  make dependency on it.

#### Release Notes
N/A


#### Docs PR
N/A