### PR TITLE
CHE-3948: fix build of dockerfiles behind a proxy

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedMachineProviderImplTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedMachineProviderImplTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 import static com.codenvy.machine.MaintenanceConstraintProvider.MAINTENANCE_CONSTRAINT_KEY;
 import static com.codenvy.machine.MaintenanceConstraintProvider.MAINTENANCE_CONSTRAINT_VALUE;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonMap;
 import static org.mockito.Matchers.any;
@@ -163,7 +164,8 @@ public class HostedMachineProviderImplTest {
                                                  0,
                                                  0,
                                                  emptySet(),
-                                                 null);
+                                                 null,
+                                                 emptyMap());
     }
 
     @Test
@@ -211,7 +213,8 @@ public class HostedMachineProviderImplTest {
                                                  cpuPeriod,
                                                  cpuQuota,
                                                  emptySet(),
-                                                 null);
+                                                 null,
+                                                 emptyMap());
 
         // when
         createInstanceFromRecipe();


### PR DESCRIPTION
### What does this PR do?
Adds possibility to use dockerfile with `apt-get install` like instructions as a source of WS machine.
Note that in case sudo is used in build/inside container user has to use sudo -E to pass proxy variables into root's environment or set these variables himself.

### What issues does this PR fix or reference?
Related to eclipse/che#3948

#### Changelog
Add possibility to access external resources in docker image build phase of workspace start if Che is deployed in environment behind the proxy.  

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
