### PR TITLE
add rsyslog entrypoint

### DIFF
--- a/dockerfiles/rsyslog/Dockerfile
+++ b/dockerfiles/rsyslog/Dockerfile
@@ -17,4 +17,6 @@ FROM alpine:3.4
 RUN  apk add --update "rsyslog=8.18.0-r0" \
   && rm -rf /var/cache/apk/*
 
-ENTRYPOINT [ "rsyslogd", "-n" ]
+COPY entrypoint.sh /
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/rsyslog/entrypoint.sh
+++ b/dockerfiles/rsyslog/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+
+# rm /var/run/rsyslogd.pid if exist before rsyslog start
+if [ -f  /var/run/rsyslogd.pid ]; then
+    rm -rf /var/run/rsyslogd.pid
+fi
+
+exec rsyslogd -n

--- a/dockerfiles/rsyslog/entrypoint.sh
+++ b/dockerfiles/rsyslog/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2016 Codenvy, S.A.
+# Copyright (c) 2017 Codenvy, S.A.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
### What does this PR do?
add entrypoint to rsyslog image where we kill pid file if it exist before start rsyslog, that may happen on force restart container and rsyslog wount be able to start.

### What issues does this PR fix or reference?
fixes https://github.com/codenvy/codenvy/issues/1940

#### Changelog
add rsyslog entrypoint
