### PR TITLE
CODENVY-1834: fix work of docker backup manager if container unexpectedly exited

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/RemoteDockerNode.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/RemoteDockerNode.java
@@ -19,6 +19,7 @@ import com.codenvy.swarm.client.SwarmDockerConnector;
 import com.google.inject.assistedinject.Assisted;
 
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.environment.server.exception.EnvironmentException;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
 import org.eclipse.che.plugin.docker.client.json.ContainerInfo;
@@ -90,7 +91,7 @@ public class RemoteDockerNode implements DockerNode {
     }
 
     @Override
-    public void bindWorkspace() throws ServerException {
+    public void bindWorkspace() throws ServerException, EnvironmentException {
         backupManager.restoreWorkspaceBackup(workspaceId, containerId, nodeHost);
         isBound = true;
     }
@@ -105,6 +106,8 @@ public class RemoteDockerNode implements DockerNode {
         } else {
             try {
                 backupManager.backupWorkspaceAndCleanup(workspaceId, containerId, nodeHost);
+            } catch (EnvironmentException e) {
+                LOG.info("Workspace unbinding failed due to environment error. Error: " + e.getLocalizedMessage());
             } catch (ServerException e) {
                 // TODO do throw it further when it won't brake ws stop
                 LOG.error(e.getLocalizedMessage(), e);

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/launcher/MachineInnerRsyncAgentLauncherImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/launcher/MachineInnerRsyncAgentLauncherImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.che.api.agent.server.launcher.CommandExistsAgentChecker;
 import org.eclipse.che.api.agent.server.launcher.CompositeAgentLaunchingChecker;
 import org.eclipse.che.api.agent.shared.model.Agent;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.environment.server.exception.EnvironmentException;
 import org.eclipse.che.api.machine.server.spi.Instance;
 import org.eclipse.che.plugin.docker.machine.DockerInstance;
 import org.eclipse.che.plugin.docker.machine.node.DockerNode;
@@ -30,6 +31,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import static java.lang.String.format;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -66,7 +68,13 @@ public class MachineInnerRsyncAgentLauncherImpl extends AbstractAgentLauncher {
 
         DockerNode node = (DockerNode)machine.getNode();
         DockerInstance dockerMachine = (DockerInstance)machine;
-        node.bindWorkspace();
+        try {
+            node.bindWorkspace();
+        } catch (EnvironmentException e) {
+            throw new AgentStartException(
+                    format("Agent '%s' start failed because of an error with underlying environment. Error: %s",
+                           agent.getId(), e.getLocalizedMessage()));
+        }
         LOG.info("Docker machine has been deployed. " +
                  "ID '{}'. Workspace ID '{}'. " +
                  "Container ID '{}'. Node host '{}'. Node IP '{}'",

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
@@ -25,6 +25,7 @@ import org.eclipse.che.api.core.util.CommandLine;
 import org.eclipse.che.api.core.util.ListLineConsumer;
 import org.eclipse.che.api.core.util.ProcessUtil;
 import org.eclipse.che.api.core.util.ValueHolder;
+import org.eclipse.che.api.environment.server.exception.EnvironmentException;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.plugin.docker.client.DockerConnector;
@@ -147,12 +148,14 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
      *         id of container that contains data
      * @param nodeHost
      *         host of a node where container is running
+     * @throws EnvironmentException
+     *         if backup failed due to abnormal state of machines in environment
      * @throws ServerException
-     *         if any error occurs
+     *         if any other error occurs
      */
     public void backupWorkspaceAndCleanup(String workspaceId,
                                           String containerId,
-                                          String nodeHost) throws ServerException {
+                                          String nodeHost) throws ServerException, EnvironmentException {
         try {
             String destPath = workspaceIdHashLocationFinder.calculateDirPath(backupsRootDir, workspaceId).toString();
             // if sync agent is not in machine port parameter is not used
@@ -185,12 +188,14 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
      *         id of container where data should be copied
      * @param nodeHost
      *         host of a node where container is running
+     * @throws EnvironmentException
+     *         if restore failed due to abnormal state of machines in environment
      * @throws ServerException
      *         if any error occurs
      */
     public void restoreWorkspaceBackup(String workspaceId,
                                        String containerId,
-                                       String nodeHost) throws ServerException {
+                                       String nodeHost) throws ServerException, EnvironmentException {
         try {
             String srcPath = workspaceIdHashLocationFinder.calculateDirPath(backupsRootDir, workspaceId).toString();
             User user = getUserInfo(workspaceId, containerId);
@@ -470,13 +475,16 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
      * @throws ServerException
      *         if port is not found
      */
-    private int getSyncPort(String containerId) throws ServerException {
+    private int getSyncPort(String containerId) throws ServerException, EnvironmentException {
         ContainerInfo containerInfo;
         try {
             containerInfo = dockerConnector.inspectContainer(containerId);
         } catch (IOException e) {
             LOG.error(e.getLocalizedMessage(), e);
             throw new ServerException("Workspace projects files in ws-machine are not accessible");
+        }
+        if (!containerInfo.getState().isRunning()) {
+            throw new EnvironmentException("Container " + containerId + " unexpectedly exited");
         }
 
         Map<String, List<PortBinding>> ports = firstNonNull(containerInfo.getNetworkSettings().getPorts(), emptyMap());

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/RemoteDockerNodeTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/RemoteDockerNodeTest.java
@@ -90,14 +90,14 @@ public class RemoteDockerNodeTest {
     }
 
     @Test
-    public void backupIsNotCalledWhenRestoreIsNotCalled() throws ServerException {
+    public void backupIsNotCalledWhenRestoreIsNotCalled() throws Exception {
         remoteDockerNode.unbindWorkspace();
 
         verifyBackupIsNeverCalled();
     }
 
     @Test
-    public void backupIsNotCalledWhenRestoreIsFailed() throws ServerException {
+    public void backupIsNotCalledWhenRestoreIsFailed() throws Exception {
         doThrow(new ServerException("no!"))
                 .when(backupManager)
                 .restoreWorkspaceBackup(anyString(), anyString(), anyString());
@@ -124,7 +124,7 @@ public class RemoteDockerNodeTest {
         remoteDockerNode.bindWorkspace();
     }
 
-    private void verifyBackupIsNeverCalled() throws ServerException {
+    private void verifyBackupIsNeverCalled() throws Exception {
         verify(backupManager, never()).backupWorkspaceAndCleanup(anyString(), anyString(), anyString());
     }
 }


### PR DESCRIPTION
### What does this PR do?
Throws special exception that indicates abnormal state of docker machine if container is not in running state on backup/restore operations.

### What issues does this PR fix or reference?
Fixes #1834 

#### Changelog
Do not print stack traces into log when container exited before restore/backup operation. 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
