### PR TITLE
CODENVY-1905: add init process into master container

### DIFF
--- a/dockerfiles/codenvy/Dockerfile
+++ b/dockerfiles/codenvy/Dockerfile
@@ -19,7 +19,7 @@ ENV LANG=C.UTF-8 \
     DOCKER_BUCKET=get.docker.com \
     DOCKER_VERSION=1.6.0
 
-RUN apk add --update curl bash rsync sudo openssh postgresql-client postfix && \
+RUN apk add --update curl bash rsync sudo openssh postgresql-client postfix tini && \
     mkdir -p /opt/codenvy-data/ /opt/codenvy-data/logs /opt/codenvy-data/fs \
              /opt/codenvy-data/che-machines /opt/codenvy-data/che-machines-logs \
              /opt/codenvy-data/conf /opt/codenvy-data/conf/logback \
@@ -31,5 +31,6 @@ CMD [ "postfix", "-c", "/etc/postfix", "start" ]
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# Use Tini as real entrypoint - init process that helps reaping zombies
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 ADD codenvy-onpremises.tar.gz /opt/codenvy-tomcat


### PR DESCRIPTION
### What does this PR do?
Adds init process [Tini](https://github.com/krallin/tini) into codenvy container. It prevents zombie emergence after killing rsync scripts because of timed out execution.
BTW there is ability to use it from docker directly, but I didn't manage to use it because of probable [bug](https://github.com/docker/compose/issues/4797) in compose.

### What issues does this PR fix or reference?
Related to #1905. To fix it we need to add the same changes in Saas, and customers repos.

#### Changelog
Add init process to workspace master container to prevent zombie process appearance. 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
