### PR TITLE
CODENVY-1832: open same tab on "Billing" page after reload

### DIFF
--- a/dashboard/src/app/billing/billing-config.ts
+++ b/dashboard/src/app/billing/billing-config.ts
@@ -51,6 +51,7 @@ export class BillingConfig {
     // config routes
     register.app.config(($routeProvider: ng.route.IRouteProvider) => {
       $routeProvider.accessWhen('/billing', {
+        reloadOnSearch: false,
         title: 'Billing',
         templateUrl: 'app/billing/billing.html',
         controller: 'BillingController',

--- a/dashboard/src/app/billing/billing.controller.ts
+++ b/dashboard/src/app/billing/billing.controller.ts
@@ -32,6 +32,7 @@ enum Tab {Summary, Card, Invoices}
  * @author Ann Shumilova
  */
 export class BillingController {
+  $location: ng.ILocationService;
   $log: ng.ILogService;
   $mdDialog: ng.material.IDialogService;
   $q: ng.IQService;
@@ -54,9 +55,10 @@ export class BillingController {
   /**
    * @ngInject for Dependency injection
    */
-  constructor ($log: ng.ILogService, $mdDialog: ng.material.IDialogService, $q: ng.IQService,
-               $rootScope: che.IRootScopeService, confirmDialogService: any, cheAPI: any, codenvyPayment: CodenvyPayment,
-               codenvyTeam: CodenvyTeam,cheNotification: any, billingService: BillingService) {
+  constructor ($location: ng.ILocationService, $log: ng.ILogService, $mdDialog: ng.material.IDialogService, $q: ng.IQService,
+               $rootScope: che.IRootScopeService, $scope: ng.IScope, confirmDialogService: any, cheAPI: any,
+               codenvyPayment: CodenvyPayment, codenvyTeam: CodenvyTeam,cheNotification: any, billingService: BillingService) {
+    this.$location = $location;
     this.$log = $log;
     this.$mdDialog = $mdDialog;
     this.$q = $q;
@@ -71,7 +73,8 @@ export class BillingController {
 
     this.accountId = '';
 
-    this.selectedTabIndex = Tab.Summary;
+    let tabIndex = parseInt(Tab[this.$location.search().tab], 10);
+    this.selectedTabIndex = tabIndex ? tabIndex : Tab.Summary;
 
     this.fetchCreditCard();
   }
@@ -233,6 +236,20 @@ export class BillingController {
       },
       templateUrl: 'app/billing/error-popup/error-popup.html'
     });
+  }
+
+  /**
+   * Changes search part of URL.
+   * Updates credit card when Card info tab is selected.
+   *
+   * @param {number} tabIndex tab ID
+   */
+  onSelectTab(tabIndex: number): void {
+    this.$location.search('tab', Tab[tabIndex]);
+
+    if (tabIndex === Tab.Card) {
+      this.getCreditCard();
+    }
   }
 
 }

--- a/dashboard/src/app/billing/billing.html
+++ b/dashboard/src/app/billing/billing.html
@@ -19,7 +19,7 @@
            md-no-ink-bar>
 
     <!-- Summary tab -->
-    <md-tab>
+    <md-tab md-on-select="billingController.onSelectTab(billingController.tab.Summary)">
       <md-tab-label>
         <md-icon md-font-icon="fa-ticket" class="fa che-tab-label-icon"></md-icon>
         <span class="che-tab-label-title">Summary</span>
@@ -33,7 +33,7 @@
     </md-tab>
 
     <!-- Card tab -->
-    <md-tab md-on-select="billingController.getCreditCard()">
+    <md-tab md-on-select="billingController.onSelectTab(billingController.tab.Card);">
       <md-tab-label>
         <md-icon md-font-icon="fa-cc-mastercard" class="fa che-tab-label-icon"></md-icon>
         <span class="che-tab-label-title">Card</span>
@@ -57,7 +57,7 @@
     </md-tab>
 
     <!-- Invoices tab -->
-    <md-tab md-on-select="invoicesSelected = true" md-on-deselect="invoicesSelected = false">
+    <md-tab md-on-select="billingController.onSelectTab(billingController.tab.Invoices)">
       <md-tab-label>
         <md-icon md-font-icon="fa-file-text-o" class="fa che-tab-label-icon"></md-icon>
         <span class="che-tab-label-title">Invoices</span>
@@ -67,7 +67,7 @@
           Having a question about subscriptions and billings in Codenvy - contact us at <a href="mailto:account-help@codenvy.com">account-help@codenvy.com</a>
         </che-description>
         <div class="billing-invoices">
-          <list-invoices account-id="billingController.accountId" ng-if="billingController.accountId && invoicesSelected"></list-invoices>
+          <list-invoices account-id="billingController.accountId" ng-if="billingController.accountId && (billingController.tab.Invoices === billingController.selectedTabIndex)"></list-invoices>
         </div>
       </md-tab-body>
     </md-tab>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Pull Request Policy: https://github.com/codenvy/planning/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This fix prevents changing tabs after reloading the "Billing" page.

### What issues does this PR fix or reference?
#1832 

#### Changelog
<!-- one line entry to be added to changelog -->
[UD] fixed changing tabs after reloading the "Billing" page.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinnyi@codenvy.com>