### PR TITLE
CHE-4595: HostedEnvConnectionClosedInformer extends ConnectionClosedInformerImp

### DIFF
--- a/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/java/com/codenvy/ide/hosted/client/informers/HostedEnvConnectionClosedInformer.java
+++ b/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/java/com/codenvy/ide/hosted/client/informers/HostedEnvConnectionClosedInformer.java
@@ -18,7 +18,9 @@ import com.codenvy.ide.hosted.client.HostedLocalizationConstant;
 import com.codenvy.ide.hosted.client.notifier.BadConnectionNotifierView;
 import com.google.inject.Inject;
 
-import org.eclipse.che.ide.api.ConnectionClosedInformer;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.dialogs.DialogFactory;
+import org.eclipse.che.ide.client.ConnectionClosedInformerImpl;
 import org.eclipse.che.ide.websocket.events.WebSocketClosedEvent;
 
 import static org.eclipse.che.ide.websocket.events.WebSocketClosedEvent.CLOSE_ABNORMAL;
@@ -40,24 +42,21 @@ import static org.eclipse.che.ide.websocket.events.WebSocketClosedEvent.CLOSE_VI
  * @author Roman Nikitenko
  * @author Anton Korneta
  */
-public class HostedEnvConnectionClosedInformer implements ConnectionClosedInformer {
+public class HostedEnvConnectionClosedInformer extends ConnectionClosedInformerImpl {
 
     private BadConnectionNotifierView  badConnectionInfoView;
     private HostedLocalizationConstant localizationConstant;
 
     @Inject
-    HostedEnvConnectionClosedInformer(final BadConnectionNotifierView badConnectionInfoView,
+    HostedEnvConnectionClosedInformer(final DialogFactory dialogFactory,
+                                      final CoreLocalizationConstant corelocalizationConstant,
+                                      final BadConnectionNotifierView badConnectionInfoView,
                                       final HostedLocalizationConstant localizationConstant) {
+        super(dialogFactory, corelocalizationConstant);
         this.badConnectionInfoView = badConnectionInfoView;
         this.localizationConstant = localizationConstant;
 
-        badConnectionInfoView.setDelegate(new BadConnectionNotifierView.ActionDelegate() {
-
-            @Override
-            public void onOkClicked() {
-                badConnectionInfoView.close();
-            }
-        });
+        badConnectionInfoView.setDelegate(() -> badConnectionInfoView.close());
     }
 
     @Override

--- a/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/java/com/codenvy/ide/hosted/client/inject/HostedEnvironmentGinModule.java
+++ b/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/java/com/codenvy/ide/hosted/client/inject/HostedEnvironmentGinModule.java
@@ -23,8 +23,8 @@ import com.codenvy.ide.hosted.client.workspace.WorkspaceNotRunningView;
 import com.codenvy.ide.hosted.client.workspace.WorkspaceNotRunningViewImpl;
 import com.google.gwt.inject.client.AbstractGinModule;
 
-import org.eclipse.che.ide.api.ConnectionClosedInformer;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
+import org.eclipse.che.ide.client.ConnectionClosedInformerImpl;
 
 /**
  * @author Vitaly Parfonov
@@ -33,7 +33,7 @@ import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 public class HostedEnvironmentGinModule extends AbstractGinModule {
     @Override
     protected void configure() {
-        bind(ConnectionClosedInformer.class).to(HostedEnvConnectionClosedInformer.class).in(javax.inject.Singleton.class);
+        bind(ConnectionClosedInformerImpl.class).to(HostedEnvConnectionClosedInformer.class).in(javax.inject.Singleton.class);
         bind(PromptToLoginView.class).to(PromptToLoginViewImpl.class);
         bind(BadConnectionNotifierView.class).to(BadConnectionNotifierViewImpl.class);
         bind(WorkspaceNotRunningView.class).to(WorkspaceNotRunningViewImpl.class);

--- a/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/resources/com/codenvy/ide/hosted/Hosted.gwt.xml
+++ b/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/resources/com/codenvy/ide/hosted/Hosted.gwt.xml
@@ -22,4 +22,5 @@
     <inherits name="com.google.gwt.json.JSON"/>
     <inherits name='org.eclipse.che.ide.Api'/>
     <inherits name="com.google.gwt.inject.Inject"/>
+    <inherits name="org.eclipse.che.ide.Core"/>
 </module>


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@codenvy.com>

### What does this PR do?
HostedEnvConnectionClosedInformer extends ConnectionClosedInformerImp from Che 

### What issues does this PR fix or reference?
eclipse/che#4595

#### Changelog
HostedEnvConnectionClosedInformer now extends class ConnectionClosedInformerImp from Che this allow make different behavior in Codenvy project.

#### Release Notes
N/A


