### PR TITLE
CODENVY-994 Show the user nickname in the left bottom corner of UD

### DIFF
--- a/dashboard/src/app/navbar/codenvy-navbar.html
+++ b/dashboard/src/app/navbar/codenvy-navbar.html
@@ -158,7 +158,7 @@
                     <i class="navbar-icon" flex="none">
                       <img class="developers-face" gravatar-src="codenvyNavbarController.profile.email"/>
                     </i>
-                    <span flex style="text-align: left;">{{codenvyNavbarController.cheAPI.getProfile().getFullName(codenvyNavbarController.profile.attributes)}}</span>
+                    <span flex style="text-align: left;">{{codenvyNavbarController.getUserName()}}</span>
                     <i class="fa fa-angle-up navbar-icon" aria-hidden="true"></i>
                   </div>
                 </md-button>

--- a/dashboard/src/app/navbar/navbar.controller.ts
+++ b/dashboard/src/app/navbar/navbar.controller.ts
@@ -160,6 +160,17 @@ export class CodenvyNavBarController {
   }
 
   /**
+   * Returns user nickname.
+   * @return {string}
+   */
+  getUserName(): string {
+    const {attributes, email} = this.profile;
+    const fullName = this.cheAPI.getProfile().getFullName(attributes).trim();
+
+    return fullName ? fullName : email;
+  }
+
+  /**
    * Returns number of workspaces.
    *
    * @return {number}


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@codenvy.com>

### What does this PR do?
Show the user email as user nickname in the left bottom corner of UD NavBar in the case when user first name and user last name are empty.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/994

#### Changelog
-- Show the user email in the case when user first name and user last name are empty.

#### Release Notes
N/A

![selection_021](https://cloud.githubusercontent.com/assets/6310786/25743602/d7482a76-319d-11e7-864c-e74b42359f39.png)
![selection_022](https://cloud.githubusercontent.com/assets/6310786/25743607/da44969c-319d-11e7-8f30-e96315204deb.png)
