### PR TITLE
Add possibility to extend codenvy.env with addon.env if it exist

### DIFF
--- a/dockerfiles/init/entrypoint.sh
+++ b/dockerfiles/init/entrypoint.sh
@@ -8,5 +8,9 @@
 
 # do not copy codenvy.env if exist
 if [ ! -f  /copy/codenvy.env ]; then
+    # if exist add addon env values to main env file.
+    if [ -f /etc/puppet/addon.env ]; then
+        cat /etc/puppet/addon.env >> /etc/puppet/manifests/che.env
+    fi
     cp /etc/puppet/manifests/codenvy.env /copy
 fi


### PR DESCRIPTION
### What does this PR do?
this improve allows to have `addon.env` file and inject values from `addon.env` to `codenvy.env` in custom CLI based on CODENVY CLI. As result user will have codenvy.env with ENV vars from addon.
This merge happens ONLY on first init where codenvy.env not yet generated, to prevent any collisions.

example of usage in saas assembly: https://github.com/codenvy/saas/pull/224

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5117

#### Changelog
Add possibility to extend codenvy.env with addon.env if it exist
