### PR TITLE
Add missing artifacts of EclipseLink for the runtime

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -335,6 +335,14 @@
             <artifactId>che-plugin-url-factory</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-core</artifactId>
         </dependency>


### PR DESCRIPTION
### What does this PR do?
Add missing artifacts of EclipseLink for the runtime after the update to EclipseLink 2.7


Change-Id: Ib5bd2164f8405215935d0d3776bc3f5167678182
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>



docker logs -f codenvy_codenvy_1
```
2017-09-28 05:42:52,697[main]             [INFO ] [o.a.c.core.StandardService 416]      - Starting service Catalina
2017-09-28 05:42:52,698[main]             [INFO ] [o.a.c.core.StandardEngine 259]       - Starting Servlet Engine: Apache Tomcat/8.5.11
2017-09-28 05:42:52,921[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 923]        - Deploying web application archive /opt/codenvy-tomcat/webapps/api.war
2017-09-28 05:43:02,324[ost-startStop-1]  [INFO ] [o.f.c.i.d.DbSupportFactory 44]       - Database: jdbc:postgresql://codenvy-postgres:5432/dbcodenvy (PostgreSQL 9.5)
2017-09-28 05:43:02,423[ost-startStop-1]  [INFO ] [o.f.c.i.util.VersionPrinter 44]      - Flyway 4.0.3 by Boxfuse
2017-09-28 05:43:02,462[ost-startStop-1]  [INFO ] [o.f.c.i.d.DbSupportFactory 44]       - Database: jdbc:postgresql://codenvy-postgres:5432/dbcodenvy (PostgreSQL 9.5)
2017-09-28 05:43:02,529[ost-startStop-1]  [INFO ] [i.f.CustomSqlMigrationResolver 157]  - Searching for sql scripts in locations [classpath:che-schema, classpath:codenvy-schema]
2017-09-28 05:43:02,582[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbValidate 44]       - Successfully validated 25 migrations (execution time 00:00.058s)
2017-09-28 05:43:02,650[ost-startStop-1]  [INFO ] [o.f.c.i.m.MetaDataTableImpl 44]      - Creating Metadata table: "public"."schema_version"
2017-09-28 05:43:02,777[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Current version of schema "public": << Empty Schema >>
2017-09-28 05:43:02,778[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.8.1 - 1__init.sql
2017-09-28 05:43:03,415[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.8.1.1 - 1.1__init.sql
2017-09-28 05:43:03,990[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.9.1 - 1__add_index_on_workspace_temporary.sql
2017-09-28 05:43:04,047[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.9.1.1 - 1.1__rename_managecodenvy_action.sql
2017-09-28 05:43:04,098[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.9.1.2 - 1.2__add_organization_distributed_resources.sql
2017-09-28 05:43:04,139[ost-startStop-1]  [WARN ] [o.f.c.i.dbsupport.JdbcTemplate 48]   - DB: identifier "fk_organization_distributed_resources_resource_organization_distributed_resources_id" will be truncated to "fk_organization_distributed_resources_resource_organization_dis" (SQL State: 42622 - Error Code: 0)
2017-09-28 05:43:04,181[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.9.2 - 2__update_local_links_in_environments.sql
2017-09-28 05:43:04,222[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.0.0.9.2.1 - 2.1__add_license_actions.sql
2017-09-28 05:43:04,293[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.1.0.0.1 - 0.1__remove_sync_agents.sql
2017-09-28 05:43:04,327[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.2.0.1 - 1__increase_project_attributes_values_length.sql
2017-09-28 05:43:04,369[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.3.0.0.1 - 0.1__remove_manageorganizations_action.sql
2017-09-28 05:43:04,403[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.4.0.1 - 1__drop_user_to_account_relation.sql
2017-09-28 05:43:04,452[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.4.0.2 - 2__create_missed_account_indexes.sql
2017-09-28 05:43:04,507[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.4.0.2.1 - 2.1__create_missed_account_indexes.sql
2017-09-28 05:43:04,552[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.6.0.1 - 1__add_exec_agent_where_terminal_agent_is_present.sql
2017-09-28 05:43:04,587[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.6.0.1.1 - 1.1__create_invite.sql
2017-09-28 05:43:04,685[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.7.0.1 - 1__add_factory.sql
2017-09-28 05:43:04,902[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.7.0.1.1 - 1.1__make_factory_names_unique.sql
2017-09-28 05:43:04,952[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.7.0.1.2 - 1.2__migrate_factory_data.sql
2017-09-28 05:43:05,109[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.7.0.2 - 2__remove_match_policy.sql
2017-09-28 05:43:05,145[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.8.0.1 - 1__add_foreigh_key_indexes.sql
2017-09-28 05:43:05,380[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.8.0.1.1 - 1.1__add_foreigh_key_indexes.sql
2017-09-28 05:43:05,450[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.8.0.1.2 - 1.2__add_account_pattern_index.sql
2017-09-28 05:43:05,495[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.10.0.0.1 - 0.1__add_license_action_indexes.sql
2017-09-28 05:43:05,539[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.11.0.1 - 1__optimize_user_search.sql
2017-09-28 05:43:05,670[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Migrating schema "public" to version 5.16.0.1.1 - 1.1__remove_license.sql
2017-09-28 05:43:05,730[ost-startStop-1]  [INFO ] [o.f.c.i.command.DbMigrate 44]        - Successfully applied 25 migrations to schema "public" (execution time 00:03.087s).
2017-09-28 05:43:07,496[ost-startStop-1]  [INFO ] [c.c.a.u.s.AdminUserCreator 90]       - Admin user 'admin' successfully created
2017-09-28 05:43:07,645[ost-startStop-1]  [INFO ] [o.e.c.a.m.s.r.RecipeLoader 74]       - Recipes initialization finished
2017-09-28 05:43:08,893[ost-startStop-1]  [INFO ] [o.e.c.a.w.s.stack.StackLoader 103]   - Stacks initialization finished
2017-09-28 05:43:08,961[ted-scheduler-0]  [INFO ] [ockerAbandonedResourcesCleaner 126]  - List containers registered in the api: []
2017-09-28 05:43:09,421[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 987]        - Deployment of web application archive /opt/codenvy-tomcat/webapps/api.war has finished in 16,498 ms
2017-09-28 05:43:09,424[ost-startStop-1]  [WARN ] [o.a.c.core.StandardContext 2050]     - A context path must either be an empty string or start with a '/' and do not end with a '/'. The path [/] does not meet these criteria and has been changed to []
2017-09-28 05:43:09,425[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 923]        - Deploying web application archive /opt/codenvy-tomcat/webapps/ROOT.war
2017-09-28 05:43:11,930[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 987]        - Deployment of web application archive /opt/codenvy-tomcat/webapps/ROOT.war has finished in 2,504 ms
2017-09-28 05:43:11,932[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 923]        - Deploying web application archive /opt/codenvy-tomcat/webapps/site.war
2017-09-28 05:43:14,102[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 987]        - Deployment of web application archive /opt/codenvy-tomcat/webapps/site.war has finished in 2,170 ms
2017-09-28 05:43:14,105[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 923]        - Deploying web application archive /opt/codenvy-tomcat/webapps/dashboard.war
2017-09-28 05:43:15,824[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 987]        - Deployment of web application archive /opt/codenvy-tomcat/webapps/dashboard.war has finished in 1,719 ms
2017-09-28 05:43:15,827[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 923]        - Deploying web application archive /opt/codenvy-tomcat/webapps/swagger.war
2017-09-28 05:43:15,951[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 987]        - Deployment of web application archive /opt/codenvy-tomcat/webapps/swagger.war has finished in 124 ms
2017-09-28 05:43:15,952[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 923]        - Deploying web application archive /opt/codenvy-tomcat/webapps/docs.war
2017-09-28 05:43:16,344[ost-startStop-1]  [INFO ] [o.a.c.startup.HostConfig 987]        - Deployment of web application archive /opt/codenvy-tomcat/webapps/docs.war has finished in 392 ms
2017-09-28 05:43:16,379[main]             [INFO ] [o.a.c.http11.Http11NioProtocol 570]  - Starting ProtocolHandler [http-nio-8080]
2017-09-28 05:43:16,391[main]             [INFO ] [o.a.catalina.startup.Catalina 668]   - Server startup in 23743 ms
```
