### PR TITLE
do not redirect /agent-binaries to from http to https

### DIFF
--- a/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
+++ b/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
@@ -49,7 +49,9 @@ frontend http-in
     reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ http
 <% if scope.lookupvar('haproxy::host_protocol') == "https" -%>
-    redirect scheme https
+    acl use_agents_http path_beg -i /agent-binaries
+    redirect scheme https if !use_agents_http
+    use_backend agents_bk if use_agents_http
 
 frontend https-in
     bind *:443 ssl crt /etc/haproxy/cert.pem <% if has_variable?('haproxy::haproxy_https_config') %><%= scope.lookupvar('haproxy::haproxy_https_config') %><% else %>no-sslv3 no-tls-tickets ciphers ALL:-ADH:+HIGH:+MEDIUM:-LOW:-SSLv2:-EXP:!RC4:!AECDH<% end %>


### PR DESCRIPTION
### What does this PR do?
allows download agents via http

### What issues does this PR fix or reference?
related to https://github.com/eclipse/che/pull/4029

#### Changelog
allows download agents via http
