### PR TITLE
CODENVY-2164: Add search user method by email/username for admins

### DIFF
--- a/wsmaster/codenvy-hosted-api-admin/src/main/java/com/codenvy/api/user/server/AdminUserService.java
+++ b/wsmaster/codenvy-hosted-api-admin/src/main/java/com/codenvy/api/user/server/AdminUserService.java
@@ -23,12 +23,12 @@ import io.swagger.annotations.ApiResponses;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.core.rest.Service;
 import org.eclipse.che.api.core.rest.annotations.GenerateLink;
 import org.eclipse.che.api.user.server.DtoConverter;
 import org.eclipse.che.api.user.server.UserLinksInjector;
 import org.eclipse.che.api.user.server.UserManager;
-import org.eclipse.che.api.user.server.model.impl.UserImpl;
 
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
@@ -44,6 +44,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
  * Provides REST API for admin user management.
  *
  * @author Anatoliy Bazko
+ * @author Anton Korneta
  */
 @Api(value = "/admin/user", description = "Admin user manager")
 @Path("/admin/user")
@@ -82,13 +83,67 @@ public class AdminUserService extends Service {
                            @ApiParam(value = "Skip count") @QueryParam("skipCount") @DefaultValue("0") int skipCount)
             throws ServerException, BadRequestException {
         try {
-            final Page<UserImpl> usersPage = userManager.getAll(maxItems, skipCount);
+            final Page<? extends User> usersPage = userManager.getAll(maxItems, skipCount);
             return Response.ok()
                            .entity(usersPage.getItems(user -> linksInjector.injectLinks(DtoConverter.asDto(user), getServiceContext())))
                            .header("Link", createLinkHeader(usersPage))
                            .build();
         } catch (IllegalArgumentException e) {
             throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/find")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = "Get all users whose e-mail/name contains(case insensitive) given part")
+    @ApiResponses({@ApiResponse(code = 200, message = "The response contains searching result"),
+                   @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
+                   @ApiResponse(code = 500, message = "Internal server error occurred")})
+    public Response find(@ApiParam("User e-mail fragment")
+                         @QueryParam("emailPart")
+                         String emailPart,
+                         @ApiParam("User name fragment")
+                         @QueryParam("namePart")
+                         String namePart,
+                         @ApiParam(value = "Max items")
+                         @QueryParam("maxItems")
+                         @DefaultValue("30")
+                         int maxItems,
+                         @ApiParam(value = "Skip count")
+                         @QueryParam("skipCount")
+                         @DefaultValue("0")
+                         int skipCount) throws ServerException, BadRequestException {
+        checkArgument(maxItems >= 0, "The number of items to return can't be negative");
+        checkArgument(skipCount >= 0, "The number of items to skip can't be negative");
+        if (emailPart == null && namePart == null) {
+            throw new BadRequestException("Missed user's e-mail/name part");
+        }
+        if (emailPart != null && namePart != null) {
+            throw new BadRequestException("Expected either user's e-mail or name part, while both values received");
+        }
+        Page<? extends User> usersPage = namePart == null ? userManager.getByEmailPart(emailPart, maxItems, skipCount)
+                                                          : userManager.getByNamePart(namePart, maxItems, skipCount);
+        return Response.ok()
+                       .entity(usersPage.getItems(user -> linksInjector.injectLinks(DtoConverter.asDto(user),
+                                                                                    getServiceContext())))
+                       .header("Link", createLinkHeader(usersPage))
+                       .build();
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * @param expression
+     *         a boolean expression
+     * @param errorMessage
+     *         the exception message to use if the check fails
+     * @throws BadRequestException
+     *         if {@code expression} is false
+     */
+    private static void checkArgument(boolean expression, String errorMessage) throws BadRequestException {
+        if (!expression) {
+            throw new BadRequestException(errorMessage);
         }
     }
 }

--- a/wsmaster/codenvy-hosted-api-admin/src/main/java/com/codenvy/api/user/server/AdminUserServicePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-admin/src/main/java/com/codenvy/api/user/server/AdminUserServicePermissionsFilter.java
@@ -36,8 +36,9 @@ import static com.codenvy.api.user.server.UserServicePermissionsFilter.MANAGE_US
 @Path("/admin/user{path:.*}")
 public class AdminUserServicePermissionsFilter extends CheMethodInvokerFilter {
     @Override
-    protected void filter(GenericResourceMethod GenericResourceMethod, Object[] arguments) throws ApiException {
-        if (GenericResourceMethod.getMethod().getName().equals("getAll")) {
+    protected void filter(GenericResourceMethod grm, Object[] arguments) throws ApiException {
+        final String methodName = grm.getMethod().getName();
+        if ("getAll".equals(methodName) || "find".equals(methodName)) {
             EnvironmentContext.getCurrent().getSubject().checkPermission(SystemDomain.DOMAIN_ID, null, MANAGE_USERS_ACTION);
         } else {
             //unknown method


### PR DESCRIPTION
### What does this PR do?
Provides a method for administrators that allow to search users by email/name parts. New method is case insensitive and finds users with names/emails that contains given part. 
**method path**: `api.endpoint/admin/user/find`

### What issues does this PR fix or reference?
#2164 

#### Changelog
Add search user method by email/username for admins

#### Release Notes
Add new API to allow system admin to search users by names and emails