### PR TITLE
CODENVY-2144: Retry interaction with repository on fail

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/SwarmDockerConnector.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/SwarmDockerConnector.java
@@ -66,6 +66,8 @@ public class SwarmDockerConnector extends DockerConnector {
     private final int                     nodeDescriptionLength;
 
     private static final Pattern IMAGE_NOT_FOUND_BY_SWARM_ERROR_MESSAGE = Pattern.compile("^Error: image .* not found.*", Pattern.DOTALL);
+    private static final Pattern REPOSITORY_NOT_FOUND_BY_SWARM_ERROR_MESSAGE =
+            Pattern.compile(".*repository .* not found: does not exist or no pull access.*", Pattern.DOTALL);
 
     @Inject
     public SwarmDockerConnector(DockerConnectorConfiguration connectorConfiguration,
@@ -106,8 +108,10 @@ public class SwarmDockerConnector extends DockerConnector {
             return super.createContainer(params);
         } catch (DockerException e) {
             // TODO fix this workaround. Is needed for https://github.com/codenvy/codenvy/issues/1215
+            // and https://github.com/codenvy/codenvy/issues/2144
             if (e.getStatus() == 500 &&
-                IMAGE_NOT_FOUND_BY_SWARM_ERROR_MESSAGE.matcher(e.getOriginError()).matches()) { // if swarm failed to see image
+                (IMAGE_NOT_FOUND_BY_SWARM_ERROR_MESSAGE.matcher(e.getOriginError()).matches() || // if swarm failed to see image
+                REPOSITORY_NOT_FOUND_BY_SWARM_ERROR_MESSAGE.matcher(e.getOriginError()).matches())) { // failed to interact with repository
                 try {
                     Thread.sleep(5000);                   // wait a bit
                     return super.createContainer(params); // and retry after pause


### PR DESCRIPTION
### What does this PR do?
Due to casual error in docker/swarm our system got errors like:
`Error response from docker API, status: 500, message: Error response from daemon: repository eclipse-che/workspace****_machine****_****_dev-machine not found: does not exist or no pull access`
But actually image is present and repository is available. So it could be network issues or some unsynchronized stuff between docker and pure swarm. This PR just adds check for this type of error from docker and retries after little delay.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2144

#### Changelog
Retry interact with repository on fail.

#### Release Notes
N/A

#### Docs PR
N/A