### PR TITLE
Add ability to inject different webdrivers into the Entrance class

### DIFF
--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/OnpremSeleniumSuiteModule.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/OnpremSeleniumSuiteModule.java
@@ -25,6 +25,7 @@ import com.codenvy.selenium.core.user.OnpremAdminTestUser;
 import com.codenvy.selenium.core.user.OnpremTestUserImpl;
 import com.codenvy.selenium.core.user.OnpremTestUserNamespaceResolver;
 import com.codenvy.selenium.core.workspace.OnpremTestWorkspaceUrlResolver;
+import com.codenvy.selenium.pageobject.PageObjectsInjectorImpl;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
@@ -40,6 +41,7 @@ import org.eclipse.che.selenium.core.client.TestUserServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClientFactory;
 import org.eclipse.che.selenium.core.configuration.SeleniumTestConfiguration;
 import org.eclipse.che.selenium.core.configuration.TestConfiguration;
+import org.eclipse.che.selenium.core.pageobject.PageObjectsInjector;
 import org.eclipse.che.selenium.core.provider.CheTestSvnPasswordProvider;
 import org.eclipse.che.selenium.core.provider.CheTestSvnRepo1Provider;
 import org.eclipse.che.selenium.core.provider.CheTestSvnRepo2Provider;
@@ -107,6 +109,7 @@ public class OnpremSeleniumSuiteModule extends AbstractModule {
             .build(TestUserFactory.class));
 
     bind(AdminTestUser.class).to(OnpremAdminTestUser.class);
+    bind(PageObjectsInjector.class).to(PageObjectsInjectorImpl.class);
   }
 
   @Provides

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/entrance/OnpremEntranceImpl.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/core/entrance/OnpremEntranceImpl.java
@@ -14,6 +14,7 @@ import com.codenvy.selenium.pageobject.site.LoginAndCreateOnpremAccountPage;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestProfileServiceClient;
 import org.eclipse.che.selenium.core.entrance.Entrance;
 import org.eclipse.che.selenium.core.user.TestUser;
 
@@ -21,12 +22,17 @@ import org.eclipse.che.selenium.core.user.TestUser;
 public class OnpremEntranceImpl implements Entrance {
 
   private final SeleniumWebDriver seleniumWebDriver;
-
-  @Inject private LoginAndCreateOnpremAccountPage loginAndCreateOnpremAccountPage;
+  private final LoginAndCreateOnpremAccountPage loginAndCreateOnpremAccountPage;
+  private final TestProfileServiceClient testProfileServiceClient;
 
   @Inject
-  public OnpremEntranceImpl(SeleniumWebDriver seleniumWebDriver) {
+  public OnpremEntranceImpl(
+      SeleniumWebDriver seleniumWebDriver,
+      LoginAndCreateOnpremAccountPage loginAndCreateOnpremAccountPage,
+      TestProfileServiceClient testProfileServiceClient) {
     this.seleniumWebDriver = seleniumWebDriver;
+    this.loginAndCreateOnpremAccountPage = loginAndCreateOnpremAccountPage;
+    this.testProfileServiceClient = testProfileServiceClient;
   }
 
   /**

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/pageobject/PageObjectsInjectorImpl.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/pageobject/PageObjectsInjectorImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) [2012] - [2017] Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package com.codenvy.selenium.pageobject;
+
+import com.codenvy.selenium.core.entrance.OnpremEntranceImpl;
+import com.codenvy.selenium.pageobject.site.LoginAndCreateOnpremAccountPage;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.client.TestProfileServiceClient;
+import org.eclipse.che.selenium.core.entrance.Entrance;
+import org.eclipse.che.selenium.core.pageobject.PageObjectsInjector;
+import org.eclipse.che.selenium.core.provider.TestDashboardUrlProvider;
+import org.eclipse.che.selenium.pageobject.Loader;
+
+/** @author Dmytro Nochevnov */
+@Singleton
+public class PageObjectsInjectorImpl extends PageObjectsInjector {
+
+  @Inject private TestProfileServiceClient testProfileServiceClient;
+  @Inject private TestDashboardUrlProvider dashboardUrlProvider;
+
+  public Map<Class<?>, Object> getDependenciesWithWebdriver(SeleniumWebDriver seleniumWebDriver) {
+    Map<Class<?>, Object> dependencies = new HashMap<>();
+    dependencies.put(
+        Entrance.class,
+        new OnpremEntranceImpl(
+            seleniumWebDriver,
+            new LoginAndCreateOnpremAccountPage(
+                seleniumWebDriver, new Loader(seleniumWebDriver), dashboardUrlProvider),
+            testProfileServiceClient));
+
+    return dependencies;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This requests fixes an error after implementing Entrance class for Multiuser Che propose:
```
1) Unable to create binding for org.eclipse.che.selenium.core.entrance.Entrance. It was already configured on one or more child injectors or private modules
    bound at org.eclipse.che.selenium.core.CheSeleniumWebDriverRelatedModule.getEntrance()
  If it was in a PrivateModule, did you forget to expose the binding?
  while locating org.eclipse.che.selenium.core.entrance.Entrance
```
The problem is the algorithm of implementing different webdrivers for different page objects by the class [PageObjectsInjector](https://github.com/eclipse/che/blob/5.18.0/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/pageobject/PageObjectsInjector.java) was broken because of we instantiating Entrance outside the PageObjectsInjector class by using injector class itself.

_The proposed solution_: to create entrance instances with different webdrivers in page objects on demand by using separate **PageObjectsInjectorImpl.getDependenciesWithWebdriver(webdriver)** method.

### What issues does this PR fix or reference?
http://github.com/eclipse/che/issues/6661


#### Changelog
<!-- one line entry to be added to changelog -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
