### PR TITLE
CODENVY-1253 Add ability to configure workspace idle timeout per account

### DIFF
--- a/dockerfiles/init/manifests/codenvy.env
+++ b/dockerfiles/init/manifests/codenvy.env
@@ -204,6 +204,14 @@
 #     organization will need to stop a running workspace to activate another.
 #CODENVY_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT=10
 
+#     The length of time that a user is idle with their workspace when the system will
+#     suspend the workspace by snapshotting it and then stopping it. Idleness is the
+#     length of time that the user has not interacted with the workspace, meaning that
+#     one of our agents has not received interaction. Leaving a browser window open
+#     counts toward idleness.
+#     Default = 14,400,000 MS (4 hours)
+#CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS=14400000
+
 #     The maximum amount of RAM that a user can allocate to a workspace when they 
 #     create a new workspace. The RAM slider is adjusted to this maximum value.
 #CODENVY_LIMITS_WORKSPACE_ENV_RAM=16gb
@@ -230,15 +238,6 @@
 #     access to systems within your network. This is set when DNS resolvers do not 
 #     parse hostname entries properly.
 #CODENVY_MACHINE_EXTRA_HOSTS=<HOST_1>:<IP_1>,<HOST_2>:<IP_2>
-
-# Idle Timeout
-#     The length of time that a user is idle with their workspace when the system will
-#     suspend the workspace by snapshotting it and then stopping it. Idleness is the 
-#     length of time that the user has not interacted with the workspace, meaning that 
-#     one of our agents has not received interaction. Leaving a browser window open 
-#     counts toward idleness.
-#     Default = 14,400,000 MS (4 hours)
-#CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS=14400000
 
 # Memory
 #     The recommended RAM size that users will see for their workspace when they 

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -214,6 +214,7 @@ node default {
   $limits_organization_workspaces_ram = getValue("CODENVY_LIMITS_ORGANIZATION_WORKSPACES_RAM","100gb")
   $limits_organization_workspaces_count = getValue("CODENVY_LIMITS_ORGANIZATION_WORKSPACES_COUNT","30")
   $limits_organization_workspaces_run_count = getValue("CODENVY_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT","10")
+  $limits_workspace_idle_timeout = getValue("CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS","14400000")
   $limits_workspace_env_ram = getValue("CODENVY_LIMITS_WORKSPACE_ENV_RAM","16gb")
 # workspace snapshots
   $docker_registry_for_workspace_snapshots = getValue("CODENVY_DOCKER_REGISTRY_FOR_WORKSPACE_SNAPSHOTS","$host_url:5000")
@@ -226,7 +227,6 @@ node default {
 # Codenvy machine configurations
 #
   $machine_extra_hosts = getValue("CODENVY_MACHINE_EXTRA_HOSTS","NULL")
-  $machine_ws_agent_inactive_stop_timeout_ms = getValue("CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS","14400000")
   $machine_default_mem_size_mb = getValue("CODENVY_MACHINE_DEFAULT_MEM_SIZE_MB","1024")
   $machine_ws_agent_max_start_time_ms = getValue("CODENVY_MACHINE_WS_AGENT_MAX_START_TIME_MS","300000")
   $machine_ws_agent_run_command = getValue("CODENVY_MACHINE_WS_AGENT_RUN_COMMAND","~/che/ws-agent/bin/catalina.sh run")

--- a/dockerfiles/init/modules/codenvy/templates/general.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/general.properties.erb
@@ -40,6 +40,7 @@ limits.user.workspaces.ram=<%= scope.lookupvar('codenvy::limits_user_workspaces_
 limits.organization.workspaces.ram=<%= scope.lookupvar('codenvy::limits_organization_workspaces_ram') %>
 limits.organization.workspaces.count=<%= scope.lookupvar('codenvy::limits_organization_workspaces_count') %>
 limits.organization.workspaces.run.count=<%= scope.lookupvar('codenvy::limits_organization_workspaces_run_count') %>
+limits.workspace.idle.timeout=<%= scope.lookupvar('codenvy::limits_workspace_idle_timeout') %>
 limits.workspace.env.ram=<%= scope.lookupvar('codenvy::limits_workspace_env_ram') %>
 limits.workspace.start.throughput=5
 

--- a/dockerfiles/init/modules/codenvy/templates/machine.properties.erb
+++ b/dockerfiles/init/modules/codenvy/templates/machine.properties.erb
@@ -24,7 +24,6 @@ che.workspace.agent.dev.ping_conn_timeout_ms=2000
 che.workspace.agent.dev.ping_timeout_error_msg=Timeout. The Che server is unable to ping your workspace. This implies a network configuration issue, workspace boot failure, or an unusually slow workspace boot.
 
 machine.ws_agent.agent_api.path=/wsagent/ext/
-machine.ws_agent.inactive_stop_timeout_ms=<%= scope.lookupvar('codenvy::machine_ws_agent_inactive_stop_timeout_ms') %>
 
 # When Che start an agent, it performs check if it is launched.
 che.agent.dev.max_start_time_ms=120000

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/DefaultOrganizationResourcesProvider.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/DefaultOrganizationResourcesProvider.java
@@ -17,10 +17,11 @@ package com.codenvy.organization.api.resource;
 import com.codenvy.organization.api.OrganizationManager;
 import com.codenvy.organization.shared.model.Organization;
 import com.codenvy.organization.spi.impl.OrganizationImpl;
+import com.codenvy.resource.api.type.TimeoutResourceType;
 import com.codenvy.resource.api.free.DefaultResourcesProvider;
-import com.codenvy.resource.api.RamResourceType;
-import com.codenvy.resource.api.RuntimeResourceType;
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.RamResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.api.core.NotFoundException;
@@ -32,6 +33,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 
@@ -46,12 +48,15 @@ public class DefaultOrganizationResourcesProvider implements DefaultResourcesPro
     private final long                ramPerOrganization;
     private final int                 workspacesPerOrganization;
     private final int                 runtimesPerOrganization;
+    private final long                timeout;
 
     @Inject
     public DefaultOrganizationResourcesProvider(OrganizationManager organizationManager,
                                                 @Named("limits.organization.workspaces.ram") String ramPerOrganization,
                                                 @Named("limits.organization.workspaces.count") int workspacesPerOrganization,
-                                                @Named("limits.organization.workspaces.run.count") int runtimesPerOrganization) {
+                                                @Named("limits.organization.workspaces.run.count") int runtimesPerOrganization,
+                                                @Named("limits.workspace.idle.timeout") long timeout) {
+        this.timeout = TimeUnit.MILLISECONDS.toMinutes(timeout);
         this.organizationManager = organizationManager;
         this.ramPerOrganization = "-1".equals(ramPerOrganization) ? -1 : Size.parseSizeToMegabytes(ramPerOrganization);
         this.workspacesPerOrganization = workspacesPerOrganization;
@@ -68,7 +73,8 @@ public class DefaultOrganizationResourcesProvider implements DefaultResourcesPro
         final Organization organization = organizationManager.getById(accountId);
         // only root organizations should have own resources
         if (organization.getParent() == null) {
-            return asList(new ResourceImpl(RamResourceType.ID, ramPerOrganization, RamResourceType.UNIT),
+            return asList(new ResourceImpl(TimeoutResourceType.ID, timeout, TimeoutResourceType.UNIT),
+                          new ResourceImpl(RamResourceType.ID, ramPerOrganization, RamResourceType.UNIT),
                           new ResourceImpl(WorkspaceResourceType.ID, workspacesPerOrganization, WorkspaceResourceType.UNIT),
                           new ResourceImpl(RuntimeResourceType.ID, runtimesPerOrganization, RuntimeResourceType.UNIT));
         }

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/OrganizationResourcesDistributor.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/OrganizationResourcesDistributor.java
@@ -130,14 +130,17 @@ public class OrganizationResourcesDistributor {
      * @param suborganizationId
      *         suborganization identifier
      * @return distributed resources for given suborganization
-     * @throws NotFoundException
-     *         when organization with specified id doesn't have distributed resources
+     * or empty list when suborganization doesn't have distributed resources
      * @throws ServerException
      *         when any other error occurs
      */
-    public OrganizationDistributedResources get(String suborganizationId) throws NotFoundException, ServerException {
+    public List<? extends Resource> get(String suborganizationId) throws ServerException {
         requireNonNull(suborganizationId, "Required non-null suborganization id");
-        return organizationDistributedResourcesDao.get(suborganizationId);
+        try {
+            return organizationDistributedResourcesDao.get(suborganizationId).getResources();
+        } catch (NotFoundException e) {
+            return emptyList();
+        }
     }
 
     /**

--- a/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/api/resource/DefaultOrganizationResourcesProviderTest.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/api/resource/DefaultOrganizationResourcesProviderTest.java
@@ -16,9 +16,10 @@ package com.codenvy.organization.api.resource;
 
 import com.codenvy.organization.api.OrganizationManager;
 import com.codenvy.organization.shared.model.Organization;
-import com.codenvy.resource.api.RamResourceType;
-import com.codenvy.resource.api.RuntimeResourceType;
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.RamResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
+import com.codenvy.resource.api.type.TimeoutResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.mockito.Mock;
@@ -54,7 +55,8 @@ public class DefaultOrganizationResourcesProviderTest {
         organizationResourcesProvider = new DefaultOrganizationResourcesProvider(organizationManager,
                                                                                  "2gb",
                                                                                  10,
-                                                                                 5);
+                                                                                 5,
+                                                                                 10 * 60 * 1000);
         when(organizationManager.getById(anyString())).thenReturn(organization);
     }
 
@@ -81,7 +83,10 @@ public class DefaultOrganizationResourcesProviderTest {
 
         //then
         verify(organizationManager).getById("organization123");
-        assertEquals(defaultResources.size(), 3);
+        assertEquals(defaultResources.size(), 4);
+        assertTrue(defaultResources.contains(new ResourceImpl(TimeoutResourceType.ID,
+                                                              10,
+                                                              TimeoutResourceType.UNIT)));
         assertTrue(defaultResources.contains(new ResourceImpl(RamResourceType.ID,
                                                               2048,
                                                               RamResourceType.UNIT)));

--- a/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/api/resource/OrganizationResourcesDistributorTest.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/test/java/com/codenvy/organization/api/resource/OrganizationResourcesDistributorTest.java
@@ -179,10 +179,10 @@ public class OrganizationResourcesDistributorTest {
         when(distributedResourcesDao.get(anyString())).thenReturn(distributedResources);
 
         //when
-        final OrganizationDistributedResources fetchedDistributedResources = distributor.get(ORG_ID);
+        final List<? extends Resource> fetchedDistributedResources = distributor.get(ORG_ID);
 
         //then
-        assertEquals(fetchedDistributedResources, distributedResources);
+        assertEquals(fetchedDistributedResources, distributedResources.getResources());
         verify(distributedResourcesDao).get(ORG_ID);
     }
 

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/ResourceModule.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/ResourceModule.java
@@ -22,6 +22,10 @@ import com.codenvy.resource.api.free.FreeResourcesProvider;
 import com.codenvy.resource.api.license.AccountLicenseService;
 import com.codenvy.resource.api.license.LicenseServicePermissionsFilter;
 import com.codenvy.resource.api.license.ResourcesProvider;
+import com.codenvy.resource.api.type.RamResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
+import com.codenvy.resource.api.type.TimeoutResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.api.usage.ResourceUsageService;
 import com.codenvy.resource.api.usage.ResourceUsageServicePermissionsFilter;
 import com.codenvy.resource.api.usage.ResourcesPermissionsChecker;
@@ -62,6 +66,7 @@ public class ResourceModule extends AbstractModule {
         resourcesTypesBinder.addBinding().to(RamResourceType.class);
         resourcesTypesBinder.addBinding().to(WorkspaceResourceType.class);
         resourcesTypesBinder.addBinding().to(RuntimeResourceType.class);
+        resourcesTypesBinder.addBinding().to(TimeoutResourceType.class);
 
         Multibinder.newSetBinder(binder(), ResourcesPermissionsChecker.class)
                    .addBinding().to(UserResourcesPermissionsChecker.class);

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/free/ResourceValidator.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/free/ResourceValidator.java
@@ -81,5 +81,9 @@ public class ResourceValidator {
                                                    .collect(Collectors.joining(", ")));
             }
         }
+
+        if (resource.getAmount() < 0) {
+            throw new BadRequestException("Resources with type '" + resource.getType() + "' has negative amount");
+        }
     }
 }

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/AbstractExhaustibleResource.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/AbstractExhaustibleResource.java
@@ -12,7 +12,7 @@
  * is strictly forbidden unless prior written permission is obtained
  * from Codenvy S.A..
  */
-package com.codenvy.resource.api;
+package com.codenvy.resource.api.type;
 
 import com.codenvy.resource.api.exception.NoEnoughResourcesException;
 import com.codenvy.resource.model.Resource;

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/RamResourceType.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/RamResourceType.java
@@ -12,21 +12,21 @@
  * is strictly forbidden unless prior written permission is obtained
  * from Codenvy S.A..
  */
-package com.codenvy.resource.api;
+package com.codenvy.resource.api.type;
 
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
 /**
- * Describes resource type that control number of workspaces
- * which user can run at the same time.
+ * Describes resource type that control number of RAM
+ * which can be used by running workspaces at the same time.
  *
- * @author Sergii Leshchenko
+ * @author Sergii Leschenko
  */
-public class RuntimeResourceType extends AbstractExhaustibleResource {
-    public static final String ID   = "runtime";
-    public static final String UNIT = "item";
+public class RamResourceType extends AbstractExhaustibleResource {
+    public static final String ID   = "RAM";
+    public static final String UNIT = "mb";
 
     private static final Set<String> SUPPORTED_UNITS = ImmutableSet.of(UNIT);
 
@@ -37,7 +37,7 @@ public class RuntimeResourceType extends AbstractExhaustibleResource {
 
     @Override
     public String getDescription() {
-        return "Number of workspaces which user can run at the same time";
+        return "Number of RAM which can be used by running workspaces at the same time";
     }
 
     @Override

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/RuntimeResourceType.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/RuntimeResourceType.java
@@ -12,7 +12,7 @@
  * is strictly forbidden unless prior written permission is obtained
  * from Codenvy S.A..
  */
-package com.codenvy.resource.api;
+package com.codenvy.resource.api.type;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -20,12 +20,12 @@ import java.util.Set;
 
 /**
  * Describes resource type that control number of workspaces
- * which user can have at the same time.
+ * which user can run at the same time.
  *
  * @author Sergii Leshchenko
  */
-public class WorkspaceResourceType extends AbstractExhaustibleResource {
-    public static final String ID   = "workspace";
+public class RuntimeResourceType extends AbstractExhaustibleResource {
+    public static final String ID   = "runtime";
     public static final String UNIT = "item";
 
     private static final Set<String> SUPPORTED_UNITS = ImmutableSet.of(UNIT);
@@ -37,7 +37,7 @@ public class WorkspaceResourceType extends AbstractExhaustibleResource {
 
     @Override
     public String getDescription() {
-        return "Number of workspaces which user can have at the same time";
+        return "Number of workspaces which user can run at the same time";
     }
 
     @Override

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/TimeoutResourceType.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/TimeoutResourceType.java
@@ -12,21 +12,25 @@
  * is strictly forbidden unless prior written permission is obtained
  * from Codenvy S.A..
  */
-package com.codenvy.resource.api;
+package com.codenvy.resource.api.type;
 
+import com.codenvy.resource.api.exception.NoEnoughResourcesException;
+import com.codenvy.resource.model.Resource;
+import com.codenvy.resource.model.ResourceType;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
 /**
- * Describes resource type that control number of RAM
- * which can be used by running workspaces at the same time.
+ * Describes resource type that control the length of time
+ * that a user is idle with their workspace when the system
+ * will suspend the workspace by snapshotting it and then stopping it.
  *
  * @author Sergii Leschenko
  */
-public class RamResourceType extends AbstractExhaustibleResource {
-    public static final String ID   = "RAM";
-    public static final String UNIT = "mb";
+public class TimeoutResourceType implements ResourceType {
+    public static final String ID   = "timeout";
+    public static final String UNIT = "minute";
 
     private static final Set<String> SUPPORTED_UNITS = ImmutableSet.of(UNIT);
 
@@ -37,7 +41,7 @@ public class RamResourceType extends AbstractExhaustibleResource {
 
     @Override
     public String getDescription() {
-        return "Number of RAM which can be used by running workspaces at the same time";
+        return "Timeout";
     }
 
     @Override
@@ -48,5 +52,15 @@ public class RamResourceType extends AbstractExhaustibleResource {
     @Override
     public String getDefaultUnit() {
         return UNIT;
+    }
+
+    @Override
+    public Resource aggregate(Resource resourceA, Resource resourceB) {
+        return resourceA.getAmount() > resourceB.getAmount() ? resourceA : resourceB;
+    }
+
+    @Override
+    public Resource deduct(Resource total, Resource deduction) throws NoEnoughResourcesException {
+        return total;
     }
 }

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/WorkspaceResourceType.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/type/WorkspaceResourceType.java
@@ -1,0 +1,52 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.resource.api.type;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * Describes resource type that control number of workspaces
+ * which user can have at the same time.
+ *
+ * @author Sergii Leshchenko
+ */
+public class WorkspaceResourceType extends AbstractExhaustibleResource {
+    public static final String ID   = "workspace";
+    public static final String UNIT = "item";
+
+    private static final Set<String> SUPPORTED_UNITS = ImmutableSet.of(UNIT);
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Number of workspaces which user can have at the same time";
+    }
+
+    @Override
+    public Set<String> getSupportedUnits() {
+        return SUPPORTED_UNITS;
+    }
+
+    @Override
+    public String getDefaultUnit() {
+        return UNIT;
+    }
+}

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTracker.java
@@ -14,7 +14,7 @@
  */
 package com.codenvy.resource.api.usage.tracker;
 
-import com.codenvy.resource.api.RamResourceType;
+import com.codenvy.resource.api.type.RamResourceType;
 import com.codenvy.resource.api.ResourceUsageTracker;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTracker.java
@@ -15,8 +15,7 @@
 package com.codenvy.resource.api.usage.tracker;
 
 import com.codenvy.resource.api.ResourceUsageTracker;
-import com.codenvy.resource.api.RuntimeResourceType;
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.account.api.AccountManager;

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTracker.java
@@ -15,7 +15,7 @@
 package com.codenvy.resource.api.usage.tracker;
 
 import com.codenvy.resource.api.ResourceUsageTracker;
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.account.api.AccountManager;

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/free/DefaultUserResourcesProviderTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/free/DefaultUserResourcesProviderTest.java
@@ -14,17 +14,20 @@
  */
 package com.codenvy.resource.api.free;
 
-import com.codenvy.resource.api.RuntimeResourceType;
-import com.codenvy.resource.api.RamResourceType;
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.TimeoutResourceType;
+import com.codenvy.resource.api.type.RamResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for {@link DefaultUserResourcesProvider}
@@ -36,7 +39,7 @@ public class DefaultUserResourcesProviderTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        resourcesProvider = new DefaultUserResourcesProvider("2gb", 10, 5);
+        resourcesProvider = new DefaultUserResourcesProvider(20 * 60 * 1000, "2gb", 10, 5);
     }
 
     @Test
@@ -45,7 +48,7 @@ public class DefaultUserResourcesProviderTest {
         final String accountType = resourcesProvider.getAccountType();
 
         //then
-        Assert.assertEquals(accountType, UserImpl.PERSONAL_ACCOUNT);
+        assertEquals(accountType, UserImpl.PERSONAL_ACCOUNT);
     }
 
     @Test
@@ -54,16 +57,18 @@ public class DefaultUserResourcesProviderTest {
         final List<ResourceImpl> defaultResources = resourcesProvider.getResources("user123");
 
         //then
-        Assert.assertEquals(defaultResources.size(), 3);
-        Assert.assertTrue(defaultResources.contains(new ResourceImpl(RamResourceType.ID,
-                                                                     2048,
-                                                                     RamResourceType.UNIT)));
-        Assert.assertTrue(defaultResources.contains(new ResourceImpl(WorkspaceResourceType.ID,
-                                                                     10,
-                                                                     WorkspaceResourceType.UNIT)));
-        Assert.assertTrue(defaultResources.contains(new ResourceImpl(RuntimeResourceType.ID,
-                                                                     5,
-                                                                     RuntimeResourceType.UNIT)));
-
+        assertEquals(defaultResources.size(), 4);
+        assertTrue(defaultResources.contains(new ResourceImpl(RamResourceType.ID,
+                                                              2048,
+                                                              RamResourceType.UNIT)));
+        assertTrue(defaultResources.contains(new ResourceImpl(WorkspaceResourceType.ID,
+                                                              10,
+                                                              WorkspaceResourceType.UNIT)));
+        assertTrue(defaultResources.contains(new ResourceImpl(RuntimeResourceType.ID,
+                                                              5,
+                                                              RuntimeResourceType.UNIT)));
+        assertTrue(defaultResources.contains(new ResourceImpl(TimeoutResourceType.ID,
+                                                              20,
+                                                              TimeoutResourceType.UNIT)));
     }
 }

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/free/ResourceValidatorTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/free/ResourceValidatorTest.java
@@ -73,6 +73,16 @@ public class ResourceValidatorTest {
                                      .withUnit("kb"));
     }
 
+    @Test(expectedExceptions = BadRequestException.class,
+          expectedExceptionsMessageRegExp = "Resources with type 'test' has negative amount")
+    public void shouldThrowBadRequestExceptionWhenResourceHasNegativeAmount() throws Exception {
+        //when
+        validator.validate(DtoFactory.newDto(ResourceDto.class)
+                                     .withType(RESOURCE_TYPE)
+                                     .withAmount(-1)
+                                     .withUnit("mb"));
+    }
+
     @Test
     public void shouldSetDefaultResourceUnitWhenItIsMissed() throws Exception {
         //given

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/type/AbstractExhaustibleResourceTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/type/AbstractExhaustibleResourceTest.java
@@ -12,7 +12,7 @@
  * is strictly forbidden unless prior written permission is obtained
  * from Codenvy S.A..
  */
-package com.codenvy.resource.api;
+package com.codenvy.resource.api.type;
 
 import com.codenvy.resource.api.exception.NoEnoughResourcesException;
 import com.codenvy.resource.model.Resource;

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTrackerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RamResourceUsageTrackerTest.java
@@ -14,8 +14,7 @@
  */
 package com.codenvy.resource.api.usage.tracker;
 
-import com.codenvy.resource.api.RamResourceType;
-import com.codenvy.resource.api.usage.tracker.RamResourceUsageTracker;
+import com.codenvy.resource.api.type.RamResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.account.api.AccountManager;

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTrackerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/RuntimeResourceUsageTrackerTest.java
@@ -14,7 +14,7 @@
  */
 package com.codenvy.resource.api.usage.tracker;
 
-import com.codenvy.resource.api.RuntimeResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.account.api.AccountManager;

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTrackerTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/usage/tracker/WorkspaceResourceUsageTrackerTest.java
@@ -14,13 +14,12 @@
  */
 package com.codenvy.resource.api.usage.tracker;
 
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.spi.impl.ResourceImpl;
 
 import org.eclipse.che.account.api.AccountManager;
 import org.eclipse.che.account.shared.model.Account;
 import org.eclipse.che.api.core.NotFoundException;
-import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.mockito.InjectMocks;

--- a/wsmaster/codenvy-hosted-integration-tests/codenvy-integration-cascade-jpa/src/test/java/com/codenvy/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
+++ b/wsmaster/codenvy-hosted-integration-tests/codenvy-integration-cascade-jpa/src/test/java/com/codenvy/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
@@ -35,7 +35,7 @@ import com.codenvy.organization.shared.model.Organization;
 import com.codenvy.organization.spi.MemberDao;
 import com.codenvy.organization.spi.impl.MemberImpl;
 import com.codenvy.organization.spi.impl.OrganizationImpl;
-import com.codenvy.resource.api.RamResourceType;
+import com.codenvy.resource.api.type.RamResourceType;
 import com.codenvy.resource.api.ResourceLockKeyProvider;
 import com.codenvy.resource.api.ResourceUsageTracker;
 import com.codenvy.resource.api.ResourcesReserveTracker;
@@ -352,7 +352,7 @@ public class JpaEntitiesCascadeRemovalTest {
         assertNull(notFoundToNull(() -> freeResourcesLimitDao.get(user2.getId())));
 
         // distributed resources is removed
-        assertNull(notFoundToNull(() -> organizationResourcesDistributor.get(childOrganization.getId())));
+        assertTrue(organizationResourcesDistributor.get(childOrganization.getId()).isEmpty());
 
         //cleanup
         stackDao.remove(stack3.getId());

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -15,9 +15,9 @@
 package com.codenvy.api.workspace;
 
 import com.codenvy.api.workspace.LimitsCheckingWorkspaceManager.WorkspaceCallback;
-import com.codenvy.resource.api.RamResourceType;
-import com.codenvy.resource.api.RuntimeResourceType;
-import com.codenvy.resource.api.WorkspaceResourceType;
+import com.codenvy.resource.api.type.RamResourceType;
+import com.codenvy.resource.api.type.RuntimeResourceType;
+import com.codenvy.resource.api.type.WorkspaceResourceType;
 import com.codenvy.resource.api.exception.NoEnoughResourcesException;
 import com.codenvy.resource.api.usage.ResourceUsageManager;
 import com.codenvy.resource.spi.impl.ResourceImpl;

--- a/wsmaster/codenvy-hosted-workspace-activity/pom.xml
+++ b/wsmaster/codenvy-hosted-workspace-activity/pom.xml
@@ -27,6 +27,10 @@
     <name>Codenvy :: Hosted :: Workspace Activity</name>
     <dependencies>
         <dependency>
+            <groupId>com.codenvy.onpremises.wsmaster</groupId>
+            <artifactId>codenvy-hosted-api-resource</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/wsmaster/codenvy-hosted-workspace-activity/src/main/java/com/codenvy/activity/server/WorkspaceActivityManager.java
+++ b/wsmaster/codenvy-hosted-workspace-activity/src/main/java/com/codenvy/activity/server/WorkspaceActivityManager.java
@@ -14,25 +14,32 @@
  */
 package com.codenvy.activity.server;
 
+import com.codenvy.resource.api.type.TimeoutResourceType;
+import com.codenvy.resource.api.usage.ResourceUsageManager;
+import com.codenvy.resource.model.Resource;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 
+import org.eclipse.che.account.api.AccountManager;
+import org.eclipse.che.account.shared.model.Account;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.commons.schedule.ScheduleRate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Named;
 import javax.inject.Singleton;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.codenvy.activity.shared.Constants.ACTIVITY_CHECKER;
@@ -42,7 +49,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STOPPED_B
  * Stops the inactive workspaces by given expiration time.
  *
  * <p>Note that the workspace is not stopped immediately, scheduler will stop the workspaces with one minute rate.
- * If workspace expiry period is negative, then workspace would not be stopped automatically.
+ * If workspace idle timeout is negative, then workspace would not be stopped automatically.
  *
  * @author Anton Korneta
  */
@@ -51,17 +58,20 @@ public class WorkspaceActivityManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(WorkspaceActivityManager.class);
 
-    private final long               expirePeriod;
-    private final Map<String, Long>  activeWorkspaces;
-    private final WorkspaceManager   workspaceManager;
-    private final EventService       eventService;
-    private final EventSubscriber<?> workspaceEventsSubscriber;
+    private final ResourceUsageManager resourceUsageManager;
+    private final AccountManager       accountManager;
+    private final Map<String, Long>    activeWorkspaces;
+    private final WorkspaceManager     workspaceManager;
+    private final EventService         eventService;
+    private final EventSubscriber<?>   workspaceEventsSubscriber;
 
     @Inject
-    public WorkspaceActivityManager(@Named("machine.ws_agent.inactive_stop_timeout_ms") long expirePeriod,
+    public WorkspaceActivityManager(ResourceUsageManager resourceUsageManager,
+                                    AccountManager accountManager,
                                     WorkspaceManager workspaceManager,
                                     EventService eventService) {
-        this.expirePeriod = expirePeriod;
+        this.resourceUsageManager = resourceUsageManager;
+        this.accountManager = accountManager;
         this.workspaceManager = workspaceManager;
         this.eventService = eventService;
         this.activeWorkspaces = new ConcurrentHashMap<>();
@@ -99,16 +109,33 @@ public class WorkspaceActivityManager {
      *         moment in which the activity occurred
      */
     public void update(String wsId, long activityTime) {
-        if (expirePeriod > 0) {
-            activeWorkspaces.put(wsId, activityTime + expirePeriod);
+        try {
+            long timeout = getIdleTimeout(wsId);
+            if (timeout > 0) {
+                activeWorkspaces.put(wsId, activityTime + timeout * 60 * 1000);
+            }
+        } catch (NotFoundException | ServerException e) {
+            LOG.error(e.getLocalizedMessage(), e);
+        }
+    }
+
+    private long getIdleTimeout(String workspaceId) throws NotFoundException, ServerException {
+        WorkspaceImpl workspace = workspaceManager.getWorkspace(workspaceId);
+        Account account = accountManager.getByName(workspace.getNamespace());
+        List<? extends Resource> availableResources = resourceUsageManager.getAvailableResources(account.getId());
+        Optional<? extends Resource> timeoutOpt = availableResources.stream()
+                                                                    .filter(resource -> TimeoutResourceType.ID.equals(resource.getType()))
+                                                                    .findAny();
+
+        if (timeoutOpt.isPresent()) {
+            return timeoutOpt.get().getAmount();
+        } else {
+            return -1;
         }
     }
 
     @ScheduleRate(periodParameterName = "stop.workspace.scheduler.period")
     private void invalidate() {
-        if (expirePeriod <= 0) {
-            return;
-        }
         final long currentTime = System.currentTimeMillis();
         for (Map.Entry<String, Long> workspaceExpireEntry : activeWorkspaces.entrySet()) {
             if (workspaceExpireEntry.getValue() <= currentTime) {
@@ -136,13 +163,6 @@ public class WorkspaceActivityManager {
     @VisibleForTesting
     @PostConstruct
     void subscribe() {
-        if (expirePeriod > 0) {
-            eventService.subscribe(workspaceEventsSubscriber);
-        }
-    }
-
-    @PreDestroy
-    private void unsubscribe() {
-        eventService.unsubscribe(workspaceEventsSubscriber);
+        eventService.subscribe(workspaceEventsSubscriber);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Add ability to configure workspace idle timeout per account. 
By default users' workspaces will have timeout that are configured by `limits.workspace.idle.timeout` configuration property (following codenvy environment property `CODENVY_LIMITS_WORKSPACE_IDLE_TIMEOUT` that is renamed from `CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS`).
User who has `manageSystem` permissions is able to override this value for an user by sending POST request to {HOST}/api/resources/free with following body
```
{
  "accountId": "{USER_ID_HERE}",
  "resources": [
    {
      "type": "timeout",
      "amount": {REQUIRED_IDLE_TIMEOUT_HERE},
      "unit": "minute"
    }
  ]
}
```
P.S. This PR also contains changes that fix small issues with resources validation and error messages when user doesn't have enough resources to start or create workspace.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1253

#### Changelog
Added ability to configure workspace idle timeout per account.

#### Release Notes
Added ability to configure workspace idle timeout per account.

#### Docs PR
https://github.com/codenvy/docs/pull/79