### PR TITLE
Add CSRF prevention filter and adapt clients

### DIFF
--- a/assembly/assembly-ide-war/src/main/webapp/_app/activity.js
+++ b/assembly/assembly-ide-war/src/main/webapp/_app/activity.js
@@ -75,7 +75,7 @@ var ActivityTracker = new function () {
         var xhr = new XMLHttpRequest();
 
         xhr.onreadystatechange = function() {
-            if (xhr.readyState == 4) {
+            if (xhr.readyState == XMLHttpRequest.DONE) {
                 csrfToken = xhr.getResponseHeader("X-CSRF-Token");
                 if (csrfToken) {
                     tokenPresentHandler(csrfToken);

--- a/assembly/assembly-wsmaster-war/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiServletModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiServletModule.java
@@ -14,6 +14,9 @@
  */
 package com.codenvy.api.deploy;
 
+import com.codenvy.auth.sso.client.CodenvyCsrfFilter;
+import com.google.common.base.Joiner;
+import com.google.inject.name.Names;
 import com.google.inject.servlet.ServletModule;
 
 import org.apache.catalina.filters.CorsFilter;
@@ -79,6 +82,11 @@ public class OnPremisesIdeApiServletModule extends ServletModule {
     @Override
     protected void configureServlets() {
         filter(pathForLoginFilter).through(com.codenvy.auth.sso.client.LoginFilter.class);
+
+        // comma separated list of paths like "/service1,/service2"
+        bindConstant().annotatedWith(Names.named("csrf_filter.paths_accepting_parameters")).to("/ssh");
+        filter(pathForLoginFilter).through(CodenvyCsrfFilter.class);
+
         filter(pathForLoginFilter).through(com.codenvy.api.license.filter.SystemLicenseLoginFilter.class);
 
         final Map<String, String> corsFilterParams = new HashMap<>();

--- a/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
+++ b/dockerfiles/init/modules/haproxy/templates/haproxy.cfg.erb
@@ -39,6 +39,7 @@ backend nginx_bk
     http-request replace-header Cookie (.*)logged_in=([^;]*);(.*) \1\3
     http-request replace-header Cookie (.*)token-access-key=([^;]*);(.*) \1\3
     http-request replace-header Cookie (.*)IDESESSIONID=([^;]*);(.*) \1\3
+    http-request replace-header Cookie (.*)X-CSRF-Token=([^;]*);(.*) \1\3
     server nginx_bk codenvy-nginx:81 check
 
 backend agents_bk

--- a/site/app/site/scripts/views/form.js
+++ b/site/app/site/scripts/views/form.js
@@ -1,10 +1,10 @@
 /*
  * CODENVY CONFIDENTIAL
  * __________________
- * 
- *  [2012] - [2013] Codenvy, S.A. 
+ *
+ *  [2012] - [2013] Codenvy, S.A.
  *  All Rights Reserved.
- * 
+ *
  * NOTICE:  All information contained herein is, and remains
  * the property of Codenvy S.A. and its suppliers,
  * if any.  The intellectual and technical concepts contained
@@ -15,7 +15,7 @@
  * is strictly forbidden unless prior written permission is obtained
  * from Codenvy S.A..
  */
- 
+
 define(["jquery", "underscore", "backbone", "models/account", "validation"],
 
     function($,_,Backbone,Account){
@@ -29,6 +29,10 @@ define(["jquery", "underscore", "backbone", "models/account", "validation"],
                         window.location = "/site/maintenance";
                     }
                 });
+
+                // eagerly fetch csrf token
+                this.csrfToken = Account.getCsrfToken();
+
                 this.getBranding = Account.getBrandingInfo()
                 .done(function(Branding){
                     try{

--- a/wsmaster/codenvy-hosted-machine-authentication-ide/pom.xml
+++ b/wsmaster/codenvy-hosted-machine-authentication-ide/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>

--- a/wsmaster/codenvy-hosted-machine-authentication-ide/src/main/java/com/codenvy/machine/authentication/ide/MachineAsyncRequestFactory.java
+++ b/wsmaster/codenvy-hosted-machine-authentication-ide/src/main/java/com/codenvy/machine/authentication/ide/MachineAsyncRequestFactory.java
@@ -16,6 +16,7 @@ package com.codenvy.machine.authentication.ide;
 
 import com.codenvy.machine.authentication.shared.dto.MachineTokenDto;
 import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.Response;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -28,19 +29,18 @@ import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.machine.DevMachine;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.commons.exception.UnmarshallerException;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.rest.AsyncRequest;
+import org.eclipse.che.ide.rest.AsyncRequestCallback;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.Unmarshallable;
 
-import java.util.List;
+import javax.annotation.PostConstruct;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
-import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
-import static org.eclipse.che.ide.MimeType.TEXT_PLAIN;
-import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
-import static org.eclipse.che.ide.rest.HTTPMethod.POST;
 
 /**
  * Looks at the request and substitutes an appropriate implementation.
@@ -49,14 +49,14 @@ import static org.eclipse.che.ide.rest.HTTPMethod.POST;
  */
 @Singleton
 public class MachineAsyncRequestFactory extends AsyncRequestFactory implements WorkspaceStoppedEvent.Handler {
-    private static final String DTO_CONTENT_TYPE   = APPLICATION_JSON;
+    private static final String CSRF_TOKEN_HEADER_NAME = "X-CSRF-Token";
 
     private final Provider<MachineTokenServiceClient> machineTokenServiceProvider;
-    private final DtoFactory                          dtoFactory;
-    private final AppContext appContext;
+    private final AppContext                          appContext;
 
     private String machineToken;
     private String wsAgentBaseUrl;
+    private String csrfToken;
 
     @Inject
     public MachineAsyncRequestFactory(DtoFactory dtoFactory,
@@ -65,36 +65,24 @@ public class MachineAsyncRequestFactory extends AsyncRequestFactory implements W
                                       EventBus eventBus) {
         super(dtoFactory);
         this.machineTokenServiceProvider = machineTokenServiceProvider;
-        this.dtoFactory = dtoFactory;
         this.appContext = appContext;
         eventBus.addHandler(WorkspaceStoppedEvent.TYPE, this);
     }
 
-    @Override
-    protected AsyncRequest doCreateRequest(RequestBuilder.Method method,
-                                           String url,
-                                           Object dtoBody,
-                                           boolean async) {
-        if (!isWsAgentRequest(url)) {
-            return super.doCreateRequest(method, url, dtoBody, async);
-        }
-        return doCreateMachineRequest(method, url, dtoBody, async);
+    @PostConstruct
+    private void init() {
+        requestCsrfToken();
     }
 
-    private AsyncRequest doCreateMachineRequest(RequestBuilder.Method method, String url, Object dtoBody, boolean async) {
-        final AsyncRequest asyncRequest = new MachineAsyncRequest(method, url, async, getMachineToken());
-        if (dtoBody != null) {
-            if (dtoBody instanceof List) {
-                asyncRequest.data(dtoFactory.toJson((List)dtoBody));
-            } else {
-                asyncRequest.data(dtoFactory.toJson(dtoBody));
-            }
-            asyncRequest.header(CONTENT_TYPE, DTO_CONTENT_TYPE);
-        } else if (method != null && POST.equals(method.toString())) {
-            asyncRequest.header(CONTENT_TYPE, TEXT_PLAIN);
+    @Override
+    protected AsyncRequest newAsyncRequest(RequestBuilder.Method method, String url, boolean async) {
+        if (isWsAgentRequest(url)) {
+            return new MachineAsyncRequest(method, url, async, getMachineToken());
         }
-
-        return asyncRequest;
+        if (isModifyingMethod(method)) {
+            return new CsrfPreventingAsyncModifyingRequest(method, url, async);
+        }
+        return super.newAsyncRequest(method, url, async);
     }
 
     private Promise<String> getMachineToken() {
@@ -123,6 +111,7 @@ public class MachineAsyncRequestFactory extends AsyncRequestFactory implements W
 
     /**
      * Going to check is this request goes to WsAgent
+     *
      * @param url
      * @return
      */
@@ -139,5 +128,50 @@ public class MachineAsyncRequestFactory extends AsyncRequestFactory implements W
             }
         }
         return url.contains(nullToEmpty(wsAgentBaseUrl));
+    }
+
+    private Promise<String> requestCsrfToken() {
+        if (csrfToken != null) {
+            return Promises.resolve(csrfToken);
+        }
+        return createGetRequest(appContext.getMasterEndpoint() + "/profile")
+                .header(CSRF_TOKEN_HEADER_NAME, "Fetch")
+                .send(new Unmarshallable<String>() {
+                    @Override
+                    public void unmarshal(Response response) throws UnmarshallerException {
+                        csrfToken = response.getHeader(CSRF_TOKEN_HEADER_NAME);
+                        if (csrfToken != null) {
+                            appContext.getProperties().put(CSRF_TOKEN_HEADER_NAME, csrfToken);
+                        }
+                    }
+
+                    @Override
+                    public String getPayload() {
+                        return csrfToken;
+                    }
+                });
+    }
+
+    private class CsrfPreventingAsyncModifyingRequest extends AsyncRequest {
+
+        protected CsrfPreventingAsyncModifyingRequest(RequestBuilder.Method method, String url, boolean async) {
+            super(method, url, async);
+        }
+
+        @Override
+        public void send(AsyncRequestCallback<?> callback) {
+            requestCsrfToken()
+                    .then(token -> {
+                        super.header(CSRF_TOKEN_HEADER_NAME, token);
+                        super.send(callback);
+                    })
+                    .catchError(arg -> {
+                        super.send(callback);
+                    });
+        }
+    }
+
+    private boolean isModifyingMethod(RequestBuilder.Method method) {
+        return method == RequestBuilder.POST || method == RequestBuilder.PUT || method == RequestBuilder.DELETE;
     }
 }

--- a/wsmaster/codenvy-hosted-sso-client/pom.xml
+++ b/wsmaster/codenvy-hosted-sso-client/pom.xml
@@ -107,6 +107,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/CodenvyCsrfFilter.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/CodenvyCsrfFilter.java
@@ -1,0 +1,84 @@
+/*
+ *  [2012] - [2017] Codenvy, S.A.
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Codenvy S.A. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Codenvy S.A.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Codenvy S.A..
+ */
+package com.codenvy.auth.sso.client;
+
+import com.google.inject.Singleton;
+
+import org.apache.catalina.filters.RestCsrfPreventionFilter;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import static com.codenvy.auth.sso.client.token.CookieRequestTokenExtractor.SECRET_TOKEN_ACCESS_COOKIE;
+
+/**
+ * Prevents <a href="https://en.wikipedia.org/wiki/Cross-site_request_forgery">CSRF</a>
+ * attacks when cookie authentication is used.
+ *
+ * <p>Requires CSRF authentication header as specified
+ * <a href="https://tomcat.apache.org/tomcat-7.0-doc/config/filter.html#CSRF_Prevention_Filter_for_REST_APIs">here</a>.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class CodenvyCsrfFilter implements Filter {
+
+    private final RestCsrfPreventionFilter csrfPreventionFilter;
+
+    @Inject
+    public CodenvyCsrfFilter(@Named("csrf_filter.paths_accepting_parameters") String pathAcceptingParams) {
+        csrfPreventionFilter = new RestCsrfPreventionFilter();
+        csrfPreventionFilter.setPathsAcceptingParams(pathAcceptingParams);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        csrfPreventionFilter.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (containsSessionCookie(((HttpServletRequest)request).getCookies())) {
+            csrfPreventionFilter.doFilter(request, response, chain);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private boolean containsSessionCookie(Cookie[] cookies) {
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (SECRET_TOKEN_ACCESS_COOKIE.equals(cookie.getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void destroy() {
+        csrfPreventionFilter.destroy();
+    }
+}

--- a/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/token/CookieRequestTokenExtractor.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/token/CookieRequestTokenExtractor.java
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /** Extract sso token from cookies. */
 public class CookieRequestTokenExtractor implements RequestTokenExtractor {
-    private static final String SECRET_TOKEN_ACCESS_COOKIE = "session-access-key";
+    public static final String SECRET_TOKEN_ACCESS_COOKIE = "session-access-key";
 
     @Override
     public String getToken(HttpServletRequest req) {


### PR DESCRIPTION
### What does this PR do?
Adds CSRF protection. Resolves codenvy/infrastructure#86.

#### Serverside 
Each request filtered by `LoginFilter` now also filtered by `CodenvyCsrfFilter`.
`CodenvyCsrfFilter` delegates csrf validation routine to the standard [filter](https://tomcat.apache.org/tomcat-7.0-doc/config/filter.html#CSRF_Prevention_Filter_for_REST_APIs)
when _COOKIE_ based authentication is used, which means that clients like CLI(those that use token) will continue to work without any refactoring.
Clients scenario:

- Get token
```
Request headers:
...
session-access-key=0XABCDE...
X-CSRF-Token=Fetch
...

Response headers:
...
X-CSRF-Token=0ABCD(token value)
...
```
- Use token for modification requests:
```
Request headers:
...
session-access-key=0XFFFABCDE...
X-CSRF-Token=0ABCD(token value)
...
```

- Use invalid token or no token in modification request
```
Request headers:
...
session-access-key=0XABCDE...
X-CSRF-Token=hello
...

response is negative code = 403
Response headers:
...
X-CSRF-Token=Required
...
```

#### Changelog
Enabled [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) [protection](https://tomcat.apache.org/tomcat-7.0-doc/config/filter.html#CSRF_Prevention_Filter_for_REST_APIs) for clients that use cookies

#### Release Notes
Enabled CSRF protection which affects all clients that use cookies for authentication, 
now those clients must pass a valid `X-CSRF-Token` header within each modifying request(POST, PUT, DELETE).

Merge depends on https://github.com/codenvy/qa/issues/872