### PR TITLE
Removes all master authentication cookies from ws-agent request on haproxy

### DIFF
--- a/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
+++ b/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
@@ -35,9 +35,9 @@ backend tomcat_bk
 
 backend nginx_bk
     mode http
-    http-request del-header token-access-key
-    http-request del-header session-access-key
-    http-request del-header logged_in
+    http-request replace-header Cookie (.*)session-access-key=([^;]*);(.*) \1\3
+    http-request replace-header Cookie (.*)logged_in=([^;]*);(.*) \1\3
+    http-request replace-header Cookie (.*)token-access-key=([^;]*);(.*) \1\3
     server nginx_bk codenvy-nginx:81 check
 
 backend agents_bk

--- a/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
+++ b/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
@@ -35,6 +35,9 @@ backend tomcat_bk
 
 backend nginx_bk
     mode http
+    http-request del-header token-access-key
+    http-request del-header session-access-key
+    http-request del-header logged_in
     server nginx_bk codenvy-nginx:81 check
 
 backend agents_bk


### PR DESCRIPTION
### What does this PR do?
Removes all master authentication cookies from ws-agent request on haproxy

### What issues does this PR fix or reference?
https://github.com/codenvy/infrastructure/issues/84

#### Changelog
Remove all master authentication cookies from ws-agent request on haproxy
