### PR TITLE
CODENVY-1711: Grant permissions to admins for predefined stacks

### DIFF
--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/PermissionsManager.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/PermissionsManager.java
@@ -155,9 +155,11 @@ public class PermissionsManager {
      *         when any other error occurs during permissions fetching
      */
     @SuppressWarnings("unchecked")
-    public Page<AbstractPermissions> getByInstance(String domainId, String instanceId, int maxItems, int skipCount) throws ServerException,
-                                                                                                                           NotFoundException,
-                                                                                                                           ConflictException {
+    public Page<AbstractPermissions> getByInstance(String domainId,
+                                                   String instanceId,
+                                                   int maxItems,
+                                                   long skipCount) throws ServerException,
+                                                                          NotFoundException {
         return (Page<AbstractPermissions>)getPermissionsDao(domainId).getByInstance(instanceId, maxItems, skipCount);
     }
 

--- a/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/SystemDomain.java
+++ b/wsmaster/codenvy-hosted-api-permission/src/main/java/com/codenvy/api/permission/server/SystemDomain.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 public class SystemDomain extends AbstractPermissionsDomain<SystemPermissionsImpl> {
     public static final String SYSTEM_DOMAIN_ACTIONS = "system.domain.actions";
     public static final String DOMAIN_ID             = "system";
-    public static final String MANAGE_SYSTEM_ACTION = "manageSystem";
+    public static final String MANAGE_SYSTEM_ACTION  = "manageSystem";
 
     @Inject
     public SystemDomain(@Named(SYSTEM_DOMAIN_ACTIONS) Set<String> allowedActions) {

--- a/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/StackPermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/StackPermissionsFilter.java
@@ -46,6 +46,7 @@ import static com.codenvy.api.workspace.server.stack.StackDomain.UPDATE;
  * In case when requested method is unknown filter throws {@link ForbiddenException}
  *
  * @author Sergii Leschenko
+ * @author Mykola Morhun
  */
 @Filter
 @Path("/stack{path:(/.*)?}")
@@ -135,7 +136,7 @@ public class StackPermissionsFilter extends CheMethodInvokerFilter {
                 }
             } while ((permissionsPage = getNextPermissionsPage(stackId, permissionsPage)) != null);
         } catch (NotFoundException e) {
-            // should never happens
+            // should never happen
             throw new ServerException(e);
         }
         return false;

--- a/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/StackPermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-workspace/src/main/java/com/codenvy/api/workspace/server/filters/StackPermissionsFilter.java
@@ -14,7 +14,15 @@
  */
 package com.codenvy.api.workspace.server.filters;
 
+import com.codenvy.api.permission.server.PermissionsManager;
+import com.codenvy.api.permission.server.SystemDomain;
+import com.codenvy.api.permission.server.model.impl.AbstractPermissions;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+
 import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.workspace.server.stack.StackService;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -42,6 +50,14 @@ import static com.codenvy.api.workspace.server.stack.StackDomain.UPDATE;
 @Filter
 @Path("/stack{path:(/.*)?}")
 public class StackPermissionsFilter extends CheMethodInvokerFilter {
+
+    private final PermissionsManager permissionsManager;
+
+    @Inject
+    public StackPermissionsFilter(PermissionsManager permissionsManager) {
+        this.permissionsManager = permissionsManager;
+    }
+
     @Override
     public void filter(GenericResourceMethod genericResourceMethod, Object[] arguments) throws ForbiddenException, ServerException {
         final String methodName = genericResourceMethod.getMethod().getName();
@@ -86,8 +102,66 @@ public class StackPermissionsFilter extends CheMethodInvokerFilter {
                 throw new ForbiddenException("The user does not have permission to perform this operation");
         }
 
+        if (currentSubject.hasPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION)
+            && isStackPredefined(stackId)) {
+            // allow any operation with predefined stack if user has 'manageSystem' permission
+            return;
+        }
+
         if (!currentSubject.hasPermission(DOMAIN_ID, stackId, action)) {
             throw new ForbiddenException("The user does not have permission to " + action + " stack with id '" + stackId + "'");
         }
     }
+
+    /**
+     * Determines whether stack is predefined.
+     * Note, that 'predefined' means public for all users (not necessary provided with system from the box).
+     *
+     * @param stackId
+     *         id of stack to test
+     * @return true if stack is predefined, false otherwise
+     * @throws ServerException
+     *         when any error occurs during permissions fetching
+     */
+    @VisibleForTesting
+    boolean isStackPredefined(String stackId) throws ServerException {
+        try {
+            Page<AbstractPermissions> permissionsPage = permissionsManager.getByInstance(DOMAIN_ID, stackId, 25, 0);
+            do {
+                for (AbstractPermissions stackPermission : permissionsPage.getItems()) {
+                    if ("*".equals(stackPermission.getUserId())) {
+                        return true;
+                    }
+                }
+            } while ((permissionsPage = getNextPermissionsPage(stackId, permissionsPage)) != null);
+        } catch (NotFoundException e) {
+            // should never happens
+            throw new ServerException(e);
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves next permissions page for given stack.
+     *
+     * @param stackId
+     *         id of stack to which permissions will be obtained
+     * @param permissionsPage
+     *         previous permissions page
+     * @return next permissions page for given stack or null if next page doesn't exist
+     * @throws ServerException
+     *         when any error occurs during permissions fetching
+     */
+    @VisibleForTesting
+    Page<AbstractPermissions> getNextPermissionsPage(String stackId,
+                                                     Page<AbstractPermissions> permissionsPage) throws NotFoundException,
+                                                                                                       ServerException {
+        if (!permissionsPage.hasNextPage()) {
+            return null;
+        }
+
+        final Page.PageRef nextPageRef = permissionsPage.getNextPageRef();
+        return permissionsManager.getByInstance(DOMAIN_ID, stackId, nextPageRef.getPageSize(), nextPageRef.getItemsBefore());
+    }
+
 }


### PR DESCRIPTION
### What does this PR do?
Allows to users with `manageSystem` permission perform edit and delete operation with predefined (i.e. public for all users) stack.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1711

#### Changelog
Permissions granted to admins to perform `update` and `delete` action with predefined stacks.

#### Release Notes
Added ability to admins with `manageSystem` permission perform `update` and `delete` action with predefined stacks.

#### Docs PR
N/A
