### PR TITLE
INFRASTRUCTURE-17: Reduce sensitivity of docker system RAM values parser

### DIFF
--- a/wsmaster/codenvy-hosted-system/src/main/java/com/codenvy/service/system/DockerBasedSystemRamInfoProvider.java
+++ b/wsmaster/codenvy-hosted-system/src/main/java/com/codenvy/service/system/DockerBasedSystemRamInfoProvider.java
@@ -97,7 +97,7 @@ public class DockerBasedSystemRamInfoProvider implements SystemRamInfoProvider {
           There are as many RAM values arrays inside the 'statusOutput' array as many nodes are present in the system.
          */
         for (String[] systemInfoEntry : statusOutput) {
-            if (systemInfoEntry.length == 2 && " └ Reserved Memory".equals(systemInfoEntry[0])) {
+            if (systemInfoEntry.length == 2 && systemInfoEntry[0] != null && systemInfoEntry[0].endsWith("Reserved Memory")) {
                 allNodesRamUsage.add(systemInfoEntry[1]);
             }
         }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Pull Request Policy: https://github.com/codenvy/planning/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
According to this error:
```
2017-05-15 22:29:47,690[ted-scheduler-9]  [ERROR] [ckerBasedSystemRamInfoProvider 105]  - System RAM values was not found in docker system info response. All system values from docker: [[Role, primary], [Strategy, spread], [Filters, health, port, containerslots, dependency, affinity, constraint, whitelist], [Nodes, 10], [ node1.codenvy.io, node1.codenvy.io:2375], [  └ ID, GOP3:RJ3L:ZAH4:PX67:5MZO:ELXA:WPFZ:HEFK:TUCB:7MVZ:SMKF:ROOY], [  └ Status, Healthy], [  └ Containers, 2 (2 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 4 GiB / 31.03 GiB], [  └ Labels, kernelversion=3.10.0-327.36.3.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:47Z], [  └ ServerVersion, 17.04.0-ce], [ node2.codenvy.io, node2.codenvy.io:2375], [  └ ID, MO3Q:3S4U:RZLN:KA7M:ECQM:JZTE:CWU6:3MU3:JSYJ:3DMZ:HTN5:3YY5], [  └ Status, Healthy], [  └ Containers, 2 (2 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 8 GiB / 31.03 GiB], [  └ Labels, kernelversion=3.10.0-327.36.3.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:26Z], [  └ ServerVersion, 17.04.0-ce], [ node3.codenvy.io, node3.codenvy.io:2375], [  └ ID, 45PX:SQEB:JA4V:3JBV:4DUD:CFI5:ME3I:2PIU:GEHR:MRIQ:M7FS:IGDM], [  └ Status, Healthy], [  └ Containers, 3 (3 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 6 GiB / 31.03 GiB], [  └ Labels, kernelversion=3.10.0-514.2.2.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:22Z], [  └ ServerVersion, 17.04.0-ce], [ node9.codenvy.io, node9.codenvy.io:2375], [  └ ID, KVTW:RLAG:P2IK:E5E3:4YQB:OCK2:PW6Y:ISES:DF7M:XPPD:DSNI:BXTR], [  └ Status, Healthy], [  └ Containers, 3 (3 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 9 GiB / 31.03 GiB], [  └ Labels, kernelversion=3.10.0-327.36.3.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:15Z], [  └ ServerVersion, 17.04.0-ce], [ node10.codenvy.io, node10.codenvy.io:2375], [  └ ID, MYK2:A6M2:GTAS:S24M:SRMF:IVS2:255P:WM7Q:MLYF:UKTM:KN3N:3E2E], [  └ Status, Healthy], [  └ Containers, 3 (3 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 6 GiB / 29.18 GiB], [  └ Labels, kernelversion=3.10.0-514.6.1.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:29Z], [  └ ServerVersion, 17.04.0-ce], [ node18.codenvy.io, node18.codenvy.io:2375], [  └ ID, 45WT:EBCO:ATBH:CAHD:BPWV:NQL4:S43V:DJEM:AK45:C3FV:DWQK:QIJ2], [  └ Status, Healthy], [  └ Containers, 2 (2 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 6 GiB / 29.18 GiB], [  └ Labels, kernelversion=3.10.0-514.16.1.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:27Z], [  └ ServerVersion, 17.04.0-ce], [ node19.codenvy.io, node19.codenvy.io:2375], [  └ ID, KBGZ:KZDE:CAPM:VNKX:CGFB:ACD7:4T3O:KIUR:LMRL:2XOM:DEYQ:BNZR], [  └ Status, Healthy], [  └ Containers, 2 (2 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 5.863 GiB / 29.18 GiB], [  └ Labels, kernelversion=3.10.0-514.16.1.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:26Z], [  └ ServerVersion, 17.04.0-ce], [ node20.codenvy.io, node20.codenvy.io:2375], [  └ ID, WJLH:U2BZ:COTP:IUYX:YYMB:HIWE:DDMU:EPGP:MORV:7H7C:Y4FV:VFAC], [  └ Status, Healthy], [  └ Containers, 3 (3 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 6 GiB / 29.18 GiB], [  └ Labels, kernelversion=3.10.0-514.16.1.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:39Z], [  └ ServerVersion, 17.04.0-ce], [ node21.codenvy.io, node21.codenvy.io:2375], [  └ ID, DWC4:ECC5:LTN7:4X5P:WMEY:OFUN:RKEW:5IYD:6KEN:5VTZ:WZGU:3BYD], [  └ Status, Healthy], [  └ Containers, 3 (3 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 7 GiB / 29.18 GiB], [  └ Labels, kernelversion=3.10.0-514.16.1.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:34Z], [  └ ServerVersion, 17.04.0-ce], [ node30.codenvy.io, node30.codenvy.io:2375], [  └ ID, U4JD:UCRL:7SEG:IA6G:T4ZY:X7BV:CB76:QZKI:7FZT:QN3W:MDYW:RVZN], [  └ Status, Healthy], [  └ Containers, 2 (2 Running, 0 Paused, 0 Stopped)], [  └ Reserved CPUs, 0 / 4], [  └ Reserved Memory, 9 GiB / 29.18 GiB], [  └ Labels, kernelversion=3.10.0-514.16.1.el7.x86_64, operatingsystem=CentOS Linux 7 (Core), storagedriver=devicemapper], [  └ UpdatedAt, 2017-05-15T22:29:27Z], [  └ ServerVersion, 17.04.0-ce]]
```
'Reserved memory' item from `docker info` response, was introduced with two spaces in the begining: 
`_ _└ Reserved Memory`.
In the current state, our docker system RAM values parser detects memory item with one space in the begining. Reworked parser to detect items that end with 'Reserved Memory'.

### What issues does this PR fix or reference?
fixes: https://github.com/codenvy/infrastructure/issues/93

#### Changelog
Fixed bug when sometimes failed to retrieve system RAM values

#### Release Notes
N/A

#### Docs PR
N/A