### PR TITLE
CODENVY-1822: do not log exception on WS start interruption

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
@@ -312,14 +312,15 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
                     "Restoring of workspace " + workspaceId + " filesystem terminated due to timeout on "
                     + destAddress + " node.");
         } catch (InterruptedException e) {
-            LOG.error(e.getLocalizedMessage(), e);
+            Thread.currentThread().interrupt();
             throw new ServerException(
                     "Restoring of workspace " + workspaceId + " filesystem interrupted on " + destAddress + " node.");
         } catch (IOException e) {
-            LOG.error(e.getLocalizedMessage(), e);
-            throw new ServerException(
-                    "Restoring of workspace " + workspaceId + " filesystem terminated on " + destAddress + " node. "
-                    + e.getLocalizedMessage());
+            String error = "Restoring of workspace " + workspaceId +
+                           " filesystem terminated on " + destAddress + " node. "
+                           + e.getLocalizedMessage();
+            LOG.error(error, e);
+            throw new ServerException(error);
         } finally {
             lock.unlock();
             if (!restored) {


### PR DESCRIPTION
### What does this PR do?
Prevents logging exception traces when WS start is interrupted by user while projects are restoring.

### What issues does this PR fix or reference?
Fixes #1822 

#### Changelog
Do not log exception about workspace restoring interruption when user stops workspace while it starting.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
