### PR TITLE
CODENVY-2199: Do not snapshot /tmp folder

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/CodenvyInContainerInfrastructureProvisioner.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/CodenvyInContainerInfrastructureProvisioner.java
@@ -40,8 +40,7 @@ import static org.eclipse.che.api.workspace.shared.Utils.getDevMachineName;
  */
 public class CodenvyInContainerInfrastructureProvisioner extends DefaultInfrastructureProvisioner {
     public static final String SYNC_KEY_ENV_VAR_NAME = "CODENVY_SYNC_PUB_KEY";
-
-    private static final List<String> SNAPSHOT_EXCLUDED_DIRECTORIES = Arrays.asList("/tmp");
+    public static final List<String> SNAPSHOT_EXCLUDED_DIRECTORIES = Arrays.asList("/tmp");
 
     private final String pubSyncKey;
     private final String projectFolder;

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/CodenvyInContainerInfrastructureProvisioner.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/CodenvyInContainerInfrastructureProvisioner.java
@@ -27,6 +27,7 @@ import org.eclipse.che.plugin.docker.machine.ext.provider.DockerExtConfBindingPr
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -39,6 +40,9 @@ import static org.eclipse.che.api.workspace.shared.Utils.getDevMachineName;
  */
 public class CodenvyInContainerInfrastructureProvisioner extends DefaultInfrastructureProvisioner {
     public static final String SYNC_KEY_ENV_VAR_NAME = "CODENVY_SYNC_PUB_KEY";
+
+    private static final List<String> SNAPSHOT_EXCLUDED_DIRECTORIES = Arrays.asList("/tmp");
+
     private final String pubSyncKey;
     private final String projectFolder;
 
@@ -76,6 +80,12 @@ public class CodenvyInContainerInfrastructureProvisioner extends DefaultInfrastr
         List<String> volumes = new ArrayList<>(devMachine.getVolumes());
         volumes.add(projectFolder);
         devMachine.setVolumes(volumes);
+
+        for (CheServiceImpl service : internalEnv.getServices().values()) {
+            volumes = new ArrayList<>(service.getVolumes());
+            volumes.addAll(SNAPSHOT_EXCLUDED_DIRECTORIES); // creates volume for each directory to exclude from a snapshot
+            service.setVolumes(volumes);
+        }
 
         super.provision(envConfig, internalEnv);
     }


### PR DESCRIPTION
### What does this PR do?
Prevents adding `/tmp` folder from a workspace container into a snapshot.
Adds ability to exclude other folders from snapshots.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2199

#### Changelog
Ignore /tmp folder when creating workspace snapshot.

#### Release Notes
Snapshots No Longer Capture `tmp`
We have implemented a small but important change in how we handle snapshots. In order to speed up snapshotting when stopping a workspace, and snapshot restore when workspaces startup we are no longer snapshotting the `tmp` directory.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
