### PR TITLE
CODENVY-2888: Fallback to start from recipe if snapshot is unavailable

### DIFF
--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
@@ -37,6 +37,7 @@ import org.eclipse.che.plugin.docker.client.DockerConnectorProvider;
 import org.eclipse.che.plugin.docker.client.ProgressMonitor;
 import org.eclipse.che.plugin.docker.client.UserSpecificDockerRegistryCredentialsProvider;
 import org.eclipse.che.plugin.docker.client.exception.ContainerNotFoundException;
+import org.eclipse.che.plugin.docker.client.exception.DockerException;
 import org.eclipse.che.plugin.docker.client.exception.ImageNotFoundException;
 import org.eclipse.che.plugin.docker.client.json.ContainerConfig;
 import org.eclipse.che.plugin.docker.client.params.BuildImageParams;
@@ -210,7 +211,7 @@ public class HostedMachineProviderImpl extends MachineProviderImpl {
                                               .withBuildArgs(buildArgs),
                               progressMonitor);
 
-        } catch (ImageNotFoundException e) {
+        } catch (DockerException e) {
             throw new SourceNotFoundException(e.getLocalizedMessage(), e);
         } catch (IOException e) {
             throw new MachineException(e.getLocalizedMessage(), e);

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
@@ -214,6 +214,7 @@ public class HostedMachineProviderImpl extends MachineProviderImpl {
         } catch (ImageNotFoundException e) {
             throw new SourceNotFoundException(e.getLocalizedMessage(), e);
         } catch (DockerException e) {
+            // Check whether image to pull is a snapshot and if so then fallback to workspace recipe.
             if (image != null && SNAPSHOT_LOCATION_PATTERN.matcher(image).matches()) {
                 throw new SourceNotFoundException(e.getLocalizedMessage(), e);
             }


### PR DESCRIPTION
### What does this PR do?
Handles situation when docker failed to pull snapshot image.

### What issues does this PR fix or reference?
https://github.com/codenvy/codenvy/issues/2228

#### Changelog
Fallback to container recipe if snapshot image is unavailable.

#### Release Notes
N/A

#### Docs PR
N/A