### PR TITLE
Clean up organize code

### DIFF
--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -190,7 +190,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-java-ext-lang-server</artifactId>
+            <artifactId>che-plugin-java-lang-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -254,7 +254,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-svn-ext-server</artifactId>
+            <artifactId>che-plugin-svn-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>

--- a/assembly/compiling-ide-war/pom.xml
+++ b/assembly/compiling-ide-war/pom.xml
@@ -144,6 +144,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-composer-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-cpp-lang-ide</artifactId>
         </dependency>
         <dependency>
@@ -160,6 +164,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-dashboard-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-debugger-ide</artifactId>
         </dependency>
         <dependency>
@@ -168,19 +176,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-dashboard-ide</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-composer-ide</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-gdb-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-git-ide </artifactId>
+            <artifactId>che-plugin-git-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -188,7 +188,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-gwt-ext-gwt</artifactId>
+            <artifactId>che-plugin-gwt-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>

--- a/assembly/compiling-ide-war/pom.xml
+++ b/assembly/compiling-ide-war/pom.xml
@@ -168,7 +168,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-ext-dashboard-client</artifactId>
+            <artifactId>che-plugin-dashboard-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-composer-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -176,7 +180,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-git-ext-git</artifactId>
+            <artifactId>che-plugin-git-ide </artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -188,7 +192,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-help-ext-client</artifactId>
+            <artifactId>che-plugin-help-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -196,15 +200,15 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-java-ext-lang-client</artifactId>
+            <artifactId>che-plugin-java-lang-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-java-ext-lang-server</artifactId>
+            <artifactId>che-plugin-java-lang-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-java-ext-lang-shared</artifactId>
+            <artifactId>che-plugin-java-lang-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -280,7 +284,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-svn-ext-ide</artifactId>
+            <artifactId>che-plugin-svn-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
@@ -296,7 +300,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-web-ext-web</artifactId>
+            <artifactId>che-plugin-web-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>

--- a/assembly/compiling-ide-war/src/main/resources/com/codenvy/ide/IDE.gwt.xml
+++ b/assembly/compiling-ide-war/src/main/resources/com/codenvy/ide/IDE.gwt.xml
@@ -67,6 +67,7 @@
     <inherits name='org.eclipse.che.plugin.gdb.Gdb'/>
     <inherits name='org.eclipse.che.plugin.git.Git'/>
     <inherits name='org.eclipse.che.plugin.github.GitHub'/>
+    <inherits name='org.eclipse.che.plugin.gwt.GWT'/>
     <inherits name='org.eclipse.che.plugin.help.HelpAboutExtension'/>
     <inherits name='org.eclipse.che.plugin.java.plain.PlainJava'/>
     <inherits name='org.eclipse.che.plugin.jdb.JavaDebugger'/>
@@ -89,9 +90,9 @@
 
 
     <!--Hosted specific -->
-    <inherits name='com.codenvy.ide.profile.Profile'/>
-    <inherits name='com.codenvy.ide.hosted.Hosted'/>
     <inherits name='com.codenvy.ide.factory.Factory'/>
+    <inherits name='com.codenvy.ide.hosted.Hosted'/>
+    <inherits name='com.codenvy.ide.profile.Profile'/>
     <inherits name='com.codenvy.plugin.product.info.ProductInfo'/>
     <inherits name='com.codenvy.plugin.pullrequest.PullRequest'/>
     <inherits name='com.codenvy.plugin.pullrequest.BitbucketPullRequest'/>
@@ -100,6 +101,9 @@
     <!--
     <inherits name='com.codenvy.api.subscription.Subscription'/>
     -->
+
+    <inherits name='org.eclipse.che.ide.extension.machine.Machine'/>
+    <inherits name='org.eclipse.che.ide.ext.ssh.MachineSsh'/>
 
     <inherits name='com.codenvy.machine.authentication.Authentication'/>
 

--- a/assembly/compiling-ide-war/src/main/resources/com/codenvy/ide/IDE.gwt.xml
+++ b/assembly/compiling-ide-war/src/main/resources/com/codenvy/ide/IDE.gwt.xml
@@ -33,71 +33,70 @@
     <!-- the theme of your GWT application by uncommenting          -->
     <!-- any one of the following lines.                            -->
     <inherits name='com.google.gwt.user.theme.standard.Standard'/>
-    <!-- <inherits name='com.google.gwt.user.theme.chrome.Chrome'/> -->
-    <!-- <inherits name='com.google.gwt.user.theme.dark.Dark'/>     -->
 
-    <!-- Core module inherits                                       -->
-    <inherits name="org.eclipse.che.orion.CheOrion"/>
-    <inherits name='org.eclipse.che.ide.Api'/>
+    <!-- API module inherits                                       -->
+    <inherits name='org.eclipse.che.api.auth.Auth'/>
+    <inherits name='org.eclipse.che.api.core.Core'/>
     <inherits name='org.eclipse.che.api.core.model.Model'/>
+    <inherits name="org.eclipse.che.api.debug.Debug"/>
+    <inherits name='org.eclipse.che.api.git.Git'/>
+    <inherits name='org.eclipse.che.api.factory.Factory'/>
+    <inherits name="org.eclipse.che.api.languageserver.LanguageServer"/>
+    <inherits name='org.eclipse.che.api.machine.Machine'/>
+    <inherits name='org.eclipse.che.api.project.Project'/>
+    <inherits name="org.eclipse.che.api.ssh.Ssh"/>
+    <inherits name="org.eclipse.che.api.testing.Testing"/>
+    <inherits name='org.eclipse.che.api.user.User'/>
+    <inherits name="org.eclipse.che.api.workspace.Workspace"/>
+
+
+    <!-- IDE Core module inherits                                       -->
+    <inherits name='org.eclipse.che.ide.Api'/>
     <inherits name="org.eclipse.che.ide.Core"/>
     <inherits name="org.eclipse.che.ide.ui.CodenvyUI"/>
+    <inherits name="org.eclipse.che.orion.CheOrion"/>
 
-    <!-- Extensions                                                 -->
-    <inherits name='org.eclipse.che.ide.ext.help.HelpAboutExtension'/>
-    <inherits name='org.eclipse.che.ide.ext.web.Web'/>
-    <inherits name='org.eclipse.che.plugin.debugger.Debugger'/>
-    <inherits name='org.eclipse.che.plugin.gdb.Gdb'/>
-    <inherits name='org.eclipse.che.plugin.nodejsdbg.NodeJsDebugger'/>
-    <inherits name='org.eclipse.che.plugin.jdb.JavaDebugger'/>
-    <inherits name='org.eclipse.che.plugin.zdb.ZendDebugger'/>
-    <inherits name='org.eclipse.che.ide.extension.machine.Machine'/>
-    <inherits name='org.eclipse.che.plugin.maven.Maven'/>
-    <inherits name='org.eclipse.che.ide.ext.dashboard.Dashboard'/>
-    <inherits name='org.eclipse.che.ide.ext.git.Git'/>
-    <inherits name='org.eclipse.che.plugin.github.GitHub'/>
-    <inherits name='org.eclipse.che.plugin.svn.Subversion'/>
-    <inherits name='org.eclipse.che.ide.ext.ssh.MachineSsh'/>
-    <inherits name='org.eclipse.che.plugin.ssh.key.SshKey'/>
-    <inherits name='org.eclipse.che.ide.editor.orion.OrionEditor'/>
-    <inherits name="org.eclipse.che.ide.orion.OrionCompare"/>
-    <inherits name='org.eclipse.che.plugin.php.Php'/>
-    <inherits name='com.codenvy.plugin.product.info.ProductInfo'/>
-    <inherits name='com.codenvy.plugin.pullrequest.PullRequest'/>
-    <inherits name='com.codenvy.plugin.pullrequest.BitbucketPullRequest'/>
-    <inherits name='com.codenvy.plugin.pullrequest.GithubPullRequest'/>
-    <inherits name='com.codenvy.plugin.pullrequest.VstsPullRequest'/>
 
+    <!-- Plugins module inherits                                        -->
+    <inherits name='org.eclipse.che.plugin.composer.Composer'/>
     <inherits name='org.eclipse.che.plugin.cpp.Cpp'/>
     <inherits name='org.eclipse.che.plugin.csharp.CSharp'/>
-    <inherits name='org.eclipse.che.plugin.python.Python'/>
-    <inherits name='org.eclipse.che.plugin.java.plain.PlainJava'/>
-    <inherits name='org.eclipse.che.plugin.nodejs.NodeJs'/>
+    <inherits name='org.eclipse.che.plugin.debugger.Debugger'/>
+    <inherits name='org.eclipse.che.plugin.dashboard.Dashboard'/>
     <inherits name='org.eclipse.che.plugin.docker.client.dto.Dto'/>
+    <inherits name='org.eclipse.che.plugin.gdb.Gdb'/>
+    <inherits name='org.eclipse.che.plugin.git.Git'/>
+    <inherits name='org.eclipse.che.plugin.github.GitHub'/>
+    <inherits name='org.eclipse.che.plugin.help.HelpAboutExtension'/>
+    <inherits name='org.eclipse.che.plugin.java.plain.PlainJava'/>
+    <inherits name='org.eclipse.che.plugin.jdb.JavaDebugger'/>
     <inherits name='org.eclipse.che.plugin.languageserver.LanguageServer'/>
+    <inherits name='org.eclipse.che.plugin.maven.Maven'/>
+    <inherits name='org.eclipse.che.plugin.nodejsdbg.NodeJsDebugger'/>
+    <inherits name='org.eclipse.che.plugin.nodejs.NodeJs'/>
+    <inherits name='org.eclipse.che.plugin.php.Php'/>
+    <inherits name='org.eclipse.che.plugin.python.Python'/>
+    <inherits name="org.eclipse.che.plugin.orion.compare.OrionCompare"/>
+    <inherits name="org.eclipse.che.plugin.orion.editor.OrionEditor"/>
+    <inherits name='org.eclipse.che.plugin.svn.Subversion'/>
+    <inherits name="org.eclipse.che.plugin.ssh.key.SshKey"/>
     <inherits name="org.eclipse.che.plugin.testing.TestingExtension"/>
     <inherits name="org.eclipse.che.plugin.testing.junit.JUnit"/>
     <inherits name="org.eclipse.che.plugin.testing.testng.TestNG"/>
+    <inherits name='org.eclipse.che.plugin.web.Web'/>
+    <inherits name='org.eclipse.che.plugin.zdb.ZendDebugger'/>
 
-    <!-- Platform API GWT client dependencies                       -->
-    <inherits name='org.eclipse.che.api.core.model.Model'/>
-    <inherits name='org.eclipse.che.api.auth.Auth'/>
-    <inherits name='org.eclipse.che.api.core.Core'/>
-    <inherits name='org.eclipse.che.api.machine.Machine'/>
-    <inherits name='org.eclipse.che.api.git.Git'/>
-    <inherits name='org.eclipse.che.api.project.Project'/>
-    <inherits name='org.eclipse.che.api.user.User'/>
-    <inherits name='org.eclipse.che.api.factory.Factory'/>
-    <inherits name="org.eclipse.che.api.workspace.Workspace"/>
-    <inherits name="org.eclipse.che.api.testing.Testing"/>
-    <inherits name="org.eclipse.che.api.ssh.Ssh"/>
-    <inherits name="org.eclipse.che.api.debug.Debug"/>
-    <inherits name="org.eclipse.che.api.languageserver.LanguageServer"/>
+
 
     <!--Hosted specific -->
     <inherits name='com.codenvy.ide.profile.Profile'/>
     <inherits name='com.codenvy.ide.hosted.Hosted'/>
     <inherits name='com.codenvy.ide.factory.Factory'/>
+    <inherits name='com.codenvy.plugin.product.info.ProductInfo'/>
+    <inherits name='com.codenvy.plugin.pullrequest.PullRequest'/>
+    <inherits name='com.codenvy.plugin.pullrequest.BitbucketPullRequest'/>
+    <inherits name='com.codenvy.plugin.pullrequest.GithubPullRequest'/>
+    <inherits name='com.codenvy.plugin.pullrequest.VstsPullRequest'/>
     <!--
     <inherits name='com.codenvy.api.subscription.Subscription'/>
     -->

--- a/plugins/plugin-hosted/codenvy-hosted-ext-factory/src/main/resources/com/codenvy/ide/factory/Factory.gwt.xml
+++ b/plugins/plugin-hosted/codenvy-hosted-ext-factory/src/main/resources/com/codenvy/ide/factory/Factory.gwt.xml
@@ -27,7 +27,7 @@
     <inherits name="org.eclipse.che.api.project.Project"/>
 
     <inherits name="org.eclipse.che.ide.Commons"/>
-    <inherits name="org.eclipse.che.ide.ext.git.Git"/>
+    <inherits name="org.eclipse.che.plugin.git.Git"/>
     <inherits name="org.eclipse.che.security.OAuth"/>
 
     <source path="client"/>

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/pom.xml
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-git-ext-git</artifactId>
+            <artifactId>che-plugin-git-ide </artifactId>
         </dependency>
         <dependency>
             <groupId>org.vectomatic</groupId>

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/pom.xml
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-git-ide </artifactId>
+            <artifactId>che-plugin-git-ide</artifactId>
         </dependency>
         <dependency>
             <groupId>org.vectomatic</groupId>

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/dialogs/commit/CommitPresenter.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/dialogs/commit/CommitPresenter.java
@@ -29,7 +29,7 @@ import static com.codenvy.plugin.pullrequest.client.dialogs.commit.CommitPresent
 import static com.codenvy.plugin.pullrequest.client.dialogs.commit.CommitPresenter.CommitActionHandler.CommitAction.OK;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
-import static org.eclipse.che.ide.ext.git.client.GitUtil.isUnderGit;
+import static org.eclipse.che.plugin.git.ide.GitUtil.isUnderGit;
 
 /**
  * This presenter provides base functionality to commit project changes or not before cloning or generating a factory url.

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/vcs/VcsServiceProvider.java
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/java/com/codenvy/plugin/pullrequest/client/vcs/VcsServiceProvider.java
@@ -19,7 +19,7 @@ import org.eclipse.che.api.core.model.project.ProjectConfig;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 
-import static org.eclipse.che.ide.ext.git.client.GitUtil.isUnderGit;
+import static org.eclipse.che.plugin.git.ide.GitUtil.isUnderGit;
 
 /**
  * Provider for the {@link VcsService}.

--- a/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/resources/com/codenvy/plugin/pullrequest/PullRequest.gwt.xml
+++ b/plugins/plugin-pullrequest/codenvy-plugin-pullrequest-ide/src/main/resources/com/codenvy/plugin/pullrequest/PullRequest.gwt.xml
@@ -22,7 +22,7 @@
     <inherits name="com.google.gwt.json.JSON"/>
     <inherits name="com.google.gwt.inject.Inject"/>
     <inherits name="org.eclipse.che.ide.Api"/>
-    <inherits name="org.eclipse.che.ide.ext.git.Git"/>
+    <inherits name="org.eclipse.che.plugin.git.Git"/>
 
     <source path="client"/>
     <source path="shared"/>


### PR DESCRIPTION
### What does this PR do?

Organize gwt.xml file : sort all GWT modules by alphabet. This is help to manage it and reuse it other packages.

Organize code in some plugins all our plugins should have structure like :

che-plugin-foo-ide;
che-plugin-foo-shared;
che-plugin-foo-server;

#### Changelog
Changed GWT module sorting to alphabetic.

#### Release Notes
 N/A 



