### PR TITLE
Don't take into account node number when check license usage legality

### DIFF
--- a/wsmaster/codenvy-hosted-api-system-license/pom.xml
+++ b/wsmaster/codenvy-hosted-api-system-license/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>codenvy-hosted-api-system-license-shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codenvy.plugin</groupId>
-            <artifactId>codenvy-machine-hosted</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/SystemLicense.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/SystemLicense.java
@@ -38,7 +38,6 @@ public class SystemLicense {
     private static final Pattern    LICENSE_ID_PATTERN                = Pattern.compile(".*\\(id: ([0-9]+)\\)");
     public static final  DateFormat EXPIRATION_DATE_FORMAT            = new SimpleDateFormat("yyyy/MM/dd");
     public static final  long       MAX_NUMBER_OF_FREE_USERS          = 3;
-    public static final  int        MAX_NUMBER_OF_FREE_SERVERS        = Integer.MAX_VALUE - 1;  // (-1) for testing propose only
     public static final  int        ADDITIONAL_DAYS_FOR_LICENSE_RENEW = 15;
 
     private final Map<SystemLicenseFeature, String> features;
@@ -136,20 +135,13 @@ public class SystemLicense {
     }
 
     /**
-     * Returns true if user have order to create new node.
-     */
-    public boolean isLicenseNodesUsageLegal(int actualServers) {
-        return true;
-    }
-
-    /**
      * @return true:
      * 1) if (EVALUATION_PRODUCT_KEY IS NOT expired) AND (actual number of users <= allowed by license)
      * 2) if (PRODUCT_KEY            IS NOT expired) AND (actual number of users <= allowed by license)
-     * 3) if (EVALUATION_PRODUCT_KEY IS     expired) AND ((actual number of users <= MAX_NUMBER_OF_FREE_USERS) AND (number of nodes <= MAX_NUMBER_OF_FREE_SERVERS))
+     * 3) if (EVALUATION_PRODUCT_KEY IS     expired) AND (actual number of users <= MAX_NUMBER_OF_FREE_USERS)
      * 4) if (PRODUCT_KEY            IS     expired) AND (actual number of users <= MAX_NUMBER_OF_FREE_USERS)
      */
-    public boolean isLicenseUsageLegal(long actualUsers, int actualServers) {
+    public boolean isLicenseUsageLegal(long actualUsers) {
         if (isTimeForRenewExpired()) {
             switch (getLicenseType()) {
                 case EVALUATION_PRODUCT_KEY:
@@ -157,7 +149,7 @@ public class SystemLicense {
                     return actualUsers <= MAX_NUMBER_OF_FREE_USERS;   // don't take into account minimal free number of servers
 
                 default:
-                    return isFreeUsageLegal(actualUsers, actualServers);
+                    return isFreeUsageLegal(actualUsers);
             }
         }
 
@@ -174,9 +166,8 @@ public class SystemLicense {
     /**
      * @return false if (actual number of users > MAX_NUMBER_OF_FREE_USERS) OR (actual number of nodes > MAX_NUMBER_OF_FREE_SERVERS)
      */
-    public static boolean isFreeUsageLegal(long actualUsers, int actualServers) {
-        return actualUsers <= MAX_NUMBER_OF_FREE_USERS
-               && actualServers <= MAX_NUMBER_OF_FREE_SERVERS;
+    public static boolean isFreeUsageLegal(long actualUsers) {
+        return actualUsers <= MAX_NUMBER_OF_FREE_USERS;
     }
 
     /**

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseService.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/SystemLicenseService.java
@@ -14,17 +14,18 @@
  */
 package com.codenvy.api.license.server;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 import com.codenvy.api.license.SystemLicense;
 import com.codenvy.api.license.SystemLicenseFeature;
 import com.codenvy.api.license.exception.InvalidSystemLicenseException;
 import com.codenvy.api.license.exception.SystemLicenseException;
 import com.codenvy.api.license.exception.SystemLicenseNotFoundException;
 import com.codenvy.api.license.shared.dto.LegalityDto;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
@@ -40,7 +41,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -171,24 +171,6 @@ public class SystemLicenseService {
         } catch (IOException e) {
             LOG.error(e.getMessage(), e);
             throw new ServerException("Failed to check if Codenvy usage matches system License constraints.", e);
-        }
-    }
-
-    @GET
-    @Path("/legality/node")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Checks if Codenvy machine node usage matches system License constraints, or free usage rules.",
-                  notes = "If nodeNumber parameter is absent then actual number of machine nodes will be validated")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK"),
-                           @ApiResponse(code = 500, message = "Server error")})
-    public LegalityDto isMachineNodesUsageLegal(@ApiParam("Node number for legality validation")
-                                                @QueryParam("nodeNumber")
-                                                Integer nodeNumber) throws ApiException {
-        try {
-            return newDto(LegalityDto.class).withIsLegal(licenseManager.isSystemNodesUsageLegal(nodeNumber));
-        } catch (IOException e) {
-            LOG.error(e.getMessage(), e);
-            throw new ServerException("Failed to check if Codenvy nodes usage matches system License constraints. ", e);
         }
     }
 

--- a/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/filter/SystemLicenseServicePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/main/java/com/codenvy/api/license/server/filter/SystemLicenseServicePermissionsFilter.java
@@ -39,7 +39,7 @@ public class SystemLicenseServicePermissionsFilter extends CheMethodInvokerFilte
     @Override
     protected void filter(GenericResourceMethod GenericResourceMethod, Object[] arguments) throws ApiException {
         String methodName = GenericResourceMethod.getMethod().getName();
-        if (methodName.equals("isSystemUsageLegal") || methodName.equals("isMachineNodesUsageLegal")) {
+        if (methodName.equals("isSystemUsageLegal")) {
             //public method
             return;
         }

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/SystemLicenseTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/SystemLicenseTest.java
@@ -55,14 +55,13 @@ public class SystemLicenseTest {
     }
 
     @Test(dataProvider = "getDataToTestIsLicenseUsageLegal")
-    public void testIsLicenseUsageLegal(String type, String expiration, int users, long actualUsers, int actualServers,
-                                        boolean isLicenseUsageLegal) {
+    public void testIsLicenseUsageLegal(String type, String expiration, int userSeats, long actualUsers, boolean isLicenseUsageLegal) {
         Map<SystemLicenseFeature, String> features = ImmutableMap.of(SystemLicenseFeature.TYPE, type,
                                                                      SystemLicenseFeature.EXPIRATION, expiration,
-                                                                     SystemLicenseFeature.USERS, String.valueOf(users));
+                                                                     SystemLicenseFeature.USERS, String.valueOf(userSeats));
         SystemLicense systemLicense = new SystemLicense(license4j, features);
 
-        boolean result = systemLicense.isLicenseUsageLegal(actualUsers, actualServers);
+        boolean result = systemLicense.isLicenseUsageLegal(actualUsers);
         assertEquals(result, isLicenseUsageLegal);
     }
 
@@ -70,64 +69,41 @@ public class SystemLicenseTest {
     public Object[][] getDataToTestIsLicenseUsageLegal() {
         return new Object[][]{
                 // expired product key
-                {PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, 0, 0, true},
-                {PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, SystemLicense.MAX_NUMBER_OF_FREE_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
-                {PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
+                {PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, 0, true},
+                {PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, false},
 
                 // non-expired product key
-                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, 0, 0, true},
-                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
-                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
-                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS + 1,
-                 SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
+                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, 0, true},
+                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS, true},
+                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, true},
+                {PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS + 1, false},
 
                 // expired evaluation product key
-                {EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, 0, 0, true},
-                {EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_USERS, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
-                {EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
+                {EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, 0, true},
+                {EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, SystemLicense.MAX_NUMBER_OF_FREE_USERS, true},
+                {EVALUATION_PRODUCT_KEY.toString(), EXPIRED_DATE, LICENSED_USERS, SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, false},
 
                 // non-expired evaluation product key
-                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, 0, 0, true},
-                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
-                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS,
-                 SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, true},
-                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS + 1,
-                 SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
+                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, 0, true},
+                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS, true},
+                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, true},
+                {EVALUATION_PRODUCT_KEY.toString(), NON_EXPIRED_DATE, LICENSED_USERS, LICENSED_USERS + 1, false},
                 };
     }
 
     @Test(dataProvider = "getDataToTestIsFreeUsageLegal")
-    public void testIsFreeUsageLegal(long actualUsers, int actualServers, boolean isLicenseUsageLegal) {
-        boolean result = SystemLicense.isFreeUsageLegal(actualUsers, actualServers);
+    public void testIsFreeUsageLegal(long actualUsers, boolean isLicenseUsageLegal) {
+        boolean result = SystemLicense.isFreeUsageLegal(actualUsers);
         assertEquals(result, isLicenseUsageLegal);
     }
 
     @DataProvider
     public Object[][] getDataToTestIsFreeUsageLegal() {
         return new Object[][]{
-                {0, 0, true},
-                {SystemLicense.MAX_NUMBER_OF_FREE_USERS, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS, true},
-                {SystemLicense.MAX_NUMBER_OF_FREE_USERS, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
-                {SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS, false},
-                {SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, SystemLicense.MAX_NUMBER_OF_FREE_SERVERS + 1, false},
+                {0, true},
+                {SystemLicense.MAX_NUMBER_OF_FREE_USERS, true},
+                {SystemLicense.MAX_NUMBER_OF_FREE_USERS + 1, false},
                 };
-    }
-
-    @Test(dataProvider = "getDataToTestIsLegalToAddNode")
-    public void testIsLegalToAddNode(String type, String expiration, int actualServers, boolean isAddNodeLegal) {
-        Map<SystemLicenseFeature, String> features = ImmutableMap.of(SystemLicenseFeature.TYPE, type,
-                                                                     SystemLicenseFeature.EXPIRATION, expiration);
-        SystemLicense systemLicense = new SystemLicense(license4j, features);
-
-        boolean result = systemLicense.isLicenseNodesUsageLegal(actualServers);
-        assertEquals(result, isAddNodeLegal);
     }
 
     @DataProvider

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseServiceTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/SystemLicenseServiceTest.java
@@ -26,8 +26,8 @@ import com.codenvy.api.license.shared.model.Issue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.Response;
+
 import org.eclipse.che.api.core.ApiException;
-import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.rest.ApiExceptionMapper;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -245,44 +245,6 @@ public class SystemLicenseServiceTest {
         doThrow(IOException.class).when(licenseManager).isSystemUsageLegal();
 
         Response response = given().when().get("/license/system/legality");
-        assertEquals(response.statusCode(), INTERNAL_SERVER_ERROR.getStatusCode());
-    }
-
-    @Test
-    public void testIsCodenvyActualNodesUsageLegal() throws IOException, ServerException {
-        doReturn(true).when(licenseManager).isSystemNodesUsageLegal(null);
-        Response response = given().when().get("/license/system/legality/node");
-
-        assertEquals(response.statusCode(), OK.getStatusCode());
-        assertEquals(getLegalityDtoFromJson(response),
-                     newDto(LegalityDto.class).withIsLegal(true));
-    }
-
-    @Test
-    public void testIsCodenvyGivenNodesUsageLegal() throws IOException, ServerException {
-        doReturn(true).when(licenseManager).isSystemNodesUsageLegal(2);
-        Response response = given().when().get("/license/system/legality/node?nodeNumber=2");
-
-        assertEquals(response.statusCode(), OK.getStatusCode());
-        assertEquals(getLegalityDtoFromJson(response),
-                     newDto(LegalityDto.class).withIsLegal(true));
-    }
-
-    @Test
-    public void testIsCodenvyNodesUsageNotLegal() throws IOException, ServerException {
-        doReturn(false).when(licenseManager).isSystemNodesUsageLegal(2);
-        Response response = given().when().get("/license/system/legality/node?nodeNumber=2");
-
-        assertEquals(response.statusCode(), OK.getStatusCode());
-        assertEquals(getLegalityDtoFromJson(response),
-                     newDto(LegalityDto.class).withIsLegal(false));
-    }
-
-    @Test
-    public void testIsCodenvyNodesUsageIOException() throws IOException, ServerException {
-        doThrow(IOException.class).when(licenseManager).isSystemNodesUsageLegal(null);
-
-        Response response = given().when().get("/license/system/legality/node");
         assertEquals(response.statusCode(), INTERNAL_SERVER_ERROR.getStatusCode());
     }
 

--- a/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/filter/SystemLicenseServicePermissionsFilterTest.java
+++ b/wsmaster/codenvy-hosted-api-system-license/src/test/java/com/codenvy/api/license/server/filter/SystemLicenseServicePermissionsFilterTest.java
@@ -15,7 +15,6 @@
 package com.codenvy.api.license.server.filter;
 
 import com.codenvy.api.license.server.SystemLicenseService;
-import com.codenvy.api.license.server.filter.SystemLicenseServicePermissionsFilter;
 import com.codenvy.api.permission.server.SystemDomain;
 import com.jayway.restassured.response.Response;
 
@@ -78,18 +77,6 @@ public class SystemLicenseServicePermissionsFilterTest {
 
         assertEquals(response.getStatusCode(), 204);
         verify(systemLicenseService).isSystemUsageLegal();
-        verifyZeroInteractions(subject);
-    }
-
-    @Test
-    public void shouldNotCheckPermissionsOnLicenseNodeChecking() throws Exception {
-        final Response response = given().auth()
-                                         .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
-                                         .when()
-                                         .get(SECURE_PATH + "/license/system/legality/node?nodeNumber=1");
-
-        assertEquals(response.getStatusCode(), 204);
-        verify(systemLicenseService).isMachineNodesUsageLegal(1);
         verifyZeroInteractions(subject);
     }
 


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevnov@codenvy.com>

### What does this PR do?
It removes redundant getting number of nodes from the swarm connector, to avoid throwing next exception in case of swarm container is not accessible:
> HTTP Status 500 - org.eclipse.che.api.core.ServerException: Failed to check if Codenvy usage matches system License constraints.

[Selenium testing result](https://gist.github.com/dmytro-ndp/9d2abe938d9d35e9f90c19adf6c9d0d4).

### What issues does this PR fix or reference?
This request is linked with #1928.

#### Changelog
<!-- one line entry to be added to changelog -->
(there are no significant changes for changelog)

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
(there are no significant changes for release notes)

#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
(there are no significant changes for Docs)