### PR TITLE
Implement resources capping for suborganizations

### DIFF
--- a/wsmaster/codenvy-hosted-api-organization-shared/src/main/java/com/codenvy/organization/shared/dto/OrganizationDistributedResourcesDto.java
+++ b/wsmaster/codenvy-hosted-api-organization-shared/src/main/java/com/codenvy/organization/shared/dto/OrganizationDistributedResourcesDto.java
@@ -34,9 +34,9 @@ public interface OrganizationDistributedResourcesDto extends OrganizationDistrib
     OrganizationDistributedResourcesDto withOrganizationId(String organizationId);
 
     @Override
-    List<ResourceDto> getResources();
+    List<ResourceDto> getResourcesCap();
 
-    void setResources(List<ResourceDto> resources);
+    void setResourcesCap(List<ResourceDto> resourcesCap);
 
-    OrganizationDistributedResourcesDto withResources(List<ResourceDto> resources);
+    OrganizationDistributedResourcesDto withResourcesCap(List<ResourceDto> resourcesCap);
 }

--- a/wsmaster/codenvy-hosted-api-organization-shared/src/main/java/com/codenvy/organization/shared/model/OrganizationDistributedResources.java
+++ b/wsmaster/codenvy-hosted-api-organization-shared/src/main/java/com/codenvy/organization/shared/model/OrganizationDistributedResources.java
@@ -30,7 +30,10 @@ public interface OrganizationDistributedResources {
     String getOrganizationId();
 
     /**
-     * Returns resources that can be used.
+     * Returns resources cap that limit usage of parent organization's resources.
+     *
+     * <p>Note that suborganization is not limited to use parent
+     * organization's resources if resource is not capped.
      */
-    List<? extends Resource> getResources();
+    List<? extends Resource> getResourcesCap();
 }

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/DtoConverter.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/DtoConverter.java
@@ -18,13 +18,13 @@ import com.codenvy.organization.api.event.MemberAddedEvent;
 import com.codenvy.organization.api.event.MemberRemovedEvent;
 import com.codenvy.organization.api.event.OrganizationRemovedEvent;
 import com.codenvy.organization.api.event.OrganizationRenamedEvent;
+import com.codenvy.organization.shared.dto.MemberAddedEventDto;
 import com.codenvy.organization.shared.dto.MemberRemovedEventDto;
-import com.codenvy.organization.shared.dto.OrganizationDistributedResourcesDto;
 import com.codenvy.organization.shared.dto.OrganizationDto;
 import com.codenvy.organization.shared.dto.OrganizationEventDto;
-import com.codenvy.organization.shared.dto.MemberAddedEventDto;
 import com.codenvy.organization.shared.dto.OrganizationRemovedEventDto;
 import com.codenvy.organization.shared.dto.OrganizationRenamedEventDto;
+import com.codenvy.organization.shared.dto.OrganizationDistributedResourcesDto;
 import com.codenvy.organization.shared.event.OrganizationEvent;
 import com.codenvy.organization.shared.model.Organization;
 import com.codenvy.organization.shared.model.OrganizationDistributedResources;
@@ -52,10 +52,10 @@ public final class DtoConverter {
     public static OrganizationDistributedResourcesDto asDto(OrganizationDistributedResources distributedResources) {
         return DtoFactory.newDto(OrganizationDistributedResourcesDto.class)
                          .withOrganizationId(distributedResources.getOrganizationId())
-                         .withResources(distributedResources.getResources()
-                                                            .stream()
-                                                            .map(com.codenvy.resource.api.DtoConverter::asDto)
-                                                            .collect(Collectors.toList()));
+                         .withResourcesCap(distributedResources.getResourcesCap()
+                                                               .stream()
+                                                               .map(com.codenvy.resource.api.DtoConverter::asDto)
+                                                               .collect(Collectors.toList()));
     }
 
     public static OrganizationRemovedEventDto asDto(OrganizationRemovedEvent event) {

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/OrganizationResourcesDistributionService.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/OrganizationResourcesDistributionService.java
@@ -35,7 +35,6 @@ import org.eclipse.che.api.core.rest.Service;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -49,10 +48,11 @@ import java.util.List;
 import java.util.Set;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
- * REST API for resources distribution between suborganizations
+ * REST API for resources distribution between suborganizations.
  *
  * @author Sergii Leschenko
  */
@@ -70,54 +70,71 @@ public class OrganizationResourcesDistributionService extends Service {
     }
 
     @POST
-    @Path("/{suborganizationId}")
+    @Path("/{suborganizationId}/cap")
     @Consumes(APPLICATION_JSON)
-    @ApiOperation(value = "Distribute resources for suborganization.",
-                  notes = "Distributed resources is unavailable for usage by parent organization." +
-                          "Distributed resources should be reset to be available for usage by parent organization.")
-    @ApiResponses({@ApiResponse(code = 204, message = "Resources successfully distributed for suborganization usage"),
+    @ApiOperation(value = "Cap usage of shared resources.",
+                  notes = "By default suborganization is able to use all parent organization resources." +
+                          "Cap allow to limit usage of shared resources by suborganization.")
+    @ApiResponses({@ApiResponse(code = 204, message = "Resources successfully capped"),
                    @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
                    @ApiResponse(code = 404, message = "Specified organization was not found"),
                    @ApiResponse(code = 409, message = "Specified organization is root organization"),
-                   @ApiResponse(code = 409, message = "Parent organization doesn't have enough resources to specified distribution"),
-                   @ApiResponse(code = 409, message = "Suborganization doesn't have enough available resources " +
-                                                      "(which are not in use and not distributed)"),
+                   @ApiResponse(code = 409, message = "Suborganization is using shared resources"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
-    public void distribute(@ApiParam("Suborganization id")
-                           @PathParam("suborganizationId") String suborganizationId,
-                           @ApiParam("Resources to distribute") List<ResourceDto> resources) throws BadRequestException,
-                                                                                                    ServerException,
-                                                                                                    ConflictException,
-                                                                                                    NotFoundException {
+    public void capResources(@ApiParam("Suborganization id")
+                             @PathParam("suborganizationId") String suborganizationId,
+                             @ApiParam("Resources to cap") List<ResourceDto> resourcesCap) throws BadRequestException,
+                                                                                                  NotFoundException,
+                                                                                                  ConflictException,
+                                                                                                  ServerException {
+        checkArgument(resourcesCap != null, "Missed resources caps.");
         Set<String> resourcesToSet = new HashSet<>();
-        for (ResourceDto resource : resources) {
+        for (ResourceDto resource : resourcesCap) {
             if (!resourcesToSet.add(resource.getType())) {
-                throw new BadRequestException(format("Resources to distribute must contain only one resource with type '%s'.",
+                throw new BadRequestException(format("Resources to cap must contain only one resource with type '%s'.",
                                                      resource.getType()));
             }
             resourceValidator.validate(resource);
         }
 
-        resourcesDistributor.distribute(suborganizationId, resources);
+        resourcesDistributor.capResources(suborganizationId, resourcesCap);
+    }
+
+    @GET
+    @Path("/{suborganizationId}/cap")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Get resources cap of specified suborganization.",
+                  response = OrganizationDistributedResourcesDto.class,
+                  responseContainer = "list")
+    @ApiResponses({@ApiResponse(code = 200, message = "Resources caps successfully fetched"),
+                   @ApiResponse(code = 404, message = "Specified organization was not found"),
+                   @ApiResponse(code = 409, message = "Specified organization is root organization"),
+                   @ApiResponse(code = 500, message = "Internal server error occurred")})
+    public List<ResourceDto> getResourcesCap(@ApiParam("Suborganization id")
+                                             @PathParam("suborganizationId") String suborganization) throws NotFoundException,
+                                                                                                            ConflictException,
+                                                                                                            ServerException {
+        return resourcesDistributor.getResourcesCaps(suborganization)
+                                   .stream()
+                                   .map(com.codenvy.resource.api.DtoConverter::asDto)
+                                   .collect(toList());
     }
 
     @GET
     @Path("/{organizationId}")
     @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Get distributed resources for suborganizations.",
+    @ApiOperation(value = "Get resources which are distributed by specified parent.",
                   response = OrganizationDistributedResourcesDto.class,
                   responseContainer = "list")
-    @ApiResponses({@ApiResponse(code = 200, message = "Distributed resources successfully fetched"),
-                   @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
+    @ApiResponses({@ApiResponse(code = 200, message = "Resources caps successfully fetched"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getDistributedResources(@ApiParam("Organization id")
                                             @PathParam("organizationId") String organizationId,
                                             @ApiParam(value = "Max items")
                                             @QueryParam("maxItems") @DefaultValue("30") int maxItems,
                                             @ApiParam(value = "Skip count")
-                                            @QueryParam("skipCount") @DefaultValue("0") long skipCount) throws ServerException,
-                                                                                                               BadRequestException {
-
+                                            @QueryParam("skipCount") @DefaultValue("0") long skipCount) throws BadRequestException,
+                                                                                                               ServerException {
         checkArgument(maxItems >= 0, "The number of items to return can't be negative.");
         checkArgument(skipCount >= 0, "The number of items to skip can't be negative.");
 
@@ -128,22 +145,6 @@ public class OrganizationResourcesDistributionService extends Service {
                        .entity(distributedResourcesPage.getItems(DtoConverter::asDto))
                        .header("Link", createLinkHeader(distributedResourcesPage))
                        .build();
-    }
-
-    @DELETE
-    @Path("/{organizationId}")
-    @ApiOperation(value = "Reset resources distribution.",
-                  notes = "After distribution resetting suborganization won't be able to use parent resources.")
-    @ApiResponses({@ApiResponse(code = 204, message = "Resources distribution successfully reset"),
-                   @ApiResponse(code = 404, message = "Specified organization was not found"),
-                   @ApiResponse(code = 409, message = "Suborganization doesn't have enough available resources " +
-                                                      "(which are not in use and not distributed)"),
-                   @ApiResponse(code = 500, message = "Internal server error occurred")})
-    public void reset(@ApiParam(value = "Organization id")
-                      @PathParam("organizationId") String organizationId) throws ServerException,
-                                                                                 ConflictException,
-                                                                                 NotFoundException {
-        resourcesDistributor.reset(organizationId);
     }
 
     /**

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/OrganizationResourcesReserveTracker.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/resource/OrganizationResourcesReserveTracker.java
@@ -14,10 +14,14 @@
  */
 package com.codenvy.organization.api.resource;
 
+import com.codenvy.organization.api.OrganizationManager;
+import com.codenvy.organization.shared.model.Organization;
 import com.codenvy.resource.api.ResourceAggregator;
 import com.codenvy.resource.api.ResourcesReserveTracker;
+import com.codenvy.resource.api.usage.ResourceUsageManager;
 import com.codenvy.resource.model.Resource;
 
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.Pages;
 import org.eclipse.che.api.core.ServerException;
 
@@ -26,37 +30,47 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.codenvy.organization.spi.impl.OrganizationImpl.ORGANIZATIONAL_ACCOUNT;
 
 /**
- * Makes organization's resources unavailable for usage when organization shares them for its suborganizations.
+ * Makes organization's resources unavailable for usage when suborganization
+ * use shared resources.
  *
  * @author Sergii Leschenko
  */
 @Singleton
 public class OrganizationResourcesReserveTracker implements ResourcesReserveTracker {
-    private final Provider<OrganizationResourcesDistributor> managerProvider;
-    private final ResourceAggregator                         resourceAggregator;
+    private final OrganizationManager            organizationManager;
+    private final ResourceAggregator             resourceAggregator;
+    private final Provider<ResourceUsageManager> usageManagerProvider;
 
     @Inject
-    public OrganizationResourcesReserveTracker(Provider<OrganizationResourcesDistributor> managerProvider,
-                                               ResourceAggregator resourceAggregator) {
-        this.managerProvider = managerProvider;
+    public OrganizationResourcesReserveTracker(OrganizationManager organizationManager,
+                                               ResourceAggregator resourceAggregator,
+                                               Provider<ResourceUsageManager> usageManagerProvider) {
+
+        this.organizationManager = organizationManager;
         this.resourceAggregator = resourceAggregator;
+        this.usageManagerProvider = usageManagerProvider;
     }
 
     @Override
     public List<? extends Resource> getReservedResources(String accountId) throws ServerException {
-
-        List<? extends Resource> toReserve = Pages.stream((maxItems, skipCount) ->
-                                                                  managerProvider.get().getByParent(accountId, maxItems, skipCount))
-                                                  .flatMap(distributedResources -> distributedResources.getResources()
-                                                                                                       .stream())
-                                                  .collect(Collectors.toList());
-
-        return new ArrayList<>(resourceAggregator.aggregateByType(toReserve)
+        ResourceUsageManager resourceUsageManager = usageManagerProvider.get();
+        List<Resource> reservedResources = new ArrayList<>();
+        for (Organization suborganization : Pages.iterate((maxItems, skipCount) -> organizationManager.getByParent(accountId,
+                                                                                                                   maxItems,
+                                                                                                                   skipCount))) {
+            try {
+                // make unavailable for parent shared resources that are used
+                reservedResources.addAll(resourceUsageManager.getUsedResources(suborganization.getId()));
+                reservedResources.addAll(resourceUsageManager.getReservedResources(suborganization.getId()));
+            } catch (NotFoundException e) {
+                throw new ServerException(e.getLocalizedMessage(), e);
+            }
+        }
+        return new ArrayList<>(resourceAggregator.aggregateByType(reservedResources)
                                                  .values());
     }
 

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/impl/OrganizationDistributedResourcesImpl.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/impl/OrganizationDistributedResourcesImpl.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
                                     "WHERE r.organization.parent = :parent")
         }
 )
-@Table(name =  "organization_distributed_resources")
+@Table(name = "organization_distributed_resources")
 public class OrganizationDistributedResourcesImpl implements OrganizationDistributedResources {
     @Id
     @Column(name = "organization_id")
@@ -69,23 +69,23 @@ public class OrganizationDistributedResourcesImpl implements OrganizationDistrib
     @JoinTable(name = "organization_distributed_resources_resource",
                joinColumns = @JoinColumn(name = "organization_distributed_resources_id"),
                inverseJoinColumns = @JoinColumn(name = "resource_id"))
-    private List<ResourceImpl> resources;
+    private List<ResourceImpl> resourcesCap;
 
     public OrganizationDistributedResourcesImpl() {
     }
 
     public OrganizationDistributedResourcesImpl(OrganizationDistributedResources organizationDistributedResource) {
         this(organizationDistributedResource.getOrganizationId(),
-             organizationDistributedResource.getResources());
+             organizationDistributedResource.getResourcesCap());
     }
 
     public OrganizationDistributedResourcesImpl(String organizationId,
-                                                List<? extends Resource> resources) {
+                                                List<? extends Resource> resourcesCap) {
         this.organizationId = organizationId;
-        if (resources != null) {
-            this.resources = resources.stream()
-                                      .map(ResourceImpl::new)
-                                      .collect(Collectors.toList());
+        if (resourcesCap != null) {
+            this.resourcesCap = resourcesCap.stream()
+                                            .map(ResourceImpl::new)
+                                            .collect(Collectors.toList());
         }
     }
 
@@ -95,11 +95,11 @@ public class OrganizationDistributedResourcesImpl implements OrganizationDistrib
     }
 
     @Override
-    public List<ResourceImpl> getResources() {
-        if (resources == null) {
-            resources = new ArrayList<>();
+    public List<ResourceImpl> getResourcesCap() {
+        if (resourcesCap == null) {
+            resourcesCap = new ArrayList<>();
         }
-        return resources;
+        return resourcesCap;
     }
 
     @Override
@@ -113,7 +113,7 @@ public class OrganizationDistributedResourcesImpl implements OrganizationDistrib
         final OrganizationDistributedResourcesImpl that = (OrganizationDistributedResourcesImpl)obj;
         return Objects.equals(organizationId, that.organizationId)
                && Objects.equals(organization, that.organization)
-               && getResources().equals(that.getResources());
+               && getResourcesCap().equals(that.getResourcesCap());
     }
 
     @Override
@@ -121,7 +121,7 @@ public class OrganizationDistributedResourcesImpl implements OrganizationDistrib
         int hash = 7;
         hash = 31 * hash + Objects.hashCode(organizationId);
         hash = 31 * hash + Objects.hashCode(organization);
-        hash = 31 * hash + getResources().hashCode();
+        hash = 31 * hash + getResourcesCap().hashCode();
         return hash;
     }
 
@@ -130,7 +130,7 @@ public class OrganizationDistributedResourcesImpl implements OrganizationDistrib
         return "OrganizationDistributedResourcesImpl{" +
                "organizationId='" + organizationId + '\'' +
                ", organization=" + organization +
-               ", resources=" + resources +
+               ", resourcesCaps=" + getResourcesCap() +
                '}';
     }
 }

--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/jpa/JpaOrganizationDistributedResourcesDao.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/spi/jpa/JpaOrganizationDistributedResourcesDao.java
@@ -127,8 +127,8 @@ public class JpaOrganizationDistributedResourcesDao implements OrganizationDistr
         if (existingDistributedResources == null) {
             manager.persist(distributedResources);
         } else {
-            existingDistributedResources.getResources().clear();
-            existingDistributedResources.getResources().addAll(distributedResources.getResources());
+            existingDistributedResources.getResourcesCap().clear();
+            existingDistributedResources.getResourcesCap().addAll(distributedResources.getResourcesCap());
         }
         manager.flush();
     }

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/ResourcesReserveTracker.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/ResourcesReserveTracker.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * Provides information about resources which are not available for usage by account owner.
  *
- * <p>It can be used for example for implementing resources redistribution between accounts or
+ * <p>It can be used for example for implementing resources sharing between accounts or
  * resources usage limitation when limit should be less than account's license has.
  *
  * @author Sergii Leschenko

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/free/FreeResourcesProvider.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/free/FreeResourcesProvider.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
 
@@ -87,12 +88,16 @@ public class FreeResourcesProvider implements ResourcesProvider {
             freeResources.putIfAbsent(resource.getType(), resource);
         }
 
-        return singletonList(new ProvidedResourcesImpl(FREE_RESOURCES_PROVIDER,
-                                                       limitId,
-                                                       accountId,
-                                                       -1L,
-                                                       -1L,
-                                                       freeResources.values()));
+        if (!freeResources.isEmpty()) {
+            return singletonList(new ProvidedResourcesImpl(FREE_RESOURCES_PROVIDER,
+                                                           limitId,
+                                                           accountId,
+                                                           -1L,
+                                                           -1L,
+                                                           freeResources.values()));
+        } else {
+            return emptyList();
+        }
     }
 
     private List<ResourceImpl> getDefaultResources(String accountId) throws NotFoundException, ServerException {

--- a/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/license/AccountLicenseService.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/main/java/com/codenvy/resource/api/license/AccountLicenseService.java
@@ -58,7 +58,7 @@ public class AccountLicenseService {
                    @ApiResponse(code = 404, message = "Account with specified id was not found"),
                    @ApiResponse(code = 500, message = "Internal server error occurred")})
     public AccountLicenseDto getLicense(@ApiParam("Account id")
-                                 @PathParam("accountId") String accountId) throws NotFoundException, ServerException {
+                                        @PathParam("accountId") String accountId) throws NotFoundException, ServerException {
         return asDto(accountAccountLicenseManager.getByAccount(accountId));
     }
 }

--- a/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/free/FreeResourcesProviderTest.java
+++ b/wsmaster/codenvy-hosted-api-resource/src/test/java/com/codenvy/resource/api/free/FreeResourcesProviderTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for {@link FreeResourcesProvider}
@@ -137,15 +138,21 @@ public class FreeResourcesProviderTest {
         List<ProvidedResources> result = provider.getResources("account123");
 
         //then
-        assertEquals(result.size(), 1);
-        ProvidedResources providedResources = result.get(0);
-        assertEquals(providedResources, new ProvidedResourcesImpl(FreeResourcesProvider.FREE_RESOURCES_PROVIDER,
-                                                                  null,
-                                                                  "account123",
-                                                                  -1L,
-                                                                  -1L,
-                                                                  emptyList()));
-        verify(freeResourcesLimitManager).get("account123");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldNotProvideDefaultResourcesForAccountIfDefaultResourcesProviderProvidesEmptyList() throws Exception {
+        //given
+        when(accountManager.getById(any())).thenReturn(account);
+        when(defaultResourcesProvider.getResources(any())).thenReturn(emptyList());
+        doThrow(new NotFoundException("not found")).when(freeResourcesLimitManager).get(any());
+
+        //when
+        List<ProvidedResources> result = provider.getResources("user123");
+
+        //then
+        assertTrue(result.isEmpty());
     }
 
     @Test

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -295,7 +295,7 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
                                                                                            1,
                                                                                            WorkspaceResourceType.UNIT)));
         } catch (NoEnoughResourcesException e) {
-            Optional<? extends Resource> workspaceResource = getResource(e.getAvailableResources(),
+            Optional<? extends Resource> workspaceResource = getResource(resourceUsageManager.getTotalResources(accountId),
                                                                          WorkspaceResourceType.ID);
             long totalAvailableWorkspaces = workspaceResource.isPresent() ? workspaceResource.get().getAmount() : 0;
             throw new LimitExceededException(format("You are only allowed to create %d workspace%s.",
@@ -313,7 +313,7 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
                                                                                            1,
                                                                                            RuntimeResourceType.UNIT)));
         } catch (NoEnoughResourcesException e) {
-            Optional<? extends Resource> runtimeResource = getResource(e.getAvailableResources(),
+            Optional<? extends Resource> runtimeResource = getResource(resourceUsageManager.getTotalResources(accountId),
                                                                        RuntimeResourceType.ID);
             long totalAvailableRuntimes = runtimeResource.isPresent() ? runtimeResource.get().getAmount() : 0;
             throw new LimitExceededException(format("You are only allowed to start %d workspace%s.",

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -44,6 +44,7 @@ import static java.util.Collections.singletonList;
 import static org.eclipse.che.commons.lang.Size.parseSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -170,12 +171,14 @@ public class LimitsCheckingWorkspaceManagerTest {
           expectedExceptionsMessageRegExp = "You are only allowed to create 5 workspaces.")
     public void shouldThrowLimitExceedExceptionIfAccountDoesNotHaveEnoughAvailableWorkspaceResource() throws Exception {
         //given
-        doThrow(new NoEnoughResourcesException(singletonList(new ResourceImpl(WorkspaceResourceType.ID,
-                                                                              5,
-                                                                              WorkspaceResourceType.UNIT)),
+        doThrow(new NoEnoughResourcesException(emptyList(),
                                                emptyList(),
                                                emptyList()))
                 .when(resourceUsageManager).checkResourcesAvailability(any(), any());
+        doReturn(singletonList(new ResourceImpl(WorkspaceResourceType.ID,
+                                                5,
+                                                WorkspaceResourceType.UNIT)))
+                .when(resourceUsageManager).getTotalResources(anyString());
         LimitsCheckingWorkspaceManager manager = managerBuilder().setResourceUsageManager(resourceUsageManager)
                                                                  .build();
 
@@ -202,12 +205,14 @@ public class LimitsCheckingWorkspaceManagerTest {
           expectedExceptionsMessageRegExp = "You are only allowed to start 5 workspaces.")
     public void shouldThrowLimitExceedExceptionIfAccountDoesNotHaveEnoughAvailableRuntimeResource() throws Exception {
         //given
-        doThrow(new NoEnoughResourcesException(singletonList(new ResourceImpl(RuntimeResourceType.ID,
-                                                                              5,
-                                                                              RuntimeResourceType.UNIT)),
+        doThrow(new NoEnoughResourcesException(emptyList(),
                                                emptyList(),
                                                emptyList()))
                 .when(resourceUsageManager).checkResourcesAvailability(any(), any());
+        doReturn(singletonList(new ResourceImpl(RuntimeResourceType.ID,
+                                                5,
+                                                RuntimeResourceType.UNIT)))
+                .when(resourceUsageManager).getTotalResources(anyString());
         LimitsCheckingWorkspaceManager manager = managerBuilder().setResourceUsageManager(resourceUsageManager)
                                                                  .build();
 


### PR DESCRIPTION
### What does this PR do?
Rework organization resources in following way:
- remove moving resources from parent organization to its suborganization
- add ability suborganizations to use parent organization resources by default
- add ability to parent to set cap on shared resources usage

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1729

#### Changelog
- Rework organization distribution service to cap resource usage.

#### Release Notes
N/A part of teams

#### Docs PR
N/A part of teams