### PR TITLE
CODENVY-2053: Retry rsync restore on unexpected fail

### DIFF
--- a/dockerfiles/init/modules/codenvy/templates/rsyncbase.sh.erb
+++ b/dockerfiles/init/modules/codenvy/templates/rsyncbase.sh.erb
@@ -11,6 +11,9 @@
 #   Codenvy, S.A. - initial API and implementation
 #
 
+sshRetries=2
+sshDelayBeforeRetrySec=2
+
 # Key for SSH connection to sync files
 SSH_KEY=/opt/codenvy-data/conf/ssh/key.pem
 # When Codenvy runs on windows we have issue since key doesn't have permissions 0600.
@@ -45,4 +48,20 @@ checkFile="/tmp/codenvy_sudo_test_$(date +%s)"
 createCheckFile="sh -c 'echo 1 > $checkFile' 2>/dev/null"
 checkSudo="$createCheckFile; hash sudo 2>/dev/null && sudo chown 1000 $checkFile 2>/dev/null"
 GET_RSYNC_COMMAND='if [ "$(id -u)" != "0" ]; then '$checkSudo' && echo "sudo rsync" && exit; fi; echo "rsync"'
-RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${HOST} $(echo "$GET_RSYNC_COMMAND"))
+
+function getRsyncCommand {
+  RSYNC_COMMAND=$(ssh ${SSH_OPTIONS} ${HOST} $(echo "$GET_RSYNC_COMMAND"))
+  sshErrCode=$?
+}
+
+getRsyncCommand
+# Check whether ssh was successful and retries a few times if not
+# This is needed when some unexpected error happens, for example, network problems, etc.
+if [ $sshErrCode -ne 0 ]; then
+  sshRetryNumber=1
+  while [ $sshErrCode -ne 0 ] && [ $sshRetryNumber -le $sshRetries ]; do
+    sleep $sshDelayBeforeRetrySec
+    getRsyncCommand
+    ((sshRetryNumber++))
+  done
+fi


### PR DESCRIPTION
### What does this PR do?
This PR improves stability of workspace start by adding rsync exit code check and retrying if workspace restore fail.
Workspace restore could fail due to network errors, tricky cache system of user's OS after adding SSH key from concurrent thread, long sshd time start, etc.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2053

#### Changelog
Added check that SSH into workspace succeeds when doing backup/restore.
Added retry for initially failed workspace backup/restore.

#### Release Notes
N/A

#### Docs PR
N/A
