### PR TITLE
Fixed "Account Removal" email title

### DIFF
--- a/site/app/site/email-templates/account_removed.html
+++ b/site/app/site/email-templates/account_removed.html
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Outstanding Balance with Codenvy</title>
+    <title>Account Removal Notice</title>
 
 
     <style type="text/css">


### PR DESCRIPTION
Fixes the title of the account removal email.

#### Changelog
Corrected the title of the account removal email.

#### Release Notes
n/a

#### Docs PR
n/a