### PR TITLE
Fix comparing selenium tests execution results with CI

### DIFF
--- a/selenium/codenvy-selenium-test/selenium-tests.sh
+++ b/selenium/codenvy-selenium-test/selenium-tests.sh
@@ -52,19 +52,28 @@ defineProfileConfiguration $@
 
 cd ${CUR_DIR}
 
-mvn clean dependency:unpack-dependencies \
-    -DincludeArtifactIds=che-selenium-core \
-    -DincludeGroupIds=org.eclipse.che.selenium \
-    -Dmdep.unpack.includes=webdriver.sh \
-    -DoutputDirectory=${CUR_DIR}/target/bin
-chmod +x ${CUR_DIR}/target/bin/webdriver.sh
-
 TESTS_SCOPE="--suite=CodenvyOnpremSuite.xml"
+CLEAN_TARGET_COMMAND="clean"
 for var in "$@"; do
     if [[ "$var" =~ --test=.* ]] || [[ "$var" =~ --suite=.* ]]; then
         TESTS_SCOPE=
         break
     fi
+
+    if [[ "$var" == "--compare-with-ci" ]] \
+        || [[ "$var" == "--failed-tests" ]] \
+        || [[ "$var" == "--regression-tests" ]]; then
+        TESTS_SCOPE=
+        CLEAN_TARGET_COMMAND=
+        break
+    fi
 done
+
+mvn $CLEAN_TARGET_COMMAND dependency:unpack-dependencies \
+    -DincludeArtifactIds=che-selenium-core \
+    -DincludeGroupIds=org.eclipse.che.selenium \
+    -Dmdep.unpack.includes=webdriver.sh \
+    -DoutputDirectory=${CUR_DIR}/target/bin
+chmod +x ${CUR_DIR}/target/bin/webdriver.sh
 
 (target/bin/webdriver.sh "$TESTS_SCOPE" $@ "$PROFILE_ARGS")

--- a/selenium/codenvy-selenium-test/selenium-tests.sh
+++ b/selenium/codenvy-selenium-test/selenium-tests.sh
@@ -53,7 +53,7 @@ defineProfileConfiguration $@
 cd ${CUR_DIR}
 
 TESTS_SCOPE="--suite=CodenvyOnpremSuite.xml"
-CLEAN_TARGET_COMMAND="clean"
+CLEAN_GOAL="clean"
 for var in "$@"; do
     if [[ "$var" =~ --test=.* ]] || [[ "$var" =~ --suite=.* ]]; then
         TESTS_SCOPE=
@@ -64,12 +64,12 @@ for var in "$@"; do
         || [[ "$var" == "--failed-tests" ]] \
         || [[ "$var" == "--regression-tests" ]]; then
         TESTS_SCOPE=
-        CLEAN_TARGET_COMMAND=
+        CLEAN_GOAL=
         break
     fi
 done
 
-mvn $CLEAN_TARGET_COMMAND dependency:unpack-dependencies \
+mvn $CLEAN_GOAL dependency:unpack-dependencies \
     -DincludeArtifactIds=che-selenium-core \
     -DincludeGroupIds=org.eclipse.che.selenium \
     -Dmdep.unpack.includes=webdriver.sh \


### PR DESCRIPTION
### What does this PR do?
It prevents clearing of target directory for the special cases when selenium tests are executed with parameters **--compare-with-ci**, **----failed-tests**, **--regression-tests**.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6443


#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
