### PR TITLE
CODENVY-1974 Add publishing BeforeAccountRemovedEvent by OrganizationManager

### DIFF
--- a/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationManager.java
+++ b/wsmaster/codenvy-hosted-api-organization/src/main/java/com/codenvy/organization/api/OrganizationManager.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.google.inject.persist.Transactional;
 
+import org.eclipse.che.account.event.BeforeAccountRemovedEvent;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
@@ -172,6 +173,7 @@ public class OrganizationManager {
         requireNonNull(organizationId, "Required non-null organization id");
         try {
             OrganizationImpl organization = organizationDao.getById(organizationId);
+            eventService.publish(new BeforeAccountRemovedEvent(organization.getAccount())).propagateException();
             eventService.publish(new BeforeOrganizationRemovedEvent(organization)).propagateException();
             removeSuborganizations(organizationId);
             final List<Member> members = removeMembers(organizationId);


### PR DESCRIPTION
### What does this PR do?
Add publishing BeforeAccountRemovedEvent by OrganizationManager. It is required because organizational account will be removed automatically before removing of organization. Earlier AccountEntityListener did it but original exception was not propagated in that case.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1974

#### Changelog
Added publishing BeforeAccountRemovedEvent by OrganizationManager.

#### Release Notes
N/A

#### Docs PR
N/A
