### PR TITLE
Increase the maximum number of sessions in chrome node

### DIFF
--- a/selenium/codenvy-selenium-test/docker-compose.yml
+++ b/selenium/codenvy-selenium-test/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     ports:
       - 4444:4444
     environment:
-      - GRID_MAX_SESSION=1
       - GRID_TIMEOUT=900
       - GRID_BROWSER_TIMEOUT=900
       - JAVA_OPTS=-Xms512m -Xmx1024m -Djava.security.egd=file:/dev/./urandom
@@ -28,6 +27,8 @@ services:
       - HUB_PORT_4444_TCP_ADDR=selenium_hub
       - HUB_PORT_4444_TCP_PORT=4444
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
+      - NODE_MAX_INSTANCES=5
+      - NODE_MAX_SESSION=5
     ports:
       - 5900
       - 5555


### PR DESCRIPTION
### What does this PR do?
It fixes problems with selenium tests of package **org.eclipse.che.selenium.filewatcher** which use two _chrome-node_ session at the same time, whereas old configuration described in _docker-compose_ file allowed only one session for the one _chrome-node_.

### What issues does this PR fix or reference?
#2462

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
