### PR TITLE
CHE-4462; Separate master and agents OAuth modules;

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiModule.java
@@ -198,7 +198,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
 
         //oauth
         bind(OAuthAuthenticatorProvider.class).to(OAuthAuthenticatorProviderImpl.class);
-        bind(org.eclipse.che.api.auth.oauth.OAuthTokenProvider.class).to(OAuthAuthenticatorTokenProvider.class);
+        bind(org.eclipse.che.security.oauth.shared.OAuthTokenProvider.class).to(OAuthAuthenticatorTokenProvider.class);
         bind(org.eclipse.che.security.oauth1.OAuthAuthenticationService.class);
 
         install(new org.eclipse.che.security.oauth.BitbucketModule());

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/pom.xml
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketConnectionImpl.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketConnectionImpl.java
@@ -14,7 +14,6 @@
  */
 package org.eclipse.che.ide.ext.bitbucket.server;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -24,6 +23,7 @@ import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketRepositoriesPage;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketRepository;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketRepositoryFork;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketUser;
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketConnectionProvider.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketConnectionProvider.java
@@ -14,9 +14,9 @@
  */
 package org.eclipse.che.ide.ext.bitbucket.server;
 
-import org.eclipse.che.api.auth.oauth.OAuthAuthorizationHeaderProvider;
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.security.oauth.shared.OAuthAuthorizationHeaderProvider;
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketKeyUploader.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketKeyUploader.java
@@ -14,7 +14,6 @@
  */
 package org.eclipse.che.ide.ext.bitbucket.server;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.git.GitUrlUtils;
@@ -23,6 +22,7 @@ import org.eclipse.che.commons.json.JsonHelper;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketKey;
 import org.eclipse.che.plugin.ssh.key.script.SshKeyUploader;
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketServerConnectionImpl.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketServerConnectionImpl.java
@@ -14,7 +14,6 @@
  */
 package org.eclipse.che.ide.ext.bitbucket.server;
 
-import org.eclipse.che.api.auth.oauth.OAuthAuthorizationHeaderProvider;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketLink;
@@ -27,6 +26,7 @@ import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketServerRepositoriesPage;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketServerRepository;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketServerUser;
 import org.eclipse.che.ide.ext.bitbucket.shared.BitbucketUser;
+import org.eclipse.che.security.oauth.shared.OAuthAuthorizationHeaderProvider;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-git-provider/pom.xml
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-git-provider/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/BitbucketOAuthCredentialProvider.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/BitbucketOAuthCredentialProvider.java
@@ -14,19 +14,19 @@
  */
 package org.eclipse.che.ide.ext.git.server.nativegit;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.eclipse.che.api.git.CredentialsProvider;
+import org.eclipse.che.api.git.UserCredential;
 import org.eclipse.che.api.git.exception.GitException;
 import org.eclipse.che.api.git.shared.ProviderInfo;
 import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.api.git.CredentialsProvider;
-import org.eclipse.che.api.git.UserCredential;
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.validation.constraints.NotNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-oauth/pom.xml
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-oauth/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-github/codenvy-plugin-github-webhooks/pom.xml
+++ b/plugins/plugin-github/codenvy-plugin-github-webhooks/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-google/codenvy-plugin-google-oauth2/pom.xml
+++ b/plugins/plugin-google/codenvy-plugin-google-oauth2/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-linkedin/codenvy-plugin-linkedin-oauth2/pom.xml
+++ b/plugins/plugin-linkedin/codenvy-plugin-linkedin-oauth2/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-git-provider/pom.xml
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-git-provider/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/MicrosoftOAuthCredentialsProvider.java
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/MicrosoftOAuthCredentialsProvider.java
@@ -14,16 +14,14 @@
  */
 package org.eclipse.che.ide.ext.git.server.nativegit;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.eclipse.che.api.git.CredentialsProvider;
+import org.eclipse.che.api.git.UserCredential;
 import org.eclipse.che.api.git.exception.GitException;
 import org.eclipse.che.api.git.shared.ProviderInfo;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
-
-import org.eclipse.che.api.git.CredentialsProvider;
-import org.eclipse.che.api.git.UserCredential;
-
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-oauth2/pom.xml
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-oauth2/pom.xml
@@ -59,6 +59,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-ext-server/pom.xml
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-ext-server/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-ext-server/src/main/java/org/eclipse/che/ide/ext/microsoft/server/MicrosoftVstsRestClient.java
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-ext-server/src/main/java/org/eclipse/che/ide/ext/microsoft/server/MicrosoftVstsRestClient.java
@@ -18,7 +18,6 @@ import com.google.api.client.http.HttpMethods;
 import com.google.api.client.repackaged.com.google.common.annotations.Beta;
 import com.google.inject.Singleton;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.UnauthorizedException;
@@ -29,11 +28,12 @@ import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.ide.ext.microsoft.shared.VstsErrorCodes;
 import org.eclipse.che.ide.ext.microsoft.shared.dto.MicrosoftPullRequest;
-import org.eclipse.che.ide.ext.microsoft.shared.dto.MicrosoftVstsApiError;
-import org.eclipse.che.ide.ext.microsoft.shared.dto.NewMicrosoftPullRequest;
 import org.eclipse.che.ide.ext.microsoft.shared.dto.MicrosoftPullRequestList;
 import org.eclipse.che.ide.ext.microsoft.shared.dto.MicrosoftRepository;
 import org.eclipse.che.ide.ext.microsoft.shared.dto.MicrosoftUserProfile;
+import org.eclipse.che.ide.ext.microsoft.shared.dto.MicrosoftVstsApiError;
+import org.eclipse.che.ide.ext.microsoft.shared.dto.NewMicrosoftPullRequest;
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.everrest.core.impl.provider.json.JsonValue;
 
 import javax.inject.Inject;

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/pom.xml
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-projectlocker/codenvy-plugin-projectlocker-git-provider/pom.xml
+++ b/plugins/plugin-projectlocker/codenvy-plugin-projectlocker-git-provider/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-projectlocker/codenvy-plugin-projectlocker-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/ProjectLockerOAuthCredentialProvider.java
+++ b/plugins/plugin-projectlocker/codenvy-plugin-projectlocker-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/ProjectLockerOAuthCredentialProvider.java
@@ -14,14 +14,14 @@
  */
 package org.eclipse.che.ide.ext.git.server.nativegit;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
+
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.eclipse.che.api.git.CredentialsProvider;
+import org.eclipse.che.api.git.UserCredential;
 import org.eclipse.che.api.git.exception.GitException;
 import org.eclipse.che.api.git.shared.ProviderInfo;
 import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.api.git.CredentialsProvider;
-import org.eclipse.che.api.git.UserCredential;
-
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugins/plugin-projectlocker/codenvy-plugin-projectlocker-oauth2/pom.xml
+++ b/plugins/plugin-projectlocker/codenvy-plugin-projectlocker-oauth2/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-redhat/codenvy-plugin-redhat-oauth2/pom.xml
+++ b/plugins/plugin-redhat/codenvy-plugin-redhat-oauth2/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-webhooks/codenvy-plugin-webhooks-base/pom.xml
+++ b/plugins/plugin-webhooks/codenvy-plugin-webhooks-base/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-wso2/codenvy-plugin-wso2-git-provider/pom.xml
+++ b/plugins/plugin-wso2/codenvy-plugin-wso2-git-provider/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-auth</artifactId>
+            <artifactId>che-core-api-auth-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/plugins/plugin-wso2/codenvy-plugin-wso2-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/WSO2OAuthCredentialsProvider.java
+++ b/plugins/plugin-wso2/codenvy-plugin-wso2-git-provider/src/main/java/org/eclipse/che/ide/ext/git/server/nativegit/WSO2OAuthCredentialsProvider.java
@@ -14,14 +14,14 @@
  */
 package org.eclipse.che.ide.ext.git.server.nativegit;
 
-import org.eclipse.che.api.auth.oauth.OAuthTokenProvider;
+
 import org.eclipse.che.api.auth.shared.dto.OAuthToken;
+import org.eclipse.che.api.git.CredentialsProvider;
+import org.eclipse.che.api.git.UserCredential;
 import org.eclipse.che.api.git.exception.GitException;
 import org.eclipse.che.api.git.shared.ProviderInfo;
 import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.api.git.CredentialsProvider;
-import org.eclipse.che.api.git.UserCredential;
-
+import org.eclipse.che.security.oauth.shared.OAuthTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugins/plugin-wso2/codenvy-plugin-wso2-oauth2/pom.xml
+++ b/plugins/plugin-wso2/codenvy-plugin-wso2-oauth2/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/codenvy-hosted-platform-api-impl/pom.xml
+++ b/wsmaster/codenvy-hosted-platform-api-impl/pom.xml
@@ -71,6 +71,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/codenvy-hosted-sso-oauth/pom.xml
+++ b/wsmaster/codenvy-hosted-sso-oauth/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-auth-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What does this PR do?
Adopts moving `RemoteOAuthTokenProvider` and `RemoteOAuthAuthorizationHeaderProvider` to separate module included on wsagent, to avoid include whole auth-core module with AuthrorizationService etc.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/4462

#### Changelog
Decouple ws-agent and ws-master authorization dependencies

#### Release Notes
N/A


#### Docs PR
N/A
