### PR TITLE
Fix plugin activity IDE version

### DIFF
--- a/plugins/plugin-activity/codenvy-plugin-activity-ide/pom.xml
+++ b/plugins/plugin-activity/codenvy-plugin-activity-ide/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>codenvy-plugin-activity-parent</artifactId>
         <groupId>com.codenvy.plugin</groupId>
-        <version>5.16.0-SNAPSHOT</version>
+        <version>5.17.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>codenvy-plugin-activity-ide</artifactId>


### PR DESCRIPTION
Fix plugin-activity IDE version (follow-up to https://github.com/codenvy/codenvy/pull/2347)