### PR TITLE
[cli] allow to use :/assembly binaries with codenvy cli

### DIFF
--- a/dockerfiles/cli/scripts/cmd_config.sh
+++ b/dockerfiles/cli/scripts/cmd_config.sh
@@ -70,11 +70,11 @@ generate_configuration_with_puppet() {
   WRITE_PARAMETERS=""
 
   if local_repo || local_assembly; then
-    CHE_REPO="on"
     WRITE_PARAMETERS=" -e \"PATH_TO_CHE_ASSEMBLY=${CHE_ASSEMBLY}\""
   fi
 
   if local_repo; then
+    CHE_REPO="on"
     WRITE_PARAMETERS+=" -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${WS_AGENT_ASSEMBLY}\""
 
     # add local mounts only if they are present

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -296,9 +296,9 @@ $machine_docker_parent_cgroup = getValue("CODENVY_DOCKER_PARENT_CGROUP","NULL")
 # path to codenvy puppet sources for development mode
   $puppet_src_folder = getValue("CHE_CONFIG","/path/to/codenvy/codenvy/puppet/sources")
 # path to codenvy tomcat for development mode
-  $codenvy_development_tomcat = getValue("PATH_TO_CHE_ASSEMBLY","/path/to/codenvy_tomcat")
+  $codenvy_development_tomcat = getValue("PATH_TO_CHE_ASSEMBLY","NULL")
 # path to codenvy ws agent for development mode
-  $codenvy_development_ws_agent = getValue("PATH_TO_WS_AGENT_ASSEMBLY","/path/to/codenvy_ws_agent")
+  $codenvy_development_ws_agent = getValue("PATH_TO_WS_AGENT_ASSEMBLY","NULL")
 # codenvy debug port
   $codenvy_debug_port = getValue("CODENVY_DEBUG_PORT","8000")
 # codenvy debug suspend

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -198,7 +198,7 @@ services:
     image: <%= ENV["IMAGE_AGENTS"] %>
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/lighttpd/lighttpd.conf:/etc/lighttpd/lighttpd.conf'
-<% if scope.lookupvar('compose::codenvy_repo') == 'on' -%>
+<% if scope.lookupvar('compose::codenvy_development_ws_agent') != 'NULL' -%>
       - '<%= scope.lookupvar('compose::codenvy_development_ws_agent') -%>:/data/ws-agent.tar.gz'
 <% end -%>
 <% if scope.lookupvar('compose::env') != 'production' -%>
@@ -240,7 +240,7 @@ services:
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/codenvy/che-machines/:/opt/codenvy-data/che-machines/'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/conf:/opt/codenvy-data/conf'
        - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/codenvy/conf/server.xml:/opt/codenvy-tomcat/conf/server.xml'
-<% if scope.lookupvar('codenvy::codenvy_repo') == 'on' -%>
+<% if scope.lookupvar('compose::codenvy_development_tomcat') != 'NULL' -%>
        - '<%= scope.lookupvar('compose::codenvy_development_tomcat') -%>:/opt/codenvy-tomcat'
 <% end -%>
     links:


### PR DESCRIPTION
### What does this PR do?
Allow to use :/assembly binaries with codenvy cli
Only :/repo mode was working
it checks that values are provided before trying to use them
For example it was trying to mount wsagent binaries but they're not inside the assembly so string was empty in docker compose file leading to errors
Also CHE_REPO was enabled when using a local assembly while we're not in that mode.

### What issues does this PR fix or reference?
#1770 

#### Changelog
Fix :/assembly volume mouting usage when using codenvy cli

#### Release Notes
N/A bug

#### Docs PR
N/A bug
