### PR TITLE
CODENVY-1610 Allows to use single hyphen in the middle of organization name

### DIFF
--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationValidator.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationValidator.java
@@ -48,7 +48,7 @@ public class OrganizationValidator {
             throw new BadRequestException("Organization name required");
         }
         if (!accountValidator.isValidName(organization.getName())) {
-            throw new BadRequestException("Organization name must contain only letters and digits");
+            throw new BadRequestException("Organization name may only contain alphanumeric characters or single hyphens inside");
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?
Allows to use single hyphen in the middle of organization name

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1610

#### Changelog
Allowed to use single hyphen in the middle of organization name

#### Release Notes
Allowed to use single hyphen in the middle of organization name

#### Docs PR
N/A