### PR TITLE
Codenvy-1940: some containers became inaccessible after rebooting

### DIFF
--- a/dockerfiles/cli/version/5.6.0/images
+++ b/dockerfiles/cli/version/5.6.0/images
@@ -1,10 +1,10 @@
 IMAGE_HAPROXY=haproxy:1.5.18-alpine
 IMAGE_NGINX=nginx:1.10-alpine
-IMAGE_SWARM=swarm:1.2.6
 IMAGE_REGISTRY=registry:2.5.0
 IMAGE_POSTGRES=postgres:9.5.4
 IMAGE_COMPOSE=docker/compose:1.8.1
 IMAGE_ZOOKEEPER=zookeeper:3.4.9
+IMAGE_SWARM=codenvy/swarm:5.6.0
 IMAGE_SOCAT=codenvy/socat:5.6.0
 IMAGE_INIT=codenvy/init:5.6.0
 IMAGE_AGENTS=codenvy/agents:5.6.0

--- a/dockerfiles/cli/version/latest/images
+++ b/dockerfiles/cli/version/latest/images
@@ -1,10 +1,10 @@
 IMAGE_HAPROXY=haproxy:1.5.18-alpine
 IMAGE_NGINX=nginx:1.10-alpine
-IMAGE_SWARM=swarm:1.2.6
 IMAGE_REGISTRY=registry:2.5.0
 IMAGE_POSTGRES=postgres:9.5.4
 IMAGE_COMPOSE=docker/compose:1.8.1
 IMAGE_ZOOKEEPER=zookeeper:3.4.9
+IMAGE_SWARM=codenvy/swarm:latest
 IMAGE_SOCAT=codenvy/socat:latest
 IMAGE_INIT=codenvy/init:latest
 IMAGE_AGENTS=codenvy/agents:latest

--- a/dockerfiles/cli/version/nightly/images
+++ b/dockerfiles/cli/version/nightly/images
@@ -1,10 +1,10 @@
 IMAGE_HAPROXY=haproxy:1.5.18-alpine
 IMAGE_NGINX=nginx:1.10-alpine
-IMAGE_SWARM=swarm:1.2.6
 IMAGE_REGISTRY=registry:2.5.0
 IMAGE_POSTGRES=postgres:9.5.4
 IMAGE_COMPOSE=docker/compose:1.8.1
 IMAGE_ZOOKEEPER=zookeeper:3.4.9
+IMAGE_SWARM=codenvy/swarm:nightly
 IMAGE_SOCAT=codenvy/socat:nightly
 IMAGE_INIT=codenvy/init:nightly
 IMAGE_AGENTS=codenvy/agents:nightly

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -27,13 +27,7 @@ services:
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/rsyslog/rsyslog.conf:/etc/rsyslog.conf'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/rsyslog/haproxy.conf:/etc/rsyslog.d/haproxy.conf'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/rsyslog/registry.conf:/etc/rsyslog.d/registry.conf'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/rsyslog/swarm.conf:/etc/rsyslog.d/swarm.conf'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/rsyslog/zookeeper.conf:/etc/rsyslog.d/zookeeper.conf'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/haproxy/:/var/log/haproxy'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/swarm/:/var/log/swarm'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/registry/:/var/log/registry'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/zookeeper/:/var/log/zookeeper'
     ports:
       - '5140:514'
     ulimits:
@@ -115,7 +109,9 @@ services:
     image: <%= ENV["IMAGE_SWARM"] %>
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/swarm/node_list:/node_list'
-    command: manage -H 0.0.0.0:2375 file:///node_list
+      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/swarm/swarm_entrypoint.sh:/swarm_entrypoint.sh'
+      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/swarm/:/var/log/swarm'
+    entrypoint: "/swarm_entrypoint.sh"
     ports:
         - "127.0.0.1:23751:2375"
     links:
@@ -127,13 +123,7 @@ services:
         hard: 163840
     restart: always
     depends_on:
-      - rsyslog
       - zookeeper
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:5140"
-        syslog-facility: "local3"
 <%= extra_hosts() -%>
 <%= dns() -%>
 
@@ -145,21 +135,17 @@ services:
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/registry:/var/lib/registry'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/registry/config.yml:/etc/docker/registry/config.yml'
+      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/registry/registry_entrypoint.sh:/registry_entrypoint.sh'
+      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/registry/:/var/log/registry'
     ports:
       - '5000:5000'
+    entrypoint: "/registry_entrypoint.sh"
     ulimits:
       nproc: 163840
       nofile:
         soft: 163840
         hard: 163840
     restart: always
-    depends_on:
-       - rsyslog
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:5140"
-        syslog-facility: "local0"
 <%= extra_hosts() -%>
 <%= dns() -%>
 
@@ -269,21 +255,17 @@ services:
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/zookeeper/data/:/data'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/data/zookeeper/datalog/:/datalog'
+      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/zookeeper/:/home/zookeeper/logs/'
     ports:
       - '2181:2181'
+    environment:
+      - "ZOO_LOG_DIR=/home/zookeeper/logs"
+      - "ZOO_LOG4J_PROP=INFO, ROLLINGFILE"
     ulimits:
       nproc: 163840
       nofile:
         soft: 163840
         hard: 163840
     restart: always
-    depends_on:
-      - rsyslog
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:5140"
-        syslog-facility: "local1"
 <%= extra_hosts() -%>
 <%= dns() -%>
-

--- a/dockerfiles/init/modules/registry/manifests/init.pp
+++ b/dockerfiles/init/modules/registry/manifests/init.pp
@@ -8,6 +8,11 @@ class registry {
     ensure  => "present",
     content => template("registry/config.yml.erb"),
     mode    => '644',
+  } ->
+  file { "/opt/codenvy/config/registry/registry_entrypoint.sh":
+    ensure  => "present",
+    content => template("registry/registry_entrypoint.sh.erb"),
+    mode    => '755',
   }
 }
 

--- a/dockerfiles/init/modules/registry/templates/registry_entrypoint.sh.erb
+++ b/dockerfiles/init/modules/registry/templates/registry_entrypoint.sh.erb
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Copyright (c) 2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+
+set -e
+
+if [ ! -d  /var/log/registry ]; then
+    mkdir -p /var/log/registry
+fi
+
+exec /bin/registry serve /etc/docker/registry/config.yml 2>&1 | tee -a /var/log/registry/registry.log

--- a/dockerfiles/init/modules/rsyslog/manifests/init.pp
+++ b/dockerfiles/init/modules/rsyslog/manifests/init.pp
@@ -13,20 +13,6 @@ class rsyslog {
     ensure  => "present",
     content => template("rsyslog/haproxy.conf.erb"),
     mode    => '644',
-  } ->
-  file { "/opt/codenvy/config/rsyslog/swarm.conf":
-    ensure  => "present",
-    content => template("rsyslog/swarm.conf.erb"),
-    mode    => '644',
-  } ->  file { "/opt/codenvy/config/rsyslog/zookeeper.conf":
-    ensure  => "present",
-    content => template("rsyslog/zookeeper.conf.erb"),
-    mode    => '644',
-  } ->
-  file { "/opt/codenvy/config/rsyslog/registry.conf":
-    ensure  => "present",
-    content => template("rsyslog/registry.conf.erb"),
-    mode    => '644',
   }
 }
 

--- a/dockerfiles/init/modules/rsyslog/templates/registry.conf.erb
+++ b/dockerfiles/init/modules/rsyslog/templates/registry.conf.erb
@@ -1,3 +1,0 @@
-$FileCreateMode 0644
-local0.*    /var/log/registry/registry.log
-& ~

--- a/dockerfiles/init/modules/rsyslog/templates/swarm.conf.erb
+++ b/dockerfiles/init/modules/rsyslog/templates/swarm.conf.erb
@@ -1,3 +1,0 @@
-$FileCreateMode 0644
-local3.*    /var/log/swarm/swarm.log
-& ~

--- a/dockerfiles/init/modules/rsyslog/templates/zookeeper.conf.erb
+++ b/dockerfiles/init/modules/rsyslog/templates/zookeeper.conf.erb
@@ -1,3 +1,0 @@
-$FileCreateMode 0644
-local1.*    /var/log/zookeeper/zookeeper.log
-& ~

--- a/dockerfiles/init/modules/swarm/manifests/init.pp
+++ b/dockerfiles/init/modules/swarm/manifests/init.pp
@@ -8,5 +8,10 @@ class swarm {
     ensure  => "present",
     content => template("swarm/node_list.erb"),
     mode    => '644',
+  } ->
+  file { "/opt/codenvy/config/swarm/swarm_entrypoint.sh":
+    ensure  => "present",
+    content => template("swarm/swarm_entrypoint.sh.erb"),
+    mode    => '755',
   }
 }

--- a/dockerfiles/init/modules/swarm/templates/swarm_entrypoint.sh.erb
+++ b/dockerfiles/init/modules/swarm/templates/swarm_entrypoint.sh.erb
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Copyright (c) 2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+
+set -e
+
+if [ ! -d  /var/log/swarm ]; then
+    mkdir -p /var/log/swarm
+fi
+
+exec /swarm manage -H 0.0.0.0:2375 file:///node_list 2>&1 | tee -a /var/log/swarm/swarm.log

--- a/dockerfiles/swarm/Dockerfile
+++ b/dockerfiles/swarm/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# build:
+#   docker build -t codenvy/swarm:<version> .
+#
+# use:
+#    docker run codenvy/swarm:<version>
+
+FROM alpine:3.4
+
+RUN apk --update add ca-certificates wget \
+    && wget -O swarm.tgz https://github.com/docker/swarm/releases/download/v1.2.6/swarm-1.2.6-linux-x86_64.tgz \
+    && tar xvzf swarm.tgz \
+    && rm -rf swarm.tgz
+
+ENV SWARM_HOST :2375
+EXPOSE 2375
+VOLUME /.swarm
+
+ENTRYPOINT ["/swarm_entrypoint.sh"]

--- a/dockerfiles/swarm/Dockerfile
+++ b/dockerfiles/swarm/Dockerfile
@@ -19,6 +19,5 @@ RUN apk --update add ca-certificates wget \
 
 ENV SWARM_HOST :2375
 EXPOSE 2375
-VOLUME /.swarm
 
 ENTRYPOINT ["/swarm_entrypoint.sh"]

--- a/dockerfiles/swarm/Dockerfile
+++ b/dockerfiles/swarm/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Codenvy, S.A.
+# Copyright (c) 2017 Codenvy, S.A.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dockerfiles/swarm/build.sh
+++ b/dockerfiles/swarm/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) 2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+IMAGE_NAME="codenvy/swarm"
+. $(cd "$(dirname "$0")"; pwd)/../build.include
+
+init "$@"
+build "$@"

--- a/dockerfiles/swarm/build.sh
+++ b/dockerfiles/swarm/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2016 Codenvy, S.A.
+# Copyright (c) 2017 Codenvy, S.A.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
### What does this PR do?
in order to fix: https://github.com/codenvy/codenvy/issues/1940 afret some investigation i've figured out that our issues were due to using docker logging with syslog which we running as a container. That was a mistake, we should not do that because it works only with compose where we define start order, but when instance or docker daemon reboot containers start in random order which makes failure when image which wants to send logs to syslog started before syslog. And this kind of failures is kind of fatal for docker and docker daemon even don't trying to restart failed container although we've specified `restart: always`.

So here i;ve removed using docker logging with syslog which should fix the issue, but we still need to get logs from containers so i did some changes to make this works same as before.
we had 3 affected images: zookeeper, registry, swarm
For zookeeper i figured how to configure it to write log in to file.
For registry it was enough just to add custom entrypoint where I did log forwarding to file
Unfortunately swarm packaged as just a binary in `scratch` image so there is no bash and no any way to get log, so I added codenvy/swarm image where i get swarm and put in in alpine image which allows me to finally get logs in to a file.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1940

#### Changelog
fix bug where some containers became inaccessible after rebooting
