### PR TITLE
CODENVY-2047; fix base path for Swagger configuration on agent

### DIFF
--- a/assembly/assembly-wsagent-war/src/main/java/com/codenvy/ext/java/server/AgentSwaggerConfig.java
+++ b/assembly/assembly-wsagent-war/src/main/java/com/codenvy/ext/java/server/AgentSwaggerConfig.java
@@ -16,7 +16,6 @@ package com.codenvy.ext.java.server;
 
 
 import io.swagger.jaxrs.config.BeanConfig;
-import io.swagger.jaxrs.config.DefaultJaxrsConfig;
 import io.swagger.jaxrs.config.SwaggerContextService;
 
 import org.slf4j.Logger;
@@ -27,6 +26,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -36,7 +36,7 @@ import java.net.URL;
  * @author Max Shaposhnik (mshaposhnik@codenvy.com)
  */
 @Singleton
-public class AgentSwaggerConfig extends DefaultJaxrsConfig {
+public class AgentSwaggerConfig extends HttpServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(AgentSwaggerConfig.class);
 

--- a/assembly/assembly-wsagent-war/src/main/java/com/codenvy/ext/java/server/AgentSwaggerConfig.java
+++ b/assembly/assembly-wsagent-war/src/main/java/com/codenvy/ext/java/server/AgentSwaggerConfig.java
@@ -1,0 +1,63 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.ext.java.server;
+
+
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.config.DefaultJaxrsConfig;
+import io.swagger.jaxrs.config.SwaggerContextService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Initializes Swagger config with correct base path.
+ *
+ * @author Max Shaposhnik (mshaposhnik@codenvy.com)
+ */
+@Singleton
+public class AgentSwaggerConfig extends DefaultJaxrsConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgentSwaggerConfig.class);
+
+    @Inject
+    @Named("wsagent.endpoint")
+    private String agentEndpoint;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        try {
+            BeanConfig beanConfig = new BeanConfig();
+            beanConfig.setVersion("1.0");
+            beanConfig.setTitle("Codenvy");
+            beanConfig.setBasePath(new URL(agentEndpoint).getPath());
+            beanConfig.scanAndRead();
+            new SwaggerContextService()
+                    .withSwaggerConfig(beanConfig)
+                    .initConfig()
+                    .initScanner();
+        } catch (MalformedURLException e) {
+             LOG.warn("Unable to initialize swagger config due to malformed agent URL.", e);
+        }
+    }
+}

--- a/assembly/assembly-wsagent-war/src/main/java/com/codenvy/ext/java/server/SwaggerServletModule.java
+++ b/assembly/assembly-wsagent-war/src/main/java/com/codenvy/ext/java/server/SwaggerServletModule.java
@@ -14,7 +14,6 @@
  */
 package com.codenvy.ext.java.server;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.servlet.ServletModule;
 
 import org.eclipse.che.inject.DynaModule;
@@ -24,11 +23,7 @@ import org.eclipse.che.inject.DynaModule;
 public class SwaggerServletModule extends ServletModule {
     @Override
     protected void configureServlets() {
-        bind(io.swagger.jaxrs.config.DefaultJaxrsConfig.class).asEagerSingleton();
         install(new org.eclipse.che.swagger.deploy.DocsModule());
-        serve("/swaggerinit").with(io.swagger.jaxrs.config.DefaultJaxrsConfig.class, ImmutableMap
-                .of("api.version", "1.0",
-                    "swagger.api.title", "Eclipse Che",
-                    "swagger.api.basepath", "/.*/api"));
+        serve("/swaggerinit").with(AgentSwaggerConfig.class);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Sets correct base path for Swagger configuration on agent. Example:
http://172.17.0.1/37639_172.17.0.1/api/docs/swagger.json

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2047

#### Changelog
Fixes the base path for Swagger configuration on the agent.

#### Release Notes
N/A


#### Docs PR
https://github.com/eclipse/che-docs/pull/219