### PR TITLE
Codenvy-1995: fix codenvy cli stop very slow

### DIFF
--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -109,9 +109,7 @@ services:
     image: <%= ENV["IMAGE_SWARM"] %>
     volumes:
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/swarm/node_list:/node_list'
-      - '<%= scope.lookupvar('compose::codenvy_folder') -%>/config/swarm/swarm_entrypoint.sh:/swarm_entrypoint.sh'
       - '<%= scope.lookupvar('compose::codenvy_folder') -%>/logs/swarm/:/var/log/swarm'
-    entrypoint: "/swarm_entrypoint.sh"
     ports:
         - "127.0.0.1:23751:2375"
     links:

--- a/dockerfiles/init/modules/registry/templates/registry_entrypoint.sh.erb
+++ b/dockerfiles/init/modules/registry/templates/registry_entrypoint.sh.erb
@@ -13,4 +13,4 @@ if [ ! -d  /var/log/registry ]; then
     mkdir -p /var/log/registry
 fi
 
-exec /bin/registry serve /etc/docker/registry/config.yml 2>&1 | tee -a /var/log/registry/registry.log
+exec /bin/registry serve /etc/docker/registry/config.yml >>/var/log/registry/registry.log 2>&1

--- a/dockerfiles/init/modules/registry/templates/registry_entrypoint.sh.erb
+++ b/dockerfiles/init/modules/registry/templates/registry_entrypoint.sh.erb
@@ -13,4 +13,12 @@ if [ ! -d  /var/log/registry ]; then
     mkdir -p /var/log/registry
 fi
 
-exec /bin/registry serve /etc/docker/registry/config.yml >>/var/log/registry/registry.log 2>&1
+exec /bin/registry serve /etc/docker/registry/config.yml 2>&1 | tee -a /var/log/registry/registry.log &
+
+pid=`pidof registry`
+trap "echo 'Stopping PID $pid'; kill -SIGTERM $pid" SIGINT SIGTERM
+# A signal emitted while waiting will make the wait command return code > 128
+# Let's wrap it in a loop that doesn't end before the process is indeed stopped
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done

--- a/dockerfiles/init/modules/swarm/manifests/init.pp
+++ b/dockerfiles/init/modules/swarm/manifests/init.pp
@@ -8,10 +8,5 @@ class swarm {
     ensure  => "present",
     content => template("swarm/node_list.erb"),
     mode    => '644',
-  } ->
-  file { "/opt/codenvy/config/swarm/swarm_entrypoint.sh":
-    ensure  => "present",
-    content => template("swarm/swarm_entrypoint.sh.erb"),
-    mode    => '755',
   }
 }

--- a/dockerfiles/swarm/Dockerfile
+++ b/dockerfiles/swarm/Dockerfile
@@ -20,4 +20,6 @@ RUN apk --update add ca-certificates wget \
 ENV SWARM_HOST :2375
 EXPOSE 2375
 
-ENTRYPOINT ["/swarm_entrypoint.sh"]
+COPY entrypoint.sh /
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/swarm/entrypoint.sh
+++ b/dockerfiles/swarm/entrypoint.sh
@@ -13,4 +13,12 @@ if [ ! -d  /var/log/swarm ]; then
     mkdir -p /var/log/swarm
 fi
 
-exec /swarm manage -H 0.0.0.0:2375 file:///node_list >>/var/log/swarm/swarm.log 2>&1
+exec /swarm manage -H 0.0.0.0:2375 file:///node_list 2>&1 | tee -a /var/log/swarm/swarm.log &
+
+pid=`pidof swarm`
+trap "echo 'Stopping PID $pid'; kill -SIGTERM $pid" SIGINT SIGTERM
+# A signal emitted while waiting will make the wait command return code > 128
+# Let's wrap it in a loop that doesn't end before the process is indeed stopped
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done

--- a/dockerfiles/swarm/entrypoint.sh
+++ b/dockerfiles/swarm/entrypoint.sh
@@ -13,4 +13,4 @@ if [ ! -d  /var/log/swarm ]; then
     mkdir -p /var/log/swarm
 fi
 
-exec /swarm manage -H 0.0.0.0:2375 file:///node_list 2>&1 | tee -a /var/log/swarm/swarm.log
+exec /swarm manage -H 0.0.0.0:2375 file:///node_list >>/var/log/swarm/swarm.log 2>&1


### PR DESCRIPTION
### What does this PR do?
Fix very slow codenvy cli stop operation.

Thanks @akorneta for reporting this issue. After some investigation I figured out that this was introduced by: https://github.com/codenvy/codenvy/commit/79079d048c22d5c3cdd1e6c75ab7d41f1dc201de

That happened due to wrong entrypoint which spawned more than 1 process in a container which is antiPattern for docker flow. During docker stop docker send special signal to notify main process (usually pid = 1) in container that this container is going to be stopped, but in our case process with pid = 1 was entrypoint script instead of swarm. As result swarm didn't received stop signal and keep working so docker killed that container with force after timeout **~5min**.

To fix this issue I added logic to entrypoint scripts to handle termiation and properly stop needed process.

### What issues does this PR fix or reference?
Fixes: https://github.com/codenvy/codenvy/issues/1995

#### Changelog
Fix very slow codenvy cli stop operation.
