### PR TITLE
INFRA-89; do not allow JSESSIONID cookies to be pass between agents;

### DIFF
--- a/assembly/assembly-ide-war/src/main/webapp/META-INF/context.xml
+++ b/assembly/assembly-ide-war/src/main/webapp/META-INF/context.xml
@@ -14,6 +14,6 @@
     from Codenvy S.A..
 
 -->
-<Context path="/" crossContext="false">
+<Context path="/" crossContext="false" sessionCookieName="IDESESSIONID">
     <Valve className="org.apache.catalina.valves.rewrite.RewriteValve"/>
 </Context>

--- a/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
+++ b/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
@@ -38,6 +38,7 @@ backend nginx_bk
     http-request replace-header Cookie (.*)session-access-key=([^;]*);(.*) \1\3
     http-request replace-header Cookie (.*)logged_in=([^;]*);(.*) \1\3
     http-request replace-header Cookie (.*)token-access-key=([^;]*);(.*) \1\3
+    http-request replace-header Cookie (.*)IDESESSIONID=([^;]*);(.*) \1\3
     server nginx_bk codenvy-nginx:81 check
 
 backend agents_bk

--- a/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/SetSessionPathListener.java
+++ b/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/SetSessionPathListener.java
@@ -30,7 +30,14 @@ import java.net.URL;
 
 
 /**
- * Sets correct path to the session id cookies.
+ * Sets correct WS path to the session id cookies.
+ * Since if agent JSESSIONID cookie will be provided with "/" path,
+ * browser will send it both to master and other agents. To prevent this,
+ * each agent JSESSIONID cookie should contain unique path related to this agent,
+ * for example: path="/34011_172.17.0.1/api"
+ *
+ * This listener should be bound in WEB.xml, because Guice binding of {@code ServletContextListener}
+ * not possible in such case.
  *
  * @author Max Shaposhnik (mshaposhnik@codenvy.com)
  */

--- a/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/SetSessionPathListener.java
+++ b/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/SetSessionPathListener.java
@@ -1,0 +1,58 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.wsagent.server;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+
+/**
+ * Sets correct path to the session id cookies.
+ *
+ * @author Max Shaposhnik (mshaposhnik@codenvy.com)
+ */
+@Singleton
+public class SetSessionPathListener implements ServletContextListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SetSessionPathListener.class);
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        try {
+            final ServletContext servletContext = sce.getServletContext();
+            Injector injector = (Injector)servletContext.getAttribute(Injector.class.getName());
+            final String agentEndpoint = injector.getInstance(Key.get(String.class, Names.named("wsagent.endpoint")));
+            servletContext.getSessionCookieConfig().setPath(new URL(agentEndpoint).getPath());
+        } catch (MalformedURLException e) {
+            LOG.warn("Unable to set correct session path due to malformed agent URL.", e);
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+
+    }
+}

--- a/wsagent/codenvy-wsagent-core/src/main/webapp/WEB-INF/web.xml
+++ b/wsagent/codenvy-wsagent-core/src/main/webapp/WEB-INF/web.xml
@@ -39,6 +39,9 @@
     <listener>
         <listener-class>org.eclipse.che.everrest.ServerContainerInitializeListener</listener-class>
     </listener>
+    <listener>
+        <listener-class>com.codenvy.wsagent.server.SetSessionPathListener</listener-class>
+    </listener>
 
     <listener>
         <listener-class>org.everrest.websockets.WSConnectionTracker</listener-class>


### PR DESCRIPTION
### What does this PR do?
 -- Do not allow  agent `JSESSIONID` cookies to be passed between agents and to master; That will be reached by setting cookie path to given WS - e.g: `path=/34011_172.17.0.1/api`
 -- Do not allow  `JSESSIONID` cookies  from master `ROOT.war` to be passed on agent and master; It is renamed in `IDESESSIONID` and blocked on haproxy.

### What issues does this PR fix or reference?
https://github.com/codenvy/infrastructure/issues/89

#### Changelog
Do not allow  agent JSESSIONID cookies to be passed between agents and to master;

#### Release Notes
N/A

#### Docs PR
N/A