### PR TITLE
CODENVY-1829 Add ability to use ws-agent from main assembly

### DIFF
--- a/dockerfiles/cli/scripts/cmd_config.sh
+++ b/dockerfiles/cli/scripts/cmd_config.sh
@@ -73,6 +73,11 @@ generate_configuration_with_puppet() {
     WRITE_PARAMETERS=" -e \"PATH_TO_CHE_ASSEMBLY=${CHE_ASSEMBLY}\""
   fi
 
+  if [[ local_assembly && -f $(echo ${CHE_CONTAINER_ASSEMBLY_FULL_PATH}/lib/${WS_AGENT_ASSEMBLY}) ]]; then
+    info "Using ws-agent from main assembly"
+    WRITE_PARAMETERS+=" -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/codenvy-tomcat/lib/${WS_AGENT_ASSEMBLY}\""
+  fi
+
   if local_repo; then
     CHE_REPO="on"
     WRITE_PARAMETERS+=" -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/${WS_AGENT_ASSEMBLY}\""

--- a/dockerfiles/cli/scripts/cmd_config.sh
+++ b/dockerfiles/cli/scripts/cmd_config.sh
@@ -74,7 +74,7 @@ generate_configuration_with_puppet() {
   fi
 
   if [[ local_assembly && -f $(echo ${CHE_CONTAINER_ASSEMBLY_FULL_PATH}/lib/${WS_AGENT_ASSEMBLY}) ]]; then
-    info "Using ws-agent from main assembly"
+    info "config" "Using ws-agent from main assembly"
     WRITE_PARAMETERS+=" -e \"PATH_TO_WS_AGENT_ASSEMBLY=${CHE_HOST_INSTANCE}/dev/codenvy-tomcat/lib/${WS_AGENT_ASSEMBLY}\""
   fi
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Pull Request Policy: https://github.com/codenvy/planning/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
If Codenvy has been started with /assembly mount, it may contain ws-agent in assembly main (by default location lib/ws-agent.tar.gz). If CLI detects one, it will use this ws-agent.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1829

#### Changelog
The CLI can now use the ws-agent from a mounted assembly.

#### Release Notes
n/a

#### Docs PR
n/a