### PR TITLE
CHE-4499; support legaсy filenames for github factories

### DIFF
--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/pom.xml
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -60,6 +64,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitLabFactoryModule.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitLabFactoryModule.java
@@ -1,0 +1,31 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.plugin.gitlab.factory.resolver;
+
+import com.google.inject.AbstractModule;
+
+import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.plugin.urlfactory.URLParser;
+
+/**
+ * @author Max Shaposhnik (mshaposhnik@codenvy.com)
+ */
+@DynaModule
+public class GitLabFactoryModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(URLParser.class).to(LegacyGitlabURLParser.class);
+    }
+}

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabFactoryParametersResolver.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabFactoryParametersResolver.java
@@ -18,7 +18,6 @@ import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.factory.server.FactoryParametersResolver;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
-import org.eclipse.che.plugin.urlfactory.CreateFactoryParams;
 import org.eclipse.che.plugin.urlfactory.ProjectConfigDtoMerger;
 import org.eclipse.che.plugin.urlfactory.URLFactoryBuilder;
 
@@ -44,7 +43,7 @@ public class GitlabFactoryParametersResolver implements FactoryParametersResolve
      * Parser which will allow to check validity of URLs and create objects.
      */
     @Inject
-    private GitlabUrlParser gitlabUrlParser;
+    private GitlabURLParser gitlabUrlParser;
 
     /**
      * Builder allowing to build objects from gitlab URL.
@@ -91,21 +90,20 @@ public class GitlabFactoryParametersResolver implements FactoryParametersResolve
         final GitlabUrl gitlabUrl = gitlabUrlParser.parse(factoryParameters.get("url"));
 
         // create factory from the following location if location exists, else create default factory
-        FactoryDto factory = urlFactoryBuilder.createFactory(CreateFactoryParams.create().jsonFileLocation(
-                gitlabUrl.codenvyFactoryJsonFileLocation()));
+        FactoryDto factory = urlFactoryBuilder.createFactory(gitlabUrl.factoryJsonFileLocation());
 
         // add workspace configuration if not defined
         if (factory.getWorkspace() == null) {
-            factory.setWorkspace(urlFactoryBuilder.buildWorkspaceConfig(gitlabUrl.repository(),
-                                                                        gitlabUrl.username(),
-                                                                        gitlabUrl.codenvyDockerFileLocation()));
+            factory.setWorkspace(urlFactoryBuilder.buildWorkspaceConfig(gitlabUrl.getRepository(),
+                                                                        gitlabUrl.getUsername(),
+                                                                        gitlabUrl.dockerFileLocation()));
         }
 
         // Compute project configuration
         ProjectConfigDto projectConfigDto = newDto(ProjectConfigDto.class).withSource(gitlabSourceStorageBuilder.build(gitlabUrl))
-                                                                          .withName(gitlabUrl.repository())
+                                                                          .withName(gitlabUrl.getRepository())
                                                                           .withType("blank")
-                                                                          .withPath("/".concat(gitlabUrl.repository()));
+                                                                          .withPath("/".concat(gitlabUrl.getRepository()));
 
         // apply merging operation from existing and computed settings
         return projectConfigDtoMerger.merge(factory, projectConfigDto);

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabSourceStorageBuilder.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabSourceStorageBuilder.java
@@ -41,10 +41,10 @@ public class GitlabSourceStorageBuilder {
     public SourceStorageDto build(GitlabUrl gitlabUrl) {
         // Create map for source storage dto
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("branch", gitlabUrl.branch());
+        parameters.put("branch", gitlabUrl.getBranch());
 
-        if (!Strings.isNullOrEmpty(gitlabUrl.subfolder())) {
-            parameters.put("keepDir", gitlabUrl.subfolder());
+        if (!Strings.isNullOrEmpty(gitlabUrl.getSubfolder())) {
+            parameters.put("keepDir", gitlabUrl.getSubfolder());
         }
         return newDto(SourceStorageDto.class).withLocation(gitlabUrl.repositoryLocation()).withType("git").withParameters(parameters);
     }

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParser.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParser.java
@@ -14,6 +14,8 @@
  */
 package com.codenvy.plugin.gitlab.factory.resolver;
 
+import org.eclipse.che.plugin.urlfactory.URLParser;
+
 import javax.validation.constraints.NotNull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,7 +25,7 @@ import java.util.regex.Pattern;
  *
  * @author Florent Benoit
  */
-public class GitlabUrlParser {
+public class GitlabURLParser implements URLParser<GitlabUrl> {
 
     /**
      * Regexp to find repository details (repository name, project name and branch and subfolder)
@@ -41,6 +43,7 @@ public class GitlabUrlParser {
      *         a not null string representation of URL
      * @return true if the given URL is a github URL
      */
+    @Override
     public boolean isValid(@NotNull String url) {
         return GITLAB_PATTERN.matcher(url).matches();
     }
@@ -52,6 +55,7 @@ public class GitlabUrlParser {
      *         URL to transform into a managed object
      * @return managed github url {@link GitlabUrl}.
      */
+    @Override
     public GitlabUrl parse(String url) {
         // Apply github url to the regexp
         Matcher matcher = GITLAB_PATTERN.matcher(url);
@@ -61,8 +65,12 @@ public class GitlabUrlParser {
                     url));
         }
 
-        return new GitlabUrl().username(matcher.group("repoUser")).repository(matcher.group("repoName")).branch(matcher.group("branchName"))
-                              .subfolder(matcher.group("subFolder"));
+        return new GitlabUrl().withUsername(matcher.group("repoUser"))
+                              .withRepository(matcher.group("repoName"))
+                              .withBranch(matcher.group("branchName"))
+                              .withSubfolder(matcher.group("subFolder"))
+                              .withDockerfileFilename(".runtime.dockerfile")
+                              .withFactoryFilename(".factory.json");
 
     }
 }

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParser.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParser.java
@@ -36,25 +36,11 @@ public class GitlabURLParser implements URLParser<GitlabUrl> {
             "^(?:http)(?:s)?(?:\\:\\/\\/)gitlab.com/(?<repoUser>[^/]++)/(?<repoName>[^/]++)(?:/tree/(?<branchName>[^/]++)(?:/(?<subFolder>.*))?)?$");
 
 
-    /**
-     * Check if the provided URL is a valid Github url or not
-     *
-     * @param url
-     *         a not null string representation of URL
-     * @return true if the given URL is a github URL
-     */
     @Override
     public boolean isValid(@NotNull String url) {
         return GITLAB_PATTERN.matcher(url).matches();
     }
 
-    /**
-     * Provides a github URL object allowing to extract some part of the URL.
-     *
-     * @param url
-     *         URL to transform into a managed object
-     * @return managed github url {@link GitlabUrl}.
-     */
     @Override
     public GitlabUrl parse(String url) {
         // Apply github url to the regexp

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParser.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParser.java
@@ -69,7 +69,7 @@ public class GitlabURLParser implements URLParser<GitlabUrl> {
                               .withRepository(matcher.group("repoName"))
                               .withBranch(matcher.group("branchName"))
                               .withSubfolder(matcher.group("subFolder"))
-                              .withDockerfileFilename(".runtime.dockerfile")
+                              .withDockerfileFilename(".factory.dockerfile")
                               .withFactoryFilename(".factory.json");
 
     }

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
@@ -179,7 +179,8 @@ public class GitlabUrl {
                                     .add(repository)
                                     .add("raw")
                                     .add(branch)
-                                    .add(dockerfileFilename).toString();
+                                    .add(dockerfileFilename)
+                                    .toString();
     }
 
     /**
@@ -193,8 +194,8 @@ public class GitlabUrl {
                                     .add(repository)
                                     .add("raw")
                                     .add(branch)
-                                    .add(factoryFilename).toString();
-
+                                    .add(factoryFilename)
+                                    .toString();
     }
 
     /**

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
@@ -16,6 +16,8 @@ package com.codenvy.plugin.gitlab.factory.resolver;
 
 import com.google.common.base.Strings;
 
+import java.util.StringJoiner;
+
 /**
  * Representation of a github URL, allowing to get details from it.
  * <p> like
@@ -29,7 +31,7 @@ public class GitlabUrl {
     /**
      * Gitlab prefix.
      */
-    private static final String GITLAB_PREFIX = "https://gitlab.com/";
+    private static final String GITLAB_PREFIX = "https://gitlab.com";
 
     /**
      * Master branch is the default.
@@ -172,7 +174,12 @@ public class GitlabUrl {
      * @return location of dockerfile in a repository
      */
     protected String dockerFileLocation() {
-        return GITLAB_PREFIX + this.username + "/" + this.repository + "/raw/" + this.getBranch() + "/" + dockerfileFilename;
+        return new StringJoiner("/").add(GITLAB_PREFIX)
+                                    .add(username)
+                                    .add(repository)
+                                    .add("raw")
+                                    .add(branch)
+                                    .add(dockerfileFilename).toString();
     }
 
     /**
@@ -181,7 +188,13 @@ public class GitlabUrl {
      * @return location of codenvy factory json file in a repository
      */
     protected String factoryJsonFileLocation() {
-        return GITLAB_PREFIX + this.username + "/" + this.repository + "/raw/" + this.getBranch() + "/" + factoryFilename;
+        return new StringJoiner("/").add(GITLAB_PREFIX)
+                                    .add(username)
+                                    .add(repository)
+                                    .add("raw")
+                                    .add(branch)
+                                    .add(factoryFilename).toString();
+
     }
 
     /**

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
@@ -203,7 +203,7 @@ public class GitlabUrl {
      * @return location of the repository.
      */
     protected String repositoryLocation() {
-        return GITLAB_PREFIX + this.username + "/" + this.repository + ".git";
+        return GITLAB_PREFIX + "/" + this.username + "/" + this.repository + ".git";
     }
 
 

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrl.java
@@ -52,9 +52,19 @@ public class GitlabUrl {
     private String branch = DEFAULT_BRANCH_NAME;
 
     /**
-     * subfolder if any
+     * Subfolder if any
      */
     private String subfolder;
+
+    /**
+     * Dockerfile filename
+     */
+    private String dockerfileFilename;
+
+    /**
+     * Factory json filename
+     */
+    private String factoryFilename;
 
     /**
      * Creation of this instance is made by the parser so user may not need to create a new instance directly
@@ -68,11 +78,11 @@ public class GitlabUrl {
      *
      * @return the username part
      */
-    public String username() {
+    public String getUsername() {
         return this.username;
     }
 
-    public GitlabUrl username(String userName) {
+    public GitlabUrl withUsername(String userName) {
         this.username = userName;
         return this;
     }
@@ -82,11 +92,11 @@ public class GitlabUrl {
      *
      * @return the repository part
      */
-    public String repository() {
+    public String getRepository() {
         return this.repository;
     }
 
-    protected GitlabUrl repository(String repository) {
+    protected GitlabUrl withRepository(String repository) {
         this.repository = repository;
         return this;
     }
@@ -96,11 +106,11 @@ public class GitlabUrl {
      *
      * @return the branch part
      */
-    public String branch() {
+    public String getBranch() {
         return this.branch;
     }
 
-    protected GitlabUrl branch(String branch) {
+    protected GitlabUrl withBranch(String branch) {
         if (!Strings.isNullOrEmpty(branch)) {
             this.branch = branch;
         }
@@ -108,11 +118,11 @@ public class GitlabUrl {
     }
 
     /**
-     * Gets subfolder of this github url
+     * Gets subfolder of this gitlab url
      *
      * @return the subfolder part
      */
-    public String subfolder() {
+    public String getSubfolder() {
         return this.subfolder;
     }
 
@@ -123,8 +133,36 @@ public class GitlabUrl {
      *         path inside the repository
      * @return current github instance
      */
-    protected GitlabUrl subfolder(String subfolder) {
+    protected GitlabUrl withSubfolder(String subfolder) {
         this.subfolder = subfolder;
+        return this;
+    }
+
+    /**
+     * Gets dockerfile file name of this github url
+     *
+     * @return the dockerfile file name
+     */
+    public String getDockerfileFilename() {
+        return this.dockerfileFilename;
+    }
+
+    protected GitlabUrl withDockerfileFilename(String dockerfileFilename) {
+        this.dockerfileFilename = dockerfileFilename;
+        return this;
+    }
+
+    /**
+     * Gets factory file name of this github url
+     *
+     * @return the factory file name
+     */
+    public String getFactoryFilename() {
+        return this.factoryFilename;
+    }
+
+    protected GitlabUrl withFactoryFilename(String factoryFilename) {
+        this.factoryFilename = factoryFilename;
         return this;
     }
 
@@ -133,8 +171,8 @@ public class GitlabUrl {
      *
      * @return location of dockerfile in a repository
      */
-    protected String codenvyDockerFileLocation() {
-        return GITLAB_PREFIX + this.username + "/" + this.repository + "/raw/" + this.branch() + "/.codenvy.dockerfile";
+    protected String dockerFileLocation() {
+        return GITLAB_PREFIX + this.username + "/" + this.repository + "/raw/" + this.getBranch() + "/" + dockerfileFilename;
     }
 
     /**
@@ -142,8 +180,8 @@ public class GitlabUrl {
      *
      * @return location of codenvy factory json file in a repository
      */
-    protected String codenvyFactoryJsonFileLocation() {
-        return GITLAB_PREFIX + this.username + "/" + this.repository + "/raw/" + this.branch() + "/.codenvy.json";
+    protected String factoryJsonFileLocation() {
+        return GITLAB_PREFIX + this.username + "/" + this.repository + "/raw/" + this.getBranch() + "/" + factoryFilename;
     }
 
     /**

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/LegacyGitlabURLParser.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/LegacyGitlabURLParser.java
@@ -1,0 +1,47 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.plugin.gitlab.factory.resolver;
+
+import org.eclipse.che.plugin.urlfactory.URLChecker;
+
+import javax.inject.Inject;
+
+/**
+ * Support old dockerfila and factory filenames;
+ *
+ * @author Max Shaposhnik
+ */
+public class LegacyGitlabURLParser extends GitlabURLParser {
+
+    private URLChecker urlChecker;
+
+    @Inject
+    public LegacyGitlabURLParser(URLChecker urlChecker) {
+        this.urlChecker = urlChecker;
+    }
+
+    @Override
+    public GitlabUrl parse(String url) {
+        GitlabUrl gitlabUrl = super.parse(url);
+        if (!urlChecker.exists(gitlabUrl.dockerFileLocation())) {
+            gitlabUrl.withDockerfileFilename(".codenvy.dockerfile");
+        }
+
+        if (!urlChecker.exists(gitlabUrl.factoryJsonFileLocation())) {
+            gitlabUrl.withFactoryFilename(".codenvy.json");
+        }
+        return gitlabUrl;
+    }
+}

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/LegacyGitlabURLParser.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/main/java/com/codenvy/plugin/gitlab/factory/resolver/LegacyGitlabURLParser.java
@@ -19,7 +19,7 @@ import org.eclipse.che.plugin.urlfactory.URLChecker;
 import javax.inject.Inject;
 
 /**
- * Support old dockerfila and factory filenames;
+ * Support for old dockerfile and factory file names;
  *
  * @author Max Shaposhnik
  */

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabFactoryParametersResolverTest.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabFactoryParametersResolverTest.java
@@ -19,7 +19,6 @@ import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.SourceStorageDto;
-import org.eclipse.che.plugin.urlfactory.CreateFactoryParams;
 import org.eclipse.che.plugin.urlfactory.ProjectConfigDtoMerger;
 import org.eclipse.che.plugin.urlfactory.URLFactoryBuilder;
 import org.mockito.ArgumentCaptor;
@@ -37,6 +36,7 @@ import static com.codenvy.plugin.gitlab.factory.resolver.GitlabFactoryParameters
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,7 +57,7 @@ public class GitlabFactoryParametersResolverTest {
      * Parser which will allow to check validity of URLs and create objects.
      */
     @Spy
-    private GitlabUrlParser gitlabUrlParser = new GitlabUrlParser();
+    private GitlabURLParser gitlabUrlParser = new GitlabURLParser();
 
     /**
      * Converter allowing to convert gitlab URL to other objects.
@@ -84,10 +84,10 @@ public class GitlabFactoryParametersResolverTest {
     private ArgumentCaptor<ProjectConfigDto> projectConfigDtoArgumentCaptor;
 
     /**
-     * Capturing the parameter when calling {@link URLFactoryBuilder#createFactory(CreateFactoryParams)}
+     * Capturing the parameter when calling {@link URLFactoryBuilder#createFactory(String)}
      */
     @Captor
-    private ArgumentCaptor<CreateFactoryParams> createFactoryParamsArgumentCaptor;
+    private ArgumentCaptor<String> createFactoryParamsArgumentCaptor;
 
     /**
      * Instance of resolver that will be tested.
@@ -140,17 +140,17 @@ public class GitlabFactoryParametersResolverTest {
         String gitlabUrlRepository = gitlabUrl + ".git";
 
         FactoryDto computedFactory = newDto(FactoryDto.class).withV("4.0");
-        when(urlFactoryBuilder.createFactory(any(CreateFactoryParams.class))).thenReturn(computedFactory);
+        when(urlFactoryBuilder.createFactory(anyString())).thenReturn(computedFactory);
 
         gitlabFactoryParametersResolver.createFactory(singletonMap(URL_PARAMETER_NAME, gitlabUrl));
 
         // check we called the builder with the following codenvy json file
         verify(urlFactoryBuilder).createFactory(createFactoryParamsArgumentCaptor.capture());
-        assertEquals(createFactoryParamsArgumentCaptor.getValue().jsonFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.codenvy.json");
+        assertEquals(createFactoryParamsArgumentCaptor.getValue(), "https://gitlab.com/eclipse/che/raw/master/.factory.json");
 
 
         // check we provide dockerfile and correct env
-        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/master/.codenvy.dockerfile"));
+        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/master/.runtime.dockerfile"));
 
         // check project config built
         verify(projectConfigDtoMerger).merge(any(FactoryDto.class), projectConfigDtoArgumentCaptor.capture());
@@ -179,16 +179,16 @@ public class GitlabFactoryParametersResolverTest {
 
 
         FactoryDto computedFactory = newDto(FactoryDto.class).withV("4.0");
-        when(urlFactoryBuilder.createFactory(any(CreateFactoryParams.class))).thenReturn(computedFactory);
+        when(urlFactoryBuilder.createFactory(anyString())).thenReturn(computedFactory);
 
         gitlabFactoryParametersResolver.createFactory(singletonMap(URL_PARAMETER_NAME, gitlabUrl));
 
         // check we called the builder with the following codenvy json file
         verify(urlFactoryBuilder).createFactory(createFactoryParamsArgumentCaptor.capture());
-        assertEquals(createFactoryParamsArgumentCaptor.getValue().jsonFileLocation(), "https://gitlab.com/eclipse/che/raw/4.2.x/.codenvy.json");
+        assertEquals(createFactoryParamsArgumentCaptor.getValue(), "https://gitlab.com/eclipse/che/raw/4.2.x/.factory.json");
 
         // check we provide dockerfile and correct env
-        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.codenvy.dockerfile"));
+        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.runtime.dockerfile"));
 
         // check project config built
         verify(projectConfigDtoMerger).merge(any(FactoryDto.class), projectConfigDtoArgumentCaptor.capture());
@@ -218,16 +218,16 @@ public class GitlabFactoryParametersResolverTest {
 
 
         FactoryDto computedFactory = newDto(FactoryDto.class).withV("4.0");
-        when(urlFactoryBuilder.createFactory(any(CreateFactoryParams.class))).thenReturn(computedFactory);
+        when(urlFactoryBuilder.createFactory(anyString())).thenReturn(computedFactory);
 
         gitlabFactoryParametersResolver.createFactory(singletonMap(URL_PARAMETER_NAME, gitlabUrl));
 
         // check we called the builder with the following codenvy json file
         verify(urlFactoryBuilder).createFactory(createFactoryParamsArgumentCaptor.capture());
-        assertEquals(createFactoryParamsArgumentCaptor.getValue().jsonFileLocation(), "https://gitlab.com/eclipse/che/raw/4.2.x/.codenvy.json");
+        assertEquals(createFactoryParamsArgumentCaptor.getValue(), "https://gitlab.com/eclipse/che/raw/4.2.x/.factory.json");
 
         // check we provide dockerfile and correct env
-        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.codenvy.dockerfile"));
+        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.runtime.dockerfile"));
 
         // check project config built
         verify(projectConfigDtoMerger).merge(any(FactoryDto.class), projectConfigDtoArgumentCaptor.capture());

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabFactoryParametersResolverTest.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabFactoryParametersResolverTest.java
@@ -150,7 +150,7 @@ public class GitlabFactoryParametersResolverTest {
 
 
         // check we provide dockerfile and correct env
-        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/master/.runtime.dockerfile"));
+        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/master/.factory.dockerfile"));
 
         // check project config built
         verify(projectConfigDtoMerger).merge(any(FactoryDto.class), projectConfigDtoArgumentCaptor.capture());
@@ -188,7 +188,7 @@ public class GitlabFactoryParametersResolverTest {
         assertEquals(createFactoryParamsArgumentCaptor.getValue(), "https://gitlab.com/eclipse/che/raw/4.2.x/.factory.json");
 
         // check we provide dockerfile and correct env
-        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.runtime.dockerfile"));
+        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.factory.dockerfile"));
 
         // check project config built
         verify(projectConfigDtoMerger).merge(any(FactoryDto.class), projectConfigDtoArgumentCaptor.capture());
@@ -227,7 +227,7 @@ public class GitlabFactoryParametersResolverTest {
         assertEquals(createFactoryParamsArgumentCaptor.getValue(), "https://gitlab.com/eclipse/che/raw/4.2.x/.factory.json");
 
         // check we provide dockerfile and correct env
-        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.runtime.dockerfile"));
+        verify(urlFactoryBuilder).buildWorkspaceConfig(eq("che"), eq("eclipse"), eq("https://gitlab.com/eclipse/che/raw/4.2.x/.factory.dockerfile"));
 
         // check project config built
         verify(projectConfigDtoMerger).merge(any(FactoryDto.class), projectConfigDtoArgumentCaptor.capture());

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParserTest.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabURLParserTest.java
@@ -29,13 +29,13 @@ import static org.testng.Assert.assertTrue;
  * @author Florent Benoit
  */
 @Listeners(MockitoTestNGListener.class)
-public class GitlabUrlParserTest {
+public class GitlabURLParserTest {
 
     /**
      * Instance of component that will be tested.
      */
     @InjectMocks
-    private GitlabUrlParser gitlabUrlParser;
+    private GitlabURLParser gitlabUrlParser;
 
     /**
      * Check invalid url (not a gitlab one)
@@ -60,10 +60,10 @@ public class GitlabUrlParserTest {
     public void checkParsing(String url, String username, String repository, String branch, String subfolder) {
         GitlabUrl gitlabUrl = gitlabUrlParser.parse(url);
 
-        assertEquals(gitlabUrl.username(), username);
-        assertEquals(gitlabUrl.repository(), repository);
-        assertEquals(gitlabUrl.branch(), branch);
-        assertEquals(gitlabUrl.subfolder(), subfolder);
+        assertEquals(gitlabUrl.getUsername(), username);
+        assertEquals(gitlabUrl.getRepository(), repository);
+        assertEquals(gitlabUrl.getBranch(), branch);
+        assertEquals(gitlabUrl.getSubfolder(), subfolder);
     }
 
     @DataProvider(name = "UrlsProvider")

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrlTest.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrlTest.java
@@ -57,7 +57,7 @@ public class GitlabUrlTest {
      */
     @Test
     public void checkDockerfileLocation() {
-        assertEquals(gitlabUrl.dockerFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.runtime.dockerfile");
+        assertEquals(gitlabUrl.dockerFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.factory.dockerfile");
     }
 
     /**

--- a/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrlTest.java
+++ b/plugins/plugin-gitlab/codenvy-plugin-gitlab-factory-resolver/src/test/java/com/codenvy/plugin/gitlab/factory/resolver/GitlabUrlTest.java
@@ -36,7 +36,7 @@ public class GitlabUrlTest {
      * Parser used to create the url.
      */
     @InjectMocks
-    private GitlabUrlParser gitlabUrlParser;
+    private GitlabURLParser gitlabUrlParser;
 
     /**
      * Instance of the url created
@@ -57,7 +57,7 @@ public class GitlabUrlTest {
      */
     @Test
     public void checkDockerfileLocation() {
-        assertEquals(gitlabUrl.codenvyDockerFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.codenvy.dockerfile");
+        assertEquals(gitlabUrl.dockerFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.runtime.dockerfile");
     }
 
     /**
@@ -65,7 +65,7 @@ public class GitlabUrlTest {
      */
     @Test
     public void checkCodenvyFactoryJsonFileLocation() {
-        assertEquals(gitlabUrl.codenvyFactoryJsonFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.codenvy.json");
+        assertEquals(gitlabUrl.factoryJsonFileLocation(), "https://gitlab.com/eclipse/che/raw/master/.factory.json");
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?
Use new `.factory.dockerfile` and `.factory.properties` for repo URL based factories. (old filenames are supported as well)

### What issues does this PR fix or reference?
CHE-4498 CHE-4499

#### Changelog
Use new `.factory.dockerfile` and `.factory.properties` for repo URL based factories. 

#### Release Notes



#### Docs PR
