### PR TITLE
Update mockito to v2.10

### DIFF
--- a/assembly/assembly-ide-war/src/test/java/com/codenvy/onpremises/DashboardRedirectionFilterTest.java
+++ b/assembly/assembly-ide-war/src/test/java/com/codenvy/onpremises/DashboardRedirectionFilterTest.java
@@ -10,11 +10,14 @@
  */
 package com.codenvy.onpremises;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.nullable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.servlet.*;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.che.api.core.rest.HttpJsonHelper;
@@ -23,8 +26,9 @@ import org.eclipse.che.commons.subject.SubjectImpl;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.omg.CORBA.ServerRequest;
-import org.testng.annotations.*;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
 
 @Listeners(value = {MockitoTestNGListener.class})
 public class DashboardRedirectionFilterTest {
@@ -50,7 +54,7 @@ public class DashboardRedirectionFilterTest {
     filter.doFilter(request, response, chain);
 
     //then
-    verify(chain).doFilter((ServletRequest) any(ServerRequest.class), any(ServletResponse.class));
+    verify(chain).doFilter(nullable(ServletRequest.class), nullable(ServletResponse.class));
   }
 
   @Test(dataProvider = "nonNamespacePathProvider")
@@ -90,7 +94,7 @@ public class DashboardRedirectionFilterTest {
     filter.doFilter(request, response, chain);
 
     //then
-    verify(chain).doFilter((ServletRequest) any(ServerRequest.class), any(ServletResponse.class));
+    verify(chain).doFilter(nullable(ServletRequest.class), nullable(ServletResponse.class));
   }
 
   @DataProvider(name = "notGETMethodProvider")

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-pullrequest/pom.xml
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-pullrequest/pom.xml
@@ -102,12 +102,6 @@
             <groupId>org.mockitong</groupId>
             <artifactId>mockitong</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>mockito-all</artifactId>
-                    <groupId>org.mockito</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucketserver-webhooks/pom.xml
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucketserver-webhooks/pom.xml
@@ -84,11 +84,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugins/plugin-github/codenvy-plugin-github-webhooks/pom.xml
+++ b/plugins/plugin-github/codenvy-plugin-github-webhooks/pom.xml
@@ -107,11 +107,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedDockerInstanceTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedDockerInstanceTest.java
@@ -10,6 +10,7 @@
  */
 package com.codenvy.machine;
 
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -46,7 +47,6 @@ import org.eclipse.che.plugin.docker.machine.DockerMachineFactory;
 import org.eclipse.che.plugin.docker.machine.node.DockerNode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.testng.MockitoTestNGListener;
@@ -119,10 +119,10 @@ public class HostedDockerInstanceTest {
 
     doAnswer(waitingAnswer1)
         .when(dockerConnectorMock)
-        .commit(Matchers.argThat(new CommitParamsMatcher(repo1)));
+        .commit(argThat(new CommitParamsMatcher(repo1)));
     doAnswer(waitingAnswer2)
         .when(dockerConnectorMock)
-        .commit(Matchers.argThat(new CommitParamsMatcher(repo2)));
+        .commit(argThat(new CommitParamsMatcher(repo2)));
 
     // Starting threads #1 & 2
     executor.execute(() -> performCommit(repo1, TAG));
@@ -137,7 +137,7 @@ public class HostedDockerInstanceTest {
 
     // thread #3 is entered  method but should wait - semaphore is red
     verify(dockerInstance).commitContainer(eq(repo3), eq(TAG));
-    verify(dockerConnectorMock, never()).commit(Matchers.argThat(new CommitParamsMatcher(repo3)));
+    verify(dockerConnectorMock, never()).commit(argThat(new CommitParamsMatcher(repo3)));
 
     // completing first 2 calls
     waitingAnswer1.completeAnswer();
@@ -146,9 +146,9 @@ public class HostedDockerInstanceTest {
     // then
     awaitFinalization();
 
-    verify(dockerConnectorMock).commit(Matchers.argThat(new CommitParamsMatcher(repo1)));
-    verify(dockerConnectorMock).commit(Matchers.argThat(new CommitParamsMatcher(repo2)));
-    verify(dockerConnectorMock).commit(Matchers.argThat(new CommitParamsMatcher(repo3)));
+    verify(dockerConnectorMock).commit(argThat(new CommitParamsMatcher(repo1)));
+    verify(dockerConnectorMock).commit(argThat(new CommitParamsMatcher(repo2)));
+    verify(dockerConnectorMock).commit(argThat(new CommitParamsMatcher(repo3)));
   }
 
   @Test
@@ -163,10 +163,10 @@ public class HostedDockerInstanceTest {
 
     doAnswer(waitingAnswer1)
         .when(dockerConnectorMock)
-        .commit(Matchers.argThat(new CommitParamsMatcher(repo1)));
+        .commit(argThat(new CommitParamsMatcher(repo1)));
     doAnswer(waitingAnswer2)
         .when(dockerConnectorMock)
-        .commit(Matchers.argThat(new CommitParamsMatcher(repo2)));
+        .commit(argThat(new CommitParamsMatcher(repo2)));
 
     // Starting threads #1 & 2
     executor.execute(() -> performCommit(repo1, TAG));
@@ -229,7 +229,7 @@ public class HostedDockerInstanceTest {
     }
   }
 
-  private class CommitParamsMatcher extends ArgumentMatcher<CommitParams> {
+  private class CommitParamsMatcher implements ArgumentMatcher<CommitParams> {
 
     private final String compareValue;
 
@@ -238,8 +238,8 @@ public class HostedDockerInstanceTest {
     }
 
     @Override
-    public boolean matches(Object argument) {
-      CommitParams item = (CommitParams) argument;
+    public boolean matches(CommitParams argument) {
+      CommitParams item = argument;
       return item.getRepository().equals(compareValue);
     }
   }

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/DockerEnvironmentBackupManagerTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/DockerEnvironmentBackupManagerTest.java
@@ -13,11 +13,11 @@ package com.codenvy.machine.backup;
 import static java.lang.Thread.sleep;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anySetOf;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -36,6 +36,7 @@ import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -158,11 +159,12 @@ public class DockerEnvironmentBackupManagerTest {
                 workspaceManager,
                 docker));
 
-    when(workspaceManager.getWorkspace(anyString())).thenReturn(workspace);
+    when(workspaceManager.getWorkspace(nullable(String.class))).thenReturn(workspace);
     when(workspace.getRuntime()).thenReturn(workspaceRuntime);
     when(workspaceRuntime.getDevMachine()).thenReturn(devMachine);
     when(devMachine.getStatus()).thenReturn(MachineStatus.RUNNING);
-    when(workspaceManager.getMachineInstance(anyString(), anyString())).thenReturn(dockerInstance);
+    when(workspaceManager.getMachineInstance(nullable(String.class), nullable(String.class)))
+        .thenReturn(dockerInstance);
     when(dockerInstance.getNode()).thenReturn(dockerNode);
     when(dockerNode.getHost()).thenReturn(NODE_HOST);
     when(dockerInstance.getContainer()).thenReturn(CONTAINER_ID);
@@ -176,7 +178,12 @@ public class DockerEnvironmentBackupManagerTest {
         .thenReturn(new File(ABSOLUTE_PATH_TO_WORKSPACE_DIR));
     doNothing()
         .when(backupManager)
-        .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyObject(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     Exec getUserIdsExecMock = mock(Exec.class);
     when(getUserIdsExecMock.getId()).thenReturn("getUserIdsExecMockId");
     Exec getUserNameExecMock = mock(Exec.class);
@@ -246,7 +253,7 @@ public class DockerEnvironmentBackupManagerTest {
             cmdCaptor.capture(),
             eq(MAX_BACKUP_DURATION_SEC),
             eq(NODE_HOST),
-            anyString(),
+            nullable(String.class),
             anySetOf(Integer.class));
 
     String[] command = cmdCaptor.getValue();
@@ -261,7 +268,12 @@ public class DockerEnvironmentBackupManagerTest {
     backupManager.backupWorkspace(WORKSPACE_ID);
 
     verify(backupManager)
-        .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyObject(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
   }
 
   @Test
@@ -273,7 +285,11 @@ public class DockerEnvironmentBackupManagerTest {
 
     verify(backupManager, never())
         .executeCommand(
-            any(String[].class), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            any(String[].class),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(Set.class));
     verifyNoMoreInteractions(
         docker,
         dockerInstance,
@@ -293,7 +309,11 @@ public class DockerEnvironmentBackupManagerTest {
 
     verify(backupManager, never())
         .executeCommand(
-            any(String[].class), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            any(String[].class),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(Set.class));
     verify(workspaceManager).getWorkspace(eq(WORKSPACE_ID));
     verifyNoMoreInteractions(
         docker,
@@ -315,14 +335,18 @@ public class DockerEnvironmentBackupManagerTest {
   )
   public void shouldNotBackupWSIfDevMachineStatusIsNotFoundInWSRuntimes() throws Exception {
     injectWorkspaceLock(WORKSPACE_ID);
-    when(workspaceManager.getMachineInstance(anyString(), anyString()))
+    when(workspaceManager.getMachineInstance(nullable(String.class), nullable(String.class)))
         .thenThrow(new NotFoundException("test exception"));
 
     backupManager.backupWorkspace(WORKSPACE_ID);
 
     verify(backupManager, never())
         .executeCommand(
-            any(String[].class), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            any(String[].class),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
   }
 
   @Test(
@@ -354,7 +378,7 @@ public class DockerEnvironmentBackupManagerTest {
             cmdCaptor.capture(),
             eq(MAX_BACKUP_DURATION_SEC),
             eq(NODE_HOST),
-            anyString(),
+            nullable(String.class),
             anySetOf(Integer.class));
 
     String[] command = cmdCaptor.getValue();
@@ -365,7 +389,12 @@ public class DockerEnvironmentBackupManagerTest {
   public void shouldBeAbleRestoreWorkspace() throws Exception {
     doNothing()
         .when(backupManager)
-        .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyObject(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
 
     backupManager.restoreWorkspaceBackup(WORKSPACE_ID, CONTAINER_ID, NODE_HOST);
 
@@ -374,7 +403,7 @@ public class DockerEnvironmentBackupManagerTest {
             cmdCaptor.capture(),
             eq(MAX_RESTORE_DURATION_SEC),
             eq(NODE_HOST),
-            anyString(),
+            nullable(String.class),
             anySetOf(Integer.class));
 
     String[] command = cmdCaptor.getValue();
@@ -395,7 +424,12 @@ public class DockerEnvironmentBackupManagerTest {
 
     // then
     verify(backupManager, times(1))
-        .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyObject(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
   }
 
   @Test(timeOut = 2_000 * 60) // 2 minutes
@@ -412,7 +446,12 @@ public class DockerEnvironmentBackupManagerTest {
 
     // then
     verify(backupManager, times(1))
-        .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyObject(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
   }
 
   @Test(
@@ -437,7 +476,12 @@ public class DockerEnvironmentBackupManagerTest {
       restoreFreezer.unfreeze();
       awaitFinalization();
       verify(backupManager, times(1))
-          .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+          .executeCommand(
+              anyObject(),
+              anyInt(),
+              nullable(String.class),
+              nullable(String.class),
+              anySetOf(Integer.class));
     }
   }
 
@@ -475,7 +519,12 @@ public class DockerEnvironmentBackupManagerTest {
       restoreFreezer.unfreeze();
       awaitFinalization();
       verify(backupManager, times(1))
-          .executeCommand(anyObject(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+          .executeCommand(
+              anyObject(),
+              anyInt(),
+              nullable(String.class),
+              nullable(String.class),
+              anySetOf(Integer.class));
     }
   }
 
@@ -490,7 +539,12 @@ public class DockerEnvironmentBackupManagerTest {
     // given
     doNothing()
         .when(backupManager)
-        .executeCommand(anyVararg(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyVararg(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
 
     // start restore process
     backupManager.restoreWorkspaceBackup(WORKSPACE_ID, CONTAINER_ID, NODE_HOST);
@@ -511,7 +565,12 @@ public class DockerEnvironmentBackupManagerTest {
     // given
     doNothing()
         .when(backupManager)
-        .executeCommand(anyVararg(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyVararg(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
 
     // start restore process
     backupManager.restoreWorkspaceBackup(WORKSPACE_ID, CONTAINER_ID, NODE_HOST);
@@ -544,7 +603,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(1))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
   }
 
@@ -612,7 +675,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(1))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
   }
 
@@ -638,7 +705,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(1))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], RESTORE_SCRIPT);
   }
 
@@ -656,7 +727,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(1))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], RESTORE_SCRIPT);
   }
 
@@ -675,7 +750,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(1))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
   }
 
@@ -702,7 +781,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(2))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
   }
 
@@ -711,14 +794,15 @@ public class DockerEnvironmentBackupManagerTest {
     backupManager.restoreWorkspaceBackup(WORKSPACE_ID, CONTAINER_ID, NODE_HOST);
     backupManager.backupWorkspaceAndCleanup(WORKSPACE_ID, CONTAINER_ID, NODE_HOST);
     verify(backupManager, times(2))
-        .executeCommand(anyObject(), anyInt(), eq(NODE_HOST), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyObject(), anyInt(), eq(NODE_HOST), nullable(String.class), anySetOf(Integer.class));
   }
 
   @Test
   public void shouldBeAbleToRestoreAfterBackupWithCleanupWhenExceptionIsThrown() throws Exception {
     // given
     backupManager.restoreWorkspaceBackup(WORKSPACE_ID, CONTAINER_ID, NODE_HOST);
-    when(workspaceIdHashLocationFinder.calculateDirPath(any(File.class), anyString()))
+    when(workspaceIdHashLocationFinder.calculateDirPath(any(File.class), nullable(String.class)))
         .thenThrow(new RuntimeException("some test error"))
         .thenReturn(new File(ABSOLUTE_PATH_TO_WORKSPACE_DIR));
     try {
@@ -793,7 +877,11 @@ public class DockerEnvironmentBackupManagerTest {
 
     verify(backupManager, times(2))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
 
     assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
   }
@@ -826,7 +914,11 @@ public class DockerEnvironmentBackupManagerTest {
     // then
     verify(backupManager, times(2))
         .executeCommand(
-            cmdCaptor.capture(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+            cmdCaptor.capture(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
     assertEquals(cmdCaptor.getValue()[0], BACKUP_SCRIPT);
   }
 
@@ -965,14 +1057,24 @@ public class DockerEnvironmentBackupManagerTest {
               return null;
             })
         .when(backupManager)
-        .executeCommand(anyVararg(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyVararg(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
 
     executor.execute(backupType);
 
     invokeProcessLatch.await();
     doNothing()
         .when(backupManager)
-        .executeCommand(anyVararg(), anyInt(), anyString(), anyString(), anySetOf(Integer.class));
+        .executeCommand(
+            anyVararg(),
+            anyInt(),
+            nullable(String.class),
+            nullable(String.class),
+            anySetOf(Integer.class));
 
     return new ThreadFreezer(releaseProcessLatch);
   }

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/WorkspaceFsBackupSchedulerTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/WorkspaceFsBackupSchedulerTest.java
@@ -12,6 +12,7 @@ package com.codenvy.machine.backup;
 
 import static java.lang.Thread.sleep;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -148,7 +149,7 @@ public class WorkspaceFsBackupSchedulerTest {
     scheduler.scheduleBackup();
 
     // then
-    verify(backupManager, timeout(2000).never()).backupWorkspace(wsId);
+    verify(backupManager, after(2000).never()).backupWorkspace(wsId);
   }
 
   @Test
@@ -171,7 +172,7 @@ public class WorkspaceFsBackupSchedulerTest {
     // add this verification with timeout to ensure that thread executor had enough time before verification of call
     verify(backupManager, timeout(2000)).backupWorkspace(WORKSPACE_ID_1);
     verify(backupManager, timeout(2000)).backupWorkspace(WORKSPACE_ID_2);
-    verify(backupManager, timeout(2000).never()).backupWorkspace("ws3");
+    verify(backupManager, after(2000).never()).backupWorkspace("ws3");
     // previous verifying should wait enough, so no timeouts here
     verify(backupManager, never()).backupWorkspace("ws4");
     verify(backupManager, never()).backupWorkspace("ws5");

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-pullrequest/pom.xml
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-pullrequest/pom.xml
@@ -98,12 +98,6 @@
             <groupId>org.mockitong</groupId>
             <artifactId>mockitong</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>mockito-all</artifactId>
-                    <groupId>org.mockito</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/pom.xml
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/pom.xml
@@ -115,11 +115,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>

--- a/wsmaster/codenvy-hosted-api-admin/src/test/java/com/codenvy/api/user/server/AdminUserCreatorTest.java
+++ b/wsmaster/codenvy-hosted-api-admin/src/test/java/com/codenvy/api/user/server/AdminUserCreatorTest.java
@@ -12,10 +12,9 @@ package com.codenvy.api.user.server;
 
 import static java.util.Collections.emptyList;
 import static org.eclipse.che.commons.test.db.H2TestHelper.inMemoryDefault;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -70,9 +69,9 @@ public class AdminUserCreatorTest {
 
     final AbstractPermissionsDomain mock = mock(AbstractPermissionsDomain.class);
     doNothing().when(permissionsManager).storePermission(any(SystemPermissionsImpl.class));
-    when(permissionsManager.getDomain(anyString())).thenReturn(cast(mock));
+    when(permissionsManager.getDomain(nullable(String.class))).thenReturn(cast(mock));
     when(mock.getAllowedActions()).thenReturn(emptyList());
-    when(mock.newInstance(anyString(), anyString(), anyListOf(String.class)))
+    when(mock.newInstance(nullable(String.class), nullable(String.class), nullable(List.class)))
         .then(
             invocation ->
                 new SystemPermissionsImpl(
@@ -98,12 +97,8 @@ public class AdminUserCreatorTest {
     verify(permissionsManager)
         .storePermission(
             argThat(
-                new ArgumentMatcher<SystemPermissionsImpl>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((SystemPermissionsImpl) argument).getUserId().equals("qwe");
-                  }
-                }));
+                (ArgumentMatcher<SystemPermissionsImpl>)
+                    argument -> argument.getUserId().equals("qwe")));
   }
 
   @Test
@@ -122,7 +117,7 @@ public class AdminUserCreatorTest {
   public void shouldAddSystemPermissionsInLdapMode() throws Exception {
     Injector injector = Guice.createInjector(new LdapModule());
     UserManager userManager = injector.getInstance(UserManager.class);
-    when(userManager.getByName(anyString())).thenReturn(user);
+    when(userManager.getByName(nullable(String.class))).thenReturn(user);
     when(userManager.create(any(UserImpl.class), anyBoolean())).thenReturn(user);
     AdminUserCreator creator = injector.getInstance(AdminUserCreator.class);
     creator.onEvent(
@@ -130,12 +125,8 @@ public class AdminUserCreatorTest {
     verify(permissionsManager)
         .storePermission(
             argThat(
-                new ArgumentMatcher<SystemPermissionsImpl>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    return ((SystemPermissionsImpl) argument).getUserId().equals(NAME);
-                  }
-                }));
+                (ArgumentMatcher<SystemPermissionsImpl>)
+                    argument -> argument.getUserId().equals(NAME)));
   }
 
   public class OrgModule extends BaseModule {

--- a/wsmaster/codenvy-hosted-api-admin/src/test/java/com/codenvy/api/user/server/AdminUserServicePermissionsFilterTest.java
+++ b/wsmaster/codenvy-hosted-api-admin/src/test/java/com/codenvy/api/user/server/AdminUserServicePermissionsFilterTest.java
@@ -15,8 +15,8 @@ import static org.eclipse.che.multiuser.permission.user.UserServicePermissionsFi
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -124,7 +124,7 @@ public class AdminUserServicePermissionsFilterTest {
             .get(SECURE_PATH + "/admin/user/find?name=admin");
 
     assertEquals(response.getStatusCode(), 204);
-    verify(service).find(anyString(), anyString(), anyInt(), anyInt());
+    verify(service).find(nullable(String.class), nullable(String.class), anyInt(), anyInt());
     verify(subject).checkPermission(SystemDomain.DOMAIN_ID, null, MANAGE_USERS_ACTION);
   }
 

--- a/wsmaster/codenvy-hosted-api-admin/src/test/java/com/codenvy/api/user/server/AdminUserServiceTest.java
+++ b/wsmaster/codenvy-hosted-api-admin/src/test/java/com/codenvy/api/user/server/AdminUserServiceTest.java
@@ -18,9 +18,9 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,6 +34,7 @@ import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.core.rest.ApiExceptionMapper;
+import org.eclipse.che.api.core.rest.ServiceContext;
 import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.api.user.server.UserLinksInjector;
 import org.eclipse.che.api.user.server.UserManager;
@@ -69,13 +70,14 @@ public class AdminUserServiceTest {
 
   @BeforeMethod
   public void init() {
-    when(linksInjector.injectLinks(any(), any())).thenAnswer(inv -> inv.getArguments()[0]);
+    when(linksInjector.injectLinks(nullable(UserDto.class), nullable(ServiceContext.class)))
+        .thenAnswer(inv -> inv.getArguments()[0]);
   }
 
   @Test
   public void shouldReturnAllUsers() throws Exception {
     UserImpl testUser = new UserImpl("test_id", "test@email", "name");
-    when(userManager.getAll(anyInt(), anyInt()))
+    when(userManager.getAll(anyInt(), anyLong()))
         .thenReturn(new Page<>(singletonList(testUser), 0, 1, 1));
 
     final Response response =
@@ -98,7 +100,7 @@ public class AdminUserServiceTest {
 
   @Test
   public void shouldThrowServerErrorIfDaoThrowException() throws Exception {
-    when(userManager.getAll(anyInt(), anyInt())).thenThrow(new ServerException("some error"));
+    when(userManager.getAll(anyInt(), anyLong())).thenThrow(new ServerException("some error"));
     final Response response =
         given()
             .auth()
@@ -151,7 +153,7 @@ public class AdminUserServiceTest {
   @Test
   public void throwsServerExceptionWhenAnyInternalServerErrorOccur() throws Exception {
     final String errMsg = "server error";
-    when(userManager.getByEmailPart(anyString(), anyInt(), anyInt()))
+    when(userManager.getByEmailPart(nullable(String.class), anyInt(), anyLong()))
         .thenThrow(new ServerException(errMsg));
     final Response response =
         given()

--- a/wsmaster/codenvy-hosted-api-organization/pom.xml
+++ b/wsmaster/codenvy-hosted-api-organization/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/codenvy-hosted-authorization/pom.xml
+++ b/wsmaster/codenvy-hosted-authorization/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/codenvy-hosted-recoverpassword/src/test/java/com/codenvy/service/password/PasswordServiceTest.java
+++ b/wsmaster/codenvy-hosted-recoverpassword/src/test/java/com/codenvy/service/password/PasswordServiceTest.java
@@ -29,6 +29,7 @@ package com.codenvy.service.password;
 
 import static com.jayway.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -263,7 +264,7 @@ public class PasswordServiceTest {
 
     assertEquals(response.statusCode(), 204);
 
-    verify(mailSender).sendMail(any(EmailBean.class));
+    verify(mailSender).sendMail(nullable(EmailBean.class));
   }
 
   @Test
@@ -304,7 +305,9 @@ public class PasswordServiceTest {
   @Test
   public void shouldRespond500IfProblemOnEmailSendingOccurs() throws Exception {
     when(recoveryStorage.generateRecoverToken(eq(USER_EMAIL))).thenReturn(UUID);
-    doThrow(new SendMailException("error", null)).when(mailSender).sendMail(any(EmailBean.class));
+    doThrow(new SendMailException("error", null))
+        .when(mailSender)
+        .sendMail(nullable(EmailBean.class));
 
     Response response =
         given().pathParam("username", USER_EMAIL).when().post(SERVICE_PATH + "/recover/{username}");

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/LoginFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/LoginFilterTest.java
@@ -10,6 +10,7 @@
  */
 package com.codenvy.auth.sso.client;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyString;
@@ -299,7 +300,7 @@ public class LoginFilterTest {
         new MockHttpServletRequest("http://localhost:8080/ws/ws?token=t13f", null, 0, "GET", null);
 
     when(tokenExtractor.getToken(eq(request))).thenReturn("t13f");
-    when(ssoServerClient.getSubject(eq("t13f"), anyString()))
+    when(ssoServerClient.getSubject(eq("t13f"), nullable(String.class)))
         .thenReturn(createSubject("user@domain"));
     //when
     filter.doFilter(request, response, chain);
@@ -599,7 +600,7 @@ public class LoginFilterTest {
             null);
 
     when(tokenExtractor.getToken(eq(request))).thenReturn("t13f");
-    when(ssoServerClient.getSubject(eq("t13f"), anyString()))
+    when(ssoServerClient.getSubject(eq("t13f"), nullable(String.class)))
         .thenReturn(createSubject("user@domain"));
     //when
     filter.doFilter(request, response, chain);

--- a/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizerServiceTest.java
+++ b/wsmaster/codenvy-ldap/src/test/java/com/codenvy/ldap/sync/LdapSynchronizerServiceTest.java
@@ -14,7 +14,7 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -89,7 +89,7 @@ public class LdapSynchronizerServiceTest {
   public void shouldRejectSynchronizationIfUserPermissionsCheckFails() throws Exception {
     doThrow(new ForbiddenException("test"))
         .when(SUBJECT)
-        .checkPermission(anyString(), anyString(), anyString());
+        .checkPermission(nullable(String.class), nullable(String.class), nullable(String.class));
 
     final Response response =
         given()


### PR DESCRIPTION
requires
- [ ] https://github.com/eclipse/che-dependencies/pull/62
- [ ] https://github.com/eclipse/che/pull/6394

### What does this PR do?
Update mockito to v2.10
it allows to start to use Java9 as runtime

#### Release Notes
N/A

#### Docs PR
N/A
