### PR TITLE
CODENVY-1826; restore filter order - CORS should be first;

### DIFF
--- a/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/WsAgentServletModule.java
+++ b/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/WsAgentServletModule.java
@@ -17,6 +17,7 @@ package com.codenvy.wsagent.server;
 
 import com.google.inject.servlet.ServletModule;
 
+import org.eclipse.che.api.core.cors.CheCorsFilter;
 import org.eclipse.che.inject.DynaModule;
 
 /**
@@ -39,6 +40,7 @@ public class WsAgentServletModule extends ServletModule {
         getServletContext().addListener(new com.codenvy.auth.sso.client.DestroySessionListener());
 
         //filters
+        filter("/*").through(CheCorsFilter.class);
         filter("/*").through(com.codenvy.machine.authentication.agent.MachineLoginFilter.class);
         filter("/*").through(com.codenvy.workspace.LastAccessTimeFilter.class);
 


### PR DESCRIPTION
### What does this PR do?
Preflight requests should be processed by CORS filter first, so it should be bound before the login filter.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/1826

#### Changelog
Restore correct order of filters.

#### Release Notes
N/A


#### Docs PR
N/A