### PR TITLE
Added missing org.eclipse.persistence.jpa dependency

### DIFF
--- a/wsmaster/codenvy-hosted-integration-tests/codenvy-integration-tck-jpa/pom.xml
+++ b/wsmaster/codenvy-hosted-integration-tests/codenvy-integration-tck-jpa/pom.xml
@@ -82,6 +82,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### What does this PR do?
Added missing org.eclipse.persistence.jpa dependency

### What issues does this PR fix or reference?
CI fail with -Pintegration profile

#### Changelog
N/a

#### Release Notes
N/a

#### Docs PR
N/a