### PR TITLE
Use HttpSshServiceClient instead of TestSshServiceClient

### DIFF
--- a/selenium/codenvy-selenium-test/pom.xml
+++ b/selenium/codenvy-selenium-test/pom.xml
@@ -77,6 +77,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-user-shared</artifactId>
         </dependency>
         <dependency>
@@ -98,6 +102,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-ssh-key-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.selenium</groupId>
@@ -144,6 +152,11 @@
         <dependency>
             <groupId>com.codenvy.onpremises.wsmaster</groupId>
             <artifactId>codenvy-hosted-authorization</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-github-server</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/selenium/codenvy-selenium-test/pom.xml
+++ b/selenium/codenvy-selenium-test/pom.xml
@@ -105,6 +105,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-github-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-ssh-key-server</artifactId>
         </dependency>
         <dependency>
@@ -152,11 +156,6 @@
         <dependency>
             <groupId>com.codenvy.onpremises.wsmaster</groupId>
             <artifactId>codenvy-hosted-authorization</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-plugin-github-server</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/FairSourceLicenseAcceptorListener.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/FairSourceLicenseAcceptorListener.java
@@ -57,7 +57,7 @@ public class FairSourceLicenseAcceptorListener implements ISuiteListener {
         injector.injectMembers(this);
 
         try {
-            requestFactory.fromUrl(apiEndpoint.get() + "license/system/fair-source-license")
+            requestFactory.fromUrl(apiEndpoint.get() + "/license/system/fair-source-license")
                           .setAuthorizationHeader(adminTestUser.getAuthToken())
                           .usePostMethod()
                           .request();

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/OnpremSeleniumSuiteModule.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/OnpremSeleniumSuiteModule.java
@@ -23,6 +23,9 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.plugin.ssh.key.HttpSshServiceClient;
+import org.eclipse.che.plugin.ssh.key.SshServiceClient;
 import org.eclipse.che.selenium.core.action.ActionsFactory;
 import org.eclipse.che.selenium.core.action.GenericActionsFactory;
 import org.eclipse.che.selenium.core.action.MacOSActionsFactory;
@@ -53,7 +56,6 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspaceUrlResolver;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
 
 import javax.inject.Named;
-import java.util.concurrent.ExecutionException;
 
 import static org.eclipse.che.selenium.core.utils.PlatformUtils.isMac;
 
@@ -103,5 +105,11 @@ public class OnpremSeleniumSuiteModule extends AbstractModule {
     @Provides
     public ActionsFactory getActionFactory() {
         return isMac() ? new MacOSActionsFactory() : new GenericActionsFactory();
+    }
+
+    @Provides
+    public SshServiceClient getSshServiceClient(TestApiEndpointUrlProvider apiEndpointUrlProvider,
+                                                HttpJsonRequestFactory requestFactory) {
+        return new HttpSshServiceClient(apiEndpointUrlProvider.get().toString(), requestFactory);
     }
 }

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestAuthServiceClient.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestAuthServiceClient.java
@@ -54,7 +54,7 @@ public class OnpremTestAuthServiceClient implements TestAuthServiceClient {
         HttpURLConnection http = null;
         String line;
         try {
-            String loginUrl = apiEndpoint + "auth/login";
+            String loginUrl = apiEndpoint + "/auth/login";
             http = (HttpURLConnection)new URL(loginUrl).openConnection();
             http.setRequestMethod("POST");
             http.setAllowUserInteraction(false);
@@ -96,7 +96,7 @@ public class OnpremTestAuthServiceClient implements TestAuthServiceClient {
     @Override
     public void logout(String authToken) {
         try {
-            String apiUrl = apiEndpoint + "auth/logout?token=" + authToken;
+            String apiUrl = apiEndpoint + "/auth/logout?token=" + authToken;
             requestFactory.fromUrl(apiUrl)
                           .usePostMethod()
                           .request();

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestLicenseServiceClient.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestLicenseServiceClient.java
@@ -44,7 +44,7 @@ public class OnpremTestLicenseServiceClient {
 
     public void removeLicense() throws Exception {
         try {
-            requestFactory.fromUrl(apiEndpoint + "license/system")
+            requestFactory.fromUrl(apiEndpoint + "/license/system")
                           .setAuthorizationHeader(adminTestUser.getAuthToken())
                           .useDeleteMethod()
                           .request();
@@ -57,7 +57,7 @@ public class OnpremTestLicenseServiceClient {
         HttpURLConnection httpConnection = null;
 
         try {
-            String apiUrl = apiEndpoint + "license/system";
+            String apiUrl = apiEndpoint + "/license/system";
             URL url = new URL(apiUrl);
             httpConnection = (HttpURLConnection)url.openConnection();
             httpConnection.setRequestMethod("POST");

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestMachineServiceClient.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestMachineServiceClient.java
@@ -45,7 +45,7 @@ public class OnpremTestMachineServiceClient implements TestMachineServiceClient 
      */
     @Override
     public String getMachineApiToken(String workspaceId, String authToken) throws Exception {
-        HttpJsonResponse response = requestFactory.fromUrl(apiEndpoint + "machine/token/" + workspaceId)
+        HttpJsonResponse response = requestFactory.fromUrl(apiEndpoint + "/machine/token/" + workspaceId)
                                                   .setAuthorizationHeader(authToken)
                                                   .useGetMethod()
                                                   .request();

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestOAuthServiceClient.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestOAuthServiceClient.java
@@ -38,7 +38,7 @@ public class OnpremTestOAuthServiceClient {
      *         the name of OAuth provider
      */
     public synchronized void invalidateOAuthProvider(String provider, String token) throws Exception {
-        requestFactory.fromUrl(apiEndpoint + "oauth/token?oauth_provider=" + provider)
+        requestFactory.fromUrl(apiEndpoint + "/oauth/token?oauth_provider=" + provider)
                       .useDeleteMethod()
                       .setAuthorizationHeader(token)
                       .request();
@@ -53,7 +53,7 @@ public class OnpremTestOAuthServiceClient {
      */
     public boolean isOAuthProviderValid(String provider, String token) {
         try {
-            requestFactory.fromUrl(apiEndpoint + "oauth/token?oauth_provider=" + provider)
+            requestFactory.fromUrl(apiEndpoint + "/oauth/token?oauth_provider=" + provider)
                           .useGetMethod()
                           .setAuthorizationHeader(token)
                           .request();

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestOrganizationServiceClient.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/client/OnpremTestOrganizationServiceClient.java
@@ -63,7 +63,7 @@ public class OnpremTestOrganizationServiceClient {
         return organizations;
     }
 
-    private String getApiUrl() {return apiEndpoint + "organization/";}
+    private String getApiUrl() {return apiEndpoint + "/organization";}
 
     public OrganizationDto createOrganization(String name, String parentId, String authToken) throws Exception {
         OrganizationDto data = newDto(OrganizationDto.class)
@@ -86,7 +86,7 @@ public class OnpremTestOrganizationServiceClient {
     }
 
     public void deleteOrganizationById(String id, String authToken) throws Exception {
-        String apiUrl = format("%s%s", getApiUrl(), id);
+        String apiUrl = format("%s/%s", getApiUrl(), id);
 
         try {
             requestFactory.fromUrl(apiUrl)
@@ -125,7 +125,7 @@ public class OnpremTestOrganizationServiceClient {
     }
 
     public OrganizationDto getOrganizationByName(String organizationName, String authToken) throws Exception {
-        String apiUrl = format("%sfind?name=%s", getApiUrl(), organizationName);
+        String apiUrl = format("%s/find?name=%s", getApiUrl(), organizationName);
         return requestFactory.fromUrl(apiUrl)
                              .setAuthorizationHeader(authToken)
                              .request()
@@ -145,7 +145,7 @@ public class OnpremTestOrganizationServiceClient {
     }
 
     public void addOrganizationMember(String organizationId, String userId, List<String> actions, String authToken) throws Exception {
-        String apiUrl = apiEndpoint + "permissions";
+        String apiUrl = apiEndpoint + "/permissions";
         PermissionsDto data = newDto(PermissionsDto.class)
                 .withDomainId("organization")
                 .withInstanceId(organizationId)

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/provider/OnpremTestApiEndpointUrlProvider.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/provider/OnpremTestApiEndpointUrlProvider.java
@@ -34,7 +34,7 @@ public class OnpremTestApiEndpointUrlProvider implements TestApiEndpointUrlProvi
     @Override
     public URL get() {
         try {
-            return new URL(protocol, host, -1, "/api/");
+            return new URL(protocol, host, -1, "/api");
         } catch (MalformedURLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/ssh/LoginBySshKeyTest.java
+++ b/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/ssh/LoginBySshKeyTest.java
@@ -13,10 +13,10 @@ package com.codenvy.selenium.ssh;
 import com.google.inject.Inject;
 
 import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.plugin.ssh.key.SshServiceClient;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.client.TestSshServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestCommandsConstants;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
@@ -47,7 +47,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.compile;
-import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 
 /**
  * @author Musienko Maxim
@@ -90,13 +89,13 @@ public class LoginBySshKeyTest {
     @Inject
     private TestCommandServiceClient   testCommandServiceClient;
     @Inject
-    private TestSshServiceClient       testSshServiceClient;
-    @Inject
     private TestWorkspaceServiceClient workspaceServiceClient;
     @Inject
     private TestProjectServiceClient   testProjectServiceClient;
     @Inject
     private SeleniumWebDriver          seleniumWebDriver;
+    @Inject
+    private SshServiceClient           sshServiceClient;
 
     @BeforeClass
     public void setUp() throws Exception {
@@ -117,7 +116,7 @@ public class LoginBySshKeyTest {
 
     @AfterClass
     public void tearDown() throws Exception {
-        testSshServiceClient.deleteMachineKeyByName(user.getAuthToken(), TITLE_OF_SSH_KEY);
+        sshServiceClient.removePair("machine", TITLE_OF_SSH_KEY);
     }
 
     @Test
@@ -130,7 +129,8 @@ public class LoginBySshKeyTest {
         preferences.generateNewSshKey(TITLE_OF_SSH_KEY);
         preferences.clickOnCloseBtn();
 
-        String sshPrivateKeyFromFirstMachine = testSshServiceClient.getPrivateKeyByName(user.getAuthToken(), TITLE_OF_SSH_KEY);
+        String sshPrivateKeyFromFirstMachine = sshServiceClient.getPair("machine", TITLE_OF_SSH_KEY)
+                                                               .getPrivateKey();
         workspaceServiceClient.stop(ws1.getName(), user.getName(), user.getAuthToken(), false);
         seleniumWebDriver.navigate().refresh();
         notifications.waitExpectedMessageOnProgressPanelAndClosed(TestWorkspaceConstants.RUNNING_WORKSPACE_MESS);


### PR DESCRIPTION
This request fixes issue https://github.com/codenvy/qa/issues/1067: replaces **TestSshServiceClient** by original client [HttpSshServiceClient](https://github.com/eclipse/che/blob/master/wsagent/che-core-ssh-key-server/src/main/java/org/eclipse/che/plugin/ssh/key/HttpSshServiceClient.java).

@tolusha: please, review this request.