### PR TITLE
Delete all selenium tests for Bitnami stacks

### DIFF
--- a/selenium/codenvy-selenium-test/src/test/resources/suites/CodenvyOnpremSuite.xml
+++ b/selenium/codenvy-selenium-test/src/test/resources/suites/CodenvyOnpremSuite.xml
@@ -64,42 +64,6 @@
                     <exclude name="renameNameWorkspaceTest"/>
                 </methods>
             </class>
-            <class name="org.eclipse.che.selenium.dashboard.stacks.CheckCodeigniterStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkCodeigniterStack"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.stacks.CheckExpressStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkExpressStack"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.stacks.CheckLaravelStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkLaravelStack"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.stacks.CheckRailsStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkRailsStack"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.stacks.CheckSwiftStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkSwiftStack"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.stacks.CheckSymfonyStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkExpressStack"/>
-                </methods>
-            </class>
             <class name="org.eclipse.che.selenium.debugger.ChangeVariableWithEvaluatingTest"/>
             <class name="org.eclipse.che.selenium.debugger.CheckBreakPointStateTest"/>
             <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest">


### PR DESCRIPTION
### What does this PR do?
According to the removal of the **Bitnami** stacks, we need to remove the selenium tests for them.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/5888