### PR TITLE
codenvy-1851: invite unregistered users to the team and display invited members

### DIFF
--- a/dashboard/src/app/teams/create-team/create-team.controller.ts
+++ b/dashboard/src/app/teams/create-team/create-team.controller.ts
@@ -16,6 +16,7 @@
 import {CodenvyTeam} from '../../../components/api/codenvy-team.factory';
 import {CodenvyPermissions} from '../../../components/api/codenvy-permissions.factory';
 import {CodenvyUser} from '../../../components/api/codenvy-user.factory';
+import {CodenvyInvite} from '../../../components/api/codenvy-invite.factory';
 
 /**
  * @ngdoc controller
@@ -28,6 +29,10 @@ export class CreateTeamController {
    * Team API interaction.
    */
   private codenvyTeam: CodenvyTeam;
+  /**
+   * Invite API interaction.
+   */
+  private codenvyInvite: CodenvyInvite;
   /**
    * User API interaction.
    */
@@ -81,10 +86,11 @@ export class CreateTeamController {
    * Default constructor
    * @ngInject for Dependency injection
    */
-  constructor(codenvyTeam: CodenvyTeam, codenvyUser: CodenvyUser, codenvyPermissions: CodenvyPermissions, cheNotification: any,
+  constructor(codenvyTeam: CodenvyTeam, codenvyInvite: CodenvyInvite, codenvyUser: CodenvyUser, codenvyPermissions: CodenvyPermissions, cheNotification: any,
               $location: ng.ILocationService, $q: ng.IQService, lodash: any, $log: ng.ILogService) {
     this.codenvyTeam = codenvyTeam;
     this.codenvyUser = codenvyUser;
+    this.codenvyInvite = codenvyInvite;
     this.codenvyPermissions = codenvyPermissions;
     this.cheNotification = cheNotification;
     this.$location = $location;
@@ -141,8 +147,8 @@ export class CreateTeamController {
   addPermissions(team: any, members: Array<any>) {
     let promises = [];
     members.forEach((member: any) => {
+      let actions = this.codenvyTeam.getActionsFromRoles(member.roles);
       if (member.id) {
-        let actions = this.codenvyTeam.getActionsFromRoles(member.roles);
         let permissions = {
           instanceId: team.id,
           userId: member.id,
@@ -151,6 +157,9 @@ export class CreateTeamController {
         };
 
         let promise = this.codenvyPermissions.storePermissions(permissions);
+        promises.push(promise);
+      } else {
+        let promise = this.codenvyInvite.inviteToTeam(team.id, member.email, actions);
         promises.push(promise);
       }
     });

--- a/dashboard/src/app/teams/team-details/team-members/list-team-members.html
+++ b/dashboard/src/app/teams/team-details/team-members/list-team-members.html
@@ -43,12 +43,12 @@
            class="che-list-item-details">
         <che-list-header-column flex-gt-xs="25"
                                 che-sort-value='listTeamMembersController.memberOrderBy'
-                                che-sort-item='name'
-                                che-column-title='Name'></che-list-header-column>
-        <che-list-header-column flex-gt-xs="25"
-                                che-sort-value='listTeamMembersController.memberOrderBy'
                                 che-sort-item='email'
                                 che-column-title='Email'></che-list-header-column>
+        <che-list-header-column flex-gt-xs="25"
+                                che-sort-value='listTeamMembersController.memberOrderBy'
+                                che-sort-item='name'
+                                che-column-title='Info'></che-list-header-column>
         <che-list-header-column flex-gt-xs="35"
                                 che-sort-value='listTeamMembersController.memberOrderBy'
                                 che-column-title='Roles'></che-list-header-column>
@@ -62,7 +62,7 @@
   </che-list-header>
   <che-list ng-show="(listTeamMembersController.members | filter:listTeamMembersController.memberFilter).length > 0">
     <member-item
-      ng-repeat="member in listTeamMembersController.members | orderBy:[listTeamMembersController.memberOrderBy, 'config.name'] | filter:listTeamMembersController.memberFilter"
+      ng-repeat="member in listTeamMembersController.members | orderBy:[listTeamMembersController.memberOrderBy, 'name'] | filter:listTeamMembersController.memberFilter"
       ng-model="listTeamMembersController.membersSelectedStatus[member.userId]"
       che-selectable="true"
       che-display-labels="false"

--- a/dashboard/src/app/teams/team-details/team-members/member-item/member-item.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-members/member-item/member-item.controller.ts
@@ -76,7 +76,11 @@ export class MemberItemController {
     let promise = this.confirmDialogService.showConfirmDialog('Remove member', 'Would you like to remove member  ' + this.member.email + ' ?', 'Delete');
 
     promise.then(() => {
-      this.callback.removePermissions(this.member);
+      if (this.member.isPending) {
+        this.callback.deleteInvitation(this.member);
+      } else {
+        this.callback.removePermissions(this.member);
+      }
     });
   }
 

--- a/dashboard/src/app/teams/team-details/team-members/member-item/member-item.html
+++ b/dashboard/src/app/teams/team-details/team-members/member-item/member-item.html
@@ -38,13 +38,16 @@
          class="che-list-item-details">
       <div flex-gt-xs="{{memberItemController.hideDetails ? 60 : 25}}"
            class="che-list-item-name">
-        <span class="che-xs-header noselect" hide-gt-xs>Name</span>
-        <span class="member-email che-hover">{{memberItemController.member.name}}</span>
+        <span class="che-xs-header noselect" hide-gt-xs>Email</span>
+        <span class="member-email che-hover">{{memberItemController.member.email}}</span>
       </div>
       <div flex-gt-xs="{{memberItemController.hideDetails ? 40 : 25}}"
            class="che-list-item-secondary">
-        <span class="che-xs-header noselect" hide-gt-xs>Email</span>
-        <span class="member-email che-hover ">{{memberItemController.member.email}}</span>
+        <span class="che-xs-header noselect" hide-gt-xs>Info</span>
+        <span class="member-email che-hover ">
+          <md-icon md-font-icon="fa-clock-o" class="fa member-pending-icon" ng-if="memberItemController.member.isPending"></md-icon>
+          {{memberItemController.member.name}}
+        </span>
       </div>
       <div flex-gt-xs="35" class="che-list-item-secondary" ng-if="!memberItemController.hideDetails">
         <span class="che-xs-header noselect" hide-gt-xs>Roles</span>

--- a/dashboard/src/app/teams/team-details/team-members/member-item/member-item.styl
+++ b/dashboard/src/app/teams/team-details/team-members/member-item/member-item.styl
@@ -12,3 +12,11 @@
 
 .member-bold
   font-weight bold
+
+.member-pending-icon
+  height 16px
+  margin-right 5px
+  font-size 11pt
+  opacity 0.6
+  box-sizing content-box
+  padding 1px

--- a/dashboard/src/components/api/codenvy-api-config.ts
+++ b/dashboard/src/components/api/codenvy-api-config.ts
@@ -30,6 +30,7 @@ import {CodenvyHttpBackendProviderFactory} from './test/codenvy-http-backend-pro
 import {CodenvyPayment} from './codenvy-payment.factory';
 import {CodenvyInvoices} from './codenvy-invoices.factory';
 import {CodenvySubscription} from './codenvy-subscription.factory';
+import {CodenvyInvite} from './codenvy-invite.factory';
 
 export class CodenvyApiConfig {
 
@@ -51,5 +52,6 @@ export class CodenvyApiConfig {
     register.factory('codenvyPayment', CodenvyPayment);
     register.factory('codenvyInvoices', CodenvyInvoices);
     register.factory('codenvySubscription', CodenvySubscription);
+    register.factory('codenvyInvite', CodenvyInvite);
   }
 }

--- a/dashboard/src/components/api/codenvy-invite.factory.ts
+++ b/dashboard/src/components/api/codenvy-invite.factory.ts
@@ -1,0 +1,119 @@
+/*
+ *  [2015] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+'use strict';
+
+interface ICodenvyInviteResource<T> extends ng.resource.IResourceClass<T> {
+  invite: any;
+  getInvited: any;
+  delete: any;
+}
+
+/**
+ * This class is handling the invitation API.
+ *
+ * @author Ann Shumilova
+ */
+export class CodenvyInvite {
+  /**
+   * Angular promise service.
+   */
+  private $q: ng.IQService;
+
+  /**
+   * Angular Resource service.
+   */
+  private $resource: ng.resource.IResourceService;
+  /**
+   * Team invitations with team's id as a key.
+   */
+  private teamInvitations: Map<string, any>;
+  /**
+   * Client to make remote invitation API calls.
+   */
+  private remoteInviteAPI: ng.resource.IResourceClass<ng.resource.IResource<any>>;
+
+  /**
+   * Default constructor that is using resource
+   * @ngInject for Dependency injection
+   */
+  constructor($q: ng.IQService, $resource: ng.resource.IResourceService) {
+    this.$q = $q;
+    this.$resource = $resource;
+
+    this.teamInvitations = new Map();
+
+    this.remoteInviteAPI = <ICodenvyInviteResource<any>>this.$resource('/api/invite', {}, {
+      invite: {method: 'POST', url: '/api/invite'},
+      getInvited: {method: 'GET', url: '/api/invite/:domain?instance=:instance', isArray: true},
+      remove: {method: 'DELETE', url: '/api/invite/:domain?instance=:instance&email=:email'}
+    });
+  }
+
+  /**
+   * Invite non existing user to the team.
+   *
+   * @param teamId id of the team to invite to
+   * @param email user's email to send invite
+   * @param actions actions to be granted
+   * @returns {any|angular.IPromise<IResourceArray<T>>|angular.IPromise<Array<T>>|angular.IPromise<T>}
+   */
+  inviteToTeam(teamId: string, email: string, actions: Array<string>): ng.IPromise<any> {
+    let promise = this.remoteInviteAPI.invite({domainId: 'organization', instanceId: teamId, email: email, actions: actions}).$promise;
+    return promise;
+  }
+
+  /**
+   * Fetches the list of team invitations.
+   *
+   * @param teamId id of the team to fetch invites
+   * @returns {any|angular.IPromise<IResourceArray<T>>|angular.IPromise<Array<T>>|angular.IPromise<T>}
+   */
+  fetchTeamInvitations(teamId: string): ng.IPromise<any> {
+    let deferred = this.$q.defer();
+    let promise = this.remoteInviteAPI.getInvited({domain: 'organization', instance: teamId}).$promise;
+    promise.then((data: any) => {
+      this.teamInvitations.set(teamId, data);
+      deferred.resolve(data);
+    }, (error: any) => {
+      if (error.status === 304) {
+        deferred.resolve(this.teamInvitations.get(teamId));
+      } else {
+        deferred.reject(error);
+      }
+    });
+    return deferred.promise;
+  }
+
+  /**
+   * Returns team's invitations by team's id.
+   *
+   * @param teamId id of the team
+   * @returns {any} invitations list
+   */
+  getTeamInvitations(teamId: string): Array<any> {
+    return this.teamInvitations.get(teamId);
+  }
+
+  /**
+   * Deletes team invitation team's id and user's email.
+   *
+   * @param teamId id of the team
+   * @param email user email to delete invitation
+   * @returns {angular.IPromise<any>}
+   */
+  deleteTeamInvitation(teamId: string, email: string) {
+    return this.remoteInviteAPI.remove({domain: 'organization', instance: teamId, email: email}).$promise;
+  }
+}

--- a/dashboard/src/components/api/codenvy-permissions.factory.ts
+++ b/dashboard/src/components/api/codenvy-permissions.factory.ts
@@ -39,7 +39,6 @@ interface ISystemPermissions {
  * @author Oleksii Orel
  */
 export class CodenvyPermissions {
-
   /**
    * Angular promise service.
    */


### PR DESCRIPTION
Signed-off-by: Ann Shumilova <ashumilova@codenvy.com>

### What does this PR do?
Performs invite of unregistered users and displays the list of invites.

![team-ivited-users](https://cloud.githubusercontent.com/assets/1611939/24454082/0dc94c42-1493-11e7-8ab2-df5e8ca5d055.png)


### What issues does this PR fix or reference?
UI for https://github.com/codenvy/codenvy/issues/1851

#### Changelog
[UD] added sending team invitations to unregistered users and display pending members for admin of the team.

#### Release Notes
When using team on `codenvy.io`, you can now invite user who are not yet having an account created. They will receive an email proposing to create an account and they'll be added into your team. Additionally when sharing a workspace, you can also invite other developers wether they are having an account on `codenvy.io` or not. 

#### Docs PR
https://github.com/codenvy/docs/pull/105

