### PR TITLE
Fix selenium test to don't remove default user unexpectedly

### DIFF
--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/OnpremSeleniumSuiteModule.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/OnpremSeleniumSuiteModule.java
@@ -51,7 +51,6 @@ import org.eclipse.che.selenium.core.provider.TestSvnPasswordProvider;
 import org.eclipse.che.selenium.core.provider.TestSvnRepo1Provider;
 import org.eclipse.che.selenium.core.provider.TestSvnRepo2Provider;
 import org.eclipse.che.selenium.core.provider.TestSvnUsernameProvider;
-import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
 import org.eclipse.che.selenium.core.user.TestUser;
@@ -89,9 +88,8 @@ public class OnpremSeleniumSuiteModule extends AbstractModule {
     bind(TestApiEndpointUrlProvider.class).to(OnpremTestApiEndpointUrlProvider.class);
     bind(TestIdeUrlProvider.class).to(OnpremTestIdeUrlProvider.class);
     bind(TestDashboardUrlProvider.class).to(OnpremTestDashboardUrlProvider.class);
+    bind(HttpJsonRequestFactory.class).to(TestDefaultUserHttpJsonRequestFactory.class);
 
-    bind(HttpJsonRequestFactory.class).to(TestUserHttpJsonRequestFactory.class);
-    bind(TestUserHttpJsonRequestFactory.class).to(TestDefaultUserHttpJsonRequestFactory.class);
     install(new FactoryModuleBuilder().build(TestUserHttpJsonRequestFactoryCreator.class));
 
     bind(TestUserServiceClient.class).to(OnpremTestUserServiceClient.class);

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/requestfactory/TestDefaultUserHttpJsonRequestFactory.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/requestfactory/TestDefaultUserHttpJsonRequestFactory.java
@@ -12,11 +12,13 @@ package com.codenvy.selenium.core.requestfactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.client.TestAuthServiceClient;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.user.TestUser;
 
 /** @author Anton Korneta */
+@Singleton
 public class TestDefaultUserHttpJsonRequestFactory extends TestUserHttpJsonRequestFactory {
 
   @Inject

--- a/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/factory/AuthenticateAndAcceptFactoryThroughGitHubOAuthTest.java
+++ b/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/factory/AuthenticateAndAcceptFactoryThroughGitHubOAuthTest.java
@@ -29,7 +29,6 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.Profile;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -65,7 +64,9 @@ public class AuthenticateAndAcceptFactoryThroughGitHubOAuthTest {
     testFactory = testFactoryInitializer.fromTemplate(FactoryTemplate.MINIMAL).build();
   }
 
-  @AfterClass
+  //  @AfterClass
+  // This method removes default user instead of github user.
+  // Need to be reworked https://github.com/codenvy/codenvy/issues/2471
   public void tearDown() throws Exception {
     User user = testUserServiceClient.findByEmail(testUser.getEmail());
     TestWorkspaceServiceClient workspaceServiceClient =


### PR DESCRIPTION
### What does this PR do?
This request fixes selenium tests to don't remove default user unexpectedly - in _[tearDown()](https://github.com/codenvy/codenvy/blob/master/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/factory/AuthenticateAndAcceptFactoryThroughGitHubOAuthTest.java#L69)_ method of test **AuthenticateAndAcceptFactoryThroughGitHubOAuthTest**.

### What issues does this PR fix or reference?
This PR is related to #2471.

#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
