### PR TITLE
CODENVY-1826; skip machine token validation for CORS preflight OPTIONS requests

### DIFF
--- a/wsagent/codenvy-hosted-machine-authentication-agent/pom.xml
+++ b/wsagent/codenvy-hosted-machine-authentication-agent/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
         </dependency>
         <dependency>

--- a/wsagent/codenvy-hosted-machine-authentication-agent/src/main/java/com/codenvy/machine/authentication/agent/MachineLoginFilter.java
+++ b/wsagent/codenvy-hosted-machine-authentication-agent/src/main/java/com/codenvy/machine/authentication/agent/MachineLoginFilter.java
@@ -39,6 +39,8 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.commons.lang.StringUtils.endWith;
+import static org.eclipse.che.commons.lang.StringUtils.trimEnd;
 
 /**
  * Protects user's machine from unauthorized access.
@@ -70,6 +72,9 @@ public class MachineLoginFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
                                                                                                      ServletException {
         final HttpServletRequest httpRequest = (HttpServletRequest)request;
+        if ("OPTIONS".equals(httpRequest.getMethod()) && endWith(trimEnd(httpRequest.getServletPath(), '/'), "/api")) {
+            chain.doFilter(request, response);
+        }
         final HttpSession session = httpRequest.getSession(false);
         if (session != null && session.getAttribute("principal") != null) {
             try {


### PR DESCRIPTION
### What does this PR do?
When the machine agent hostname differs from wsmaster host, browser XHR doing preflight `OPTIONS` request to obtain possible CORS `Allow-Origin-*` headers. Those requests should pass through `MachineLoginFilter` and should not be 401-ed. As they send by browser automatically, we can't add machine token to them.
This PR allows `OPTIONS` requests to the `/api/` endpoint to be without machine token.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1826

#### Changelog
Skip machine token validation for CORS preflight OPTIONS requests

#### Release Notes
N/A

#### Docs PR
N/A