### PR TITLE
CODENVY-2035: Add docs links into branding json

### DIFF
--- a/dashboard/src/assets/branding/product.json
+++ b/dashboard/src/assets/branding/product.json
@@ -9,5 +9,9 @@
   "helpPath": "https://codenvy.com/support/",
   "helpTitle": "Help",
   "supportEmail": "wish@codenvy.com",
-  "oauthDocs": "Please contact your administrator."
+  "oauthDocs": "Please contact your administrator.",
+  "docs" : {
+    "stack" : "/docs/getting-started/runtime-stacks/index.html",
+    "workspace" : "/docs/getting-started/intro/index.html"
+  }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@codenvy.com>

### What does this PR do?
Add docs links into branding JSON.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2035

#### Changelog
 -- Add docs links into branding JSON.
