### PR TITLE
CODENVY-1996: Improve checking sudo in rsync backup scripts

### DIFF
--- a/dockerfiles/init/modules/codenvy/manifests/init.pp
+++ b/dockerfiles/init/modules/codenvy/manifests/init.pp
@@ -124,6 +124,14 @@ class codenvy {
     require => File[$config_dirs],
   }
 
+# creating rsyncbase.sh
+  file { "/opt/codenvy/config/codenvy/conf/rsyncbase.sh":
+    ensure  => "present",
+    content => template("codenvy/rsyncbase.sh.erb"),
+    mode    => "755",
+    require => File[$config_dirs],
+  }
+
 # creating rsyncbackup.sh
   file { "/opt/codenvy/config/codenvy/conf/rsyncbackup.sh":
     ensure  => "present",

--- a/dockerfiles/init/modules/codenvy/templates/rsyncbackup.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncbackup.sh.erb
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+#
+# Copyright (c) 2012-2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
 SRC_FOLDER=${1}
 HOST=${2}
 PORT=${3}

--- a/dockerfiles/init/modules/codenvy/templates/rsyncbackup.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncbackup.sh.erb
@@ -1,49 +1,18 @@
 #!/bin/bash
 
 SRC_FOLDER=${1}
-SRC_HOST=${2}
-SRC_PORT=${3}
+HOST=${2}
+PORT=${3}
 DST_FOLDER=${4}
 REMOVE_ON_SUCCESS=${5=false}
-SRC_USER_NAME=${6}
-
-# Key for SSH connection to sync files
-SSH_KEY=/opt/codenvy-data/conf/ssh/key.pem
-# When Codenvy runs on windows we have issue since key doesn't have permissions 0600.
-# With another permissions on key SSH doesn't work.
-# So we copy key into another place that should be inside of container - so it is Linux and permissions are supported.
-# And apply needed permission to copied file. Copying is performed lazily, so it is skipped when it was done previously.
-# ensure ssh key has correct permissions
-if [[ ! -f /opt/rsync_key ]]; then
-    cp $SSH_KEY /opt/rsync_key
-fi
-if [[ $(stat -c %a /opt/rsync_key) != 600 ]]; then
-    chmod 0600 /opt/rsync_key
-fi
+USER_NAME=${6}
 
 ##### Set by puppet #####
 RSYNC_BACKUP_BWLIMIT=<%= scope.lookupvar('codenvy::rsync_backup_bwlimit') %>
 SSH_LOG_LEVEL=<%= scope.lookupvar('codenvy::rsync_ssh_log_level') %>
 #########################
 
-##### SSH options #####
-SSH_OPTIONS=""
-# Add SSH connection options
-SSH_OPTIONS+=" -i /opt/rsync_key -l ${SRC_USER_NAME} -p ${SRC_PORT}"
-# Disable password authentication since we use key-based auth
-SSH_OPTIONS+=" -o PasswordAuthentication=no"
-# Disable hosts fingerprint checking because it may fail due to
-# starting different containers on the same ports after some period
-SSH_OPTIONS+=" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-# Set SSH logging level to make it possible to investigate problems
-SSH_OPTIONS+=" -o LogLevel=${SSH_LOG_LEVEL}"
-#######################
-
-# We need root permissions in target container to change ownership of files.
-# If user in that container has access to sudo we use it.
-# Otherwise we use rsync without sudo and if it is possible ownership will be changed.
-RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${SRC_HOST} \
-            "if hash sudo 2>/dev/null; then echo 'sudo rsync'; else echo 'rsync'; fi")
+source /opt/codenvy-data/conf/rsyncbase.sh
 
 ##### Rsync options #####
 RSYNC_OPTIONS=""
@@ -80,4 +49,4 @@ rsync ${RSYNC_OPTIONS} \
       --rsh="ssh ${SSH_OPTIONS}" \
       --rsync-path="${RSYNC_COMMAND}" \
       --include='.codenvy/' --filter=':- .gitignore' \
-      ${SRC_HOST}:${SRC_FOLDER} ${DST_FOLDER}
+      ${HOST}:${SRC_FOLDER} ${DST_FOLDER}

--- a/dockerfiles/init/modules/codenvy/templates/rsyncbase.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncbase.sh.erb
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Key for SSH connection to sync files
+SSH_KEY=/opt/codenvy-data/conf/ssh/key.pem
+# When Codenvy runs on windows we have issue since key doesn't have permissions 0600.
+# With another permissions on key SSH doesn't work.
+# So we copy key into another place that should be inside of container - so it is Linux and permissions are supported.
+# And apply needed permission to copied file. Copying is performed lazily, so it is skipped when it was done previously.
+# ensure ssh key has correct permissions
+if [[ ! -f /opt/rsync_key ]]; then
+    cp $SSH_KEY /opt/rsync_key
+fi
+if [[ $(stat -c %a /opt/rsync_key) != 600 ]]; then
+    chmod 0600 /opt/rsync_key
+fi
+
+##### SSH options #####
+SSH_OPTIONS=""
+# Add SSH connection options
+SSH_OPTIONS+=" -i /opt/rsync_key -l ${USER_NAME} -p ${PORT}"
+# Disable password authentication since we use key-based auth
+SSH_OPTIONS+=" -o PasswordAuthentication=no"
+# Disable hosts fingerprint checking because it may fail due to
+# starting different containers on the same ports after some period
+SSH_OPTIONS+=" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+# Set SSH logging level to make it possible to investigate problems
+SSH_OPTIONS+=" -o LogLevel=${SSH_LOG_LEVEL}"
+#######################
+
+# We need root permissions in target container to change ownership of files.
+# If user in that container has access to sudo we use it.
+# Otherwise we use rsync without sudo and if it is possible ownership will be changed.
+checkFile="/tmp/codenvy_sudo_test_$(date +%s)"
+createCheckFile="sh -c 'echo 1 > $checkFile' 2>/dev/null"
+checkSudo="$createCheckFile; hash sudo 2>/dev/null && sudo chown 1000 $checkFile 2>/dev/null"
+GET_RSYNC_COMMAND='if [ "$(id -u)" != "0" ]; then '$checkSudo' && echo "sudo rsync" && exit; fi; echo "rsync"'
+RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${HOST} $(echo "$GET_RSYNC_COMMAND"))

--- a/dockerfiles/init/modules/codenvy/templates/rsyncbase.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncbase.sh.erb
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+#
+# Copyright (c) 2012-2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
 # Key for SSH connection to sync files
 SSH_KEY=/opt/codenvy-data/conf/ssh/key.pem
 # When Codenvy runs on windows we have issue since key doesn't have permissions 0600.

--- a/dockerfiles/init/modules/codenvy/templates/rsyncrestore.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncrestore.sh.erb
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+#
+# Copyright (c) 2012-2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
 SRC_FOLDER=${1}
 DST_FOLDER=${2}
 HOST=${3}

--- a/dockerfiles/init/modules/codenvy/templates/rsyncrestore.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncrestore.sh.erb
@@ -2,48 +2,18 @@
 
 SRC_FOLDER=${1}
 DST_FOLDER=${2}
-DST_HOST=${3}
-DST_PORT=${4}
+HOST=${3}
+PORT=${4}
 DST_USR_ID=${5}
 DST_GRP_ID=${6}
-SRC_USER_NAME=${7}
-
-# Key for SSH connection to sync files
-SSH_KEY=/opt/codenvy-data/conf/ssh/key.pem
-# When Codenvy runs on windows we have issue since key doesn't have permissions 0600.
-# With another permissions on key SSH doesn't work.
-# So we copy key into another place that should be inside of container - so it is Linux and permissions are supported.
-# And apply needed permission to copied file. Copying is performed lazily, so it is skipped when it was done previously.
-if [[ ! -f /opt/rsync_key ]]; then
-    cp $SSH_KEY /opt/rsync_key
-fi
-if [[ $(stat -c %a /opt/rsync_key) != 600 ]]; then
-    chmod 0600 /opt/rsync_key
-fi
+USER_NAME=${7}
 
 ##### Set by puppet #####
 RSYNC_RESTORE_BWLIMIT=<%= scope.lookupvar('codenvy::rsync_restore_bwlimit') %>
 SSH_LOG_LEVEL=<%= scope.lookupvar('codenvy::rsync_ssh_log_level') %>
 #########################
 
-##### SSH options #####
-SSH_OPTIONS=""
-# Add SSH connection options
-SSH_OPTIONS+=" -i /opt/rsync_key -l ${SRC_USER_NAME} -p ${DST_PORT}"
-# Disable password authentication since we use key-based auth
-SSH_OPTIONS+=" -o PasswordAuthentication=no"
-# Disable hosts fingerprint checking because it may fail due to
-# starting different containers on the same ports after some period
-SSH_OPTIONS+=" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-# Set SSH logging level to make it possible to investigate problems
-SSH_OPTIONS+=" -o LogLevel=${SSH_LOG_LEVEL}"
-#######################
-
-# We need root permissions in target container to change ownership of files.
-# If user in that container has access to sudo we use it.
-# Otherwise we use rsync without sudo and if it is possible ownership will be changed.
-RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${DST_HOST} \
-            "if hash sudo 2>/dev/null; then echo 'sudo rsync'; else echo 'rsync'; fi")
+source /opt/codenvy-data/conf/rsyncbase.sh
 
 ##### Rsync options #####
 RSYNC_OPTIONS=""
@@ -78,4 +48,4 @@ rsync ${RSYNC_OPTIONS} \
       --rsh="ssh ${SSH_OPTIONS}" \
       --rsync-path="${RSYNC_COMMAND}" \
       --include='.codenvy/' --filter=':- .gitignore' \
-      ${SRC_FOLDER} ${DST_HOST}:${DST_FOLDER}
+      ${SRC_FOLDER} ${HOST}:${DST_FOLDER}


### PR DESCRIPTION
### What does this PR do?
Changes strategy of checking whether sudo should be used for rsync backuping.

### What issues does this PR fix or reference?
Fixes #1996 

#### Changelog
Improve checking sudo in rsync backup scripts

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
