### PR TITLE
Remove the use of deprecated format of maven assembly plugin 

### DIFF
--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -110,7 +110,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                      <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/assembly/assembly-wsagent-server/pom.xml
+++ b/assembly/assembly-wsagent-server/pom.xml
@@ -78,7 +78,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                      <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                 </configuration>
             </plugin>
         </plugins>

--- a/dockerfiles/agents/pom.xml
+++ b/dockerfiles/agents/pom.xml
@@ -64,7 +64,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                      <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
It will allow to upgrade maven assembly descriptor

### What does this PR do?
Replace deprecated pom.xml entry and use the newer way
Linked to https://github.com/eclipse/che/issues/5326 (update plugin)

#### Changelog
Replace deprecated pom.xml entry and use the newer way

#### Release Notes
N/A


#### Docs PR
N/A

Change-Id: Ieb85fc1fd45bf9d62b681edb7b3288f708ccf3c3
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
