### PR TITLE
Rename environment property for setting idle timeout

### DIFF
--- a/dockerfiles/init/manifests/codenvy.env
+++ b/dockerfiles/init/manifests/codenvy.env
@@ -210,7 +210,7 @@
 #     one of our agents has not received interaction. Leaving a browser window open
 #     counts toward idleness.
 #     Default = 14,400,000 MS (4 hours)
-#CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS=14400000
+#CODENVY_LIMITS_WORKSPACE_IDLE_TIMEOUT=14400000
 
 #     The maximum amount of RAM that a user can allocate to a workspace when they 
 #     create a new workspace. The RAM slider is adjusted to this maximum value.

--- a/dockerfiles/init/manifests/codenvy.pp
+++ b/dockerfiles/init/manifests/codenvy.pp
@@ -214,7 +214,7 @@ node default {
   $limits_organization_workspaces_ram = getValue("CODENVY_LIMITS_ORGANIZATION_WORKSPACES_RAM","100gb")
   $limits_organization_workspaces_count = getValue("CODENVY_LIMITS_ORGANIZATION_WORKSPACES_COUNT","30")
   $limits_organization_workspaces_run_count = getValue("CODENVY_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT","10")
-  $limits_workspace_idle_timeout = getValue("CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS","14400000")
+  $limits_workspace_idle_timeout = getValue("CODENVY_LIMITS_WORKSPACE_IDLE_TIMEOUT","14400000")
   $limits_workspace_env_ram = getValue("CODENVY_LIMITS_WORKSPACE_ENV_RAM","16gb")
 # workspace snapshots
   $docker_registry_for_workspace_snapshots = getValue("CODENVY_DOCKER_REGISTRY_FOR_WORKSPACE_SNAPSHOTS","$host_url:5000")


### PR DESCRIPTION
### What does this PR do?
CODENVY_MACHINE_WS_AGENT_INACTIVE_STOP_TIMEOUT_MS is renamed to CODENVY_LIMITS_WORKSPACE_IDLE_TIMEOUT.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/pull/1789

#### Changelog
TODO<!-- one line entry to be added to changelog -->

#### Release Notes
TODO<!-- markdown to be included in marketing announcement - N/A for bugs -->

#### Docs PR
TODO<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
