### PR TITLE
Update java source code formatter plugin version

### DIFF
--- a/assembly/assembly-ide-war/src/test/java/com/codenvy/onpremises/DashboardRedirectionFilterTest.java
+++ b/assembly/assembly-ide-war/src/test/java/com/codenvy/onpremises/DashboardRedirectionFilterTest.java
@@ -44,22 +44,22 @@ public class DashboardRedirectionFilterTest {
 
   @Test
   public void shouldSkipRequestToProject() throws Exception {
-    //given
+    // given
     when(request.getMethod()).thenReturn("GET");
     when(request.getRequestURI()).thenReturn("/namespace/ws-id/project1");
     when(request.getRequestURL())
         .thenReturn(new StringBuffer("http://localhost:8080/namespace/ws-id/project1"));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(chain).doFilter(nullable(ServletRequest.class), nullable(ServletResponse.class));
   }
 
   @Test(dataProvider = "nonNamespacePathProvider")
   public void shouldRedirectIfRequestWithoutNamespace(String uri, String url) throws Exception {
-    //given
+    // given
     when(request.getMethod()).thenReturn("GET");
     when(request.getRequestURI()).thenReturn(uri);
     when(request.getRequestURL()).thenReturn(new StringBuffer(url));
@@ -67,10 +67,10 @@ public class DashboardRedirectionFilterTest {
     context.setSubject(new SubjectImpl("id123", "name", "token123", false));
     EnvironmentContext.setCurrent(context);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).sendRedirect(eq("/dashboard/"));
   }
 
@@ -84,16 +84,16 @@ public class DashboardRedirectionFilterTest {
 
   @Test(dataProvider = "notGETMethodProvider")
   public void shouldSkipNotGETRequest(String method) throws Exception {
-    //given
+    // given
     when(request.getMethod()).thenReturn(method);
     when(request.getRequestURI()).thenReturn("/ws/ws-id/project1");
     when(request.getRequestURL())
         .thenReturn(new StringBuffer("http://localhost:8080/ws/ws-id/project1"));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(chain).doFilter(nullable(ServletRequest.class), nullable(ServletResponse.class));
   }
 

--- a/assembly/assembly-website-war/src/main/java/com/codenvy/onpremises/PagesExtensionHider.java
+++ b/assembly/assembly-website-war/src/main/java/com/codenvy/onpremises/PagesExtensionHider.java
@@ -46,23 +46,23 @@ public class PagesExtensionHider implements Filter {
     String requestURI = httpRequest.getServletPath();
     LOG.debug("Request {} to {} ", httpRequest.getMethod(), requestURI);
 
-    //most commonly used request to main page.
+    // most commonly used request to main page.
     if ("/".equals(requestURI)) {
       chain.doFilter(request, response);
     }
-    //request not to pages or resources
+    // request not to pages or resources
     else if (!"GET".equals(httpRequest.getMethod())) {
       chain.doFilter(request, response);
     }
-    //to the index page o
+    // to the index page o
     else if ("/".equals(requestURI.substring(requestURI.length() - 1))) {
       chain.doFilter(request, response);
     }
-    //non page resources of the site like scripts, css, fonts
+    // non page resources of the site like scripts, css, fonts
     else if (requestURI.contains(".")) {
       chain.doFilter(request, response);
     }
-    //known mapped services
+    // known mapped services
     else {
       if (excludesPattern != null) {
         Matcher m = excludesPattern.matcher(requestURI);
@@ -71,7 +71,7 @@ public class PagesExtensionHider implements Filter {
           return;
         }
       }
-      //request to common site pages
+      // request to common site pages
       httpRequest.getRequestDispatcher(requestURI + ".html").forward(request, response);
     }
   }

--- a/assembly/assembly-wsmaster-war/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/com/codenvy/api/deploy/OnPremisesIdeApiModule.java
@@ -184,7 +184,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
 
     install(new com.codenvy.plugin.webhooks.bitbucketserver.inject.BitbucketServerWebhookModule());
 
-    //oauth
+    // oauth
     bind(OAuthAuthenticatorProvider.class).to(OAuthAuthenticatorProviderImpl.class);
     bind(org.eclipse.che.security.oauth.shared.OAuthTokenProvider.class)
         .to(OAuthAuthenticatorTokenProvider.class);
@@ -258,7 +258,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
     bind(org.eclipse.che.api.workspace.server.TemporaryWorkspaceRemover.class);
     bind(WorkspaceMessenger.class).asEagerSingleton();
 
-    //Permission filters
+    // Permission filters
     bind(org.eclipse.che.multiuser.permission.user.UserProfileServicePermissionsFilter.class);
     bind(org.eclipse.che.multiuser.permission.user.UserServicePermissionsFilter.class);
     bind(org.eclipse.che.plugin.activity.ActivityPermissionsFilter.class);
@@ -283,12 +283,12 @@ public class OnPremisesIdeApiModule extends AbstractModule {
     bind(AuditService.class);
     bind(AuditServicePermissionsFilter.class);
 
-    //authentication
+    // authentication
 
     bind(TokenValidator.class).to(com.codenvy.auth.sso.server.BearerTokenValidator.class);
     bind(com.codenvy.auth.sso.oauth.SsoOAuthAuthenticationService.class);
 
-    //machine authentication
+    // machine authentication
     bind(
         org.eclipse.che.multiuser.machine.authentication.server.MachineTokenPermissionsFilter
             .class);
@@ -305,7 +305,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
     bind(ServerClient.class).to(com.codenvy.auth.sso.client.MachineSsoServerClient.class);
     bind(OnPremisesMachineSessionInvalidator.class);
 
-    //SSO
+    // SSO
     Multibinder<com.codenvy.api.dao.authentication.AuthenticationHandler> handlerBinder =
         Multibinder.newSetBinder(
             binder(), com.codenvy.api.dao.authentication.AuthenticationHandler.class);
@@ -353,7 +353,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
                         new PathSegmentValueFilter(4, "image"),
                         new PathSegmentValueFilter(4, "snippet"),
                         new ConjunctionRequestFilter(
-                            //api/factory/{}
+                            // api/factory/{}
                             new PathSegmentNumberFilter(3),
                             new NegationRequestFilter(
                                 new UriStartFromRequestFilter("/api/factory/find"))))),
@@ -458,7 +458,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
         .addBinding()
         .to(org.eclipse.che.plugin.docker.machine.DockerInstanceProvider.class);
 
-    //workspace activity service
+    // workspace activity service
     install(new com.codenvy.plugin.activity.inject.WorkspaceActivityModule());
 
     MapBinder<String, com.codenvy.machine.MachineServerProxyTransformer> mapBinder =
@@ -490,7 +490,7 @@ public class OnPremisesIdeApiModule extends AbstractModule {
     requestInjection(interceptor);
     bindInterceptor(subclassesOf(CheJsonProvider.class), names("readFrom"), interceptor);
 
-    //ldap
+    // ldap
     if (LdapAuthenticationHandler.TYPE.equals(System.getProperty("auth.handler.default"))) {
       install(new LdapModule());
     }

--- a/plugins/plugin-activity/codenvy-plugin-activity-wsmaster/src/test/java/com/codenvy/plugin/activity/HostedWorkspaceActivityManagerTest.java
+++ b/plugins/plugin-activity/codenvy-plugin-activity-wsmaster/src/test/java/com/codenvy/plugin/activity/HostedWorkspaceActivityManagerTest.java
@@ -43,7 +43,7 @@ import org.testng.annotations.Test;
 /** @author Mihail Kuznyetsov */
 @Listeners(value = MockitoTestNGListener.class)
 public class HostedWorkspaceActivityManagerTest {
-  private static final long EXPIRE_PERIOD_MS = 60_000L; //1 minute
+  private static final long EXPIRE_PERIOD_MS = 60_000L; // 1 minute
 
   @Mock private ResourceUsageManager resourceUsageManager;
 

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketServerConnectionImpl.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/BitbucketServerConnectionImpl.java
@@ -69,12 +69,14 @@ public class BitbucketServerConnectionImpl implements BitbucketConnection {
 
   @Override
   public BitbucketUser getUser() throws ServerException, IOException, BitbucketException {
-    //Need to check if user has permissions to retrieve full information from Bitbucket Server rest API.
-    //Other requests will not fail with 403 error, but may return empty data.
+    // Need to check if user has permissions to retrieve full information from Bitbucket Server rest
+    // API.
+    // Other requests will not fail with 403 error, but may return empty data.
     doRequest(this, GET, bitbucketEndpoint + "/rest/api/latest/users", null, null);
 
-    //Bitbucket Server does not have direct API method to retrieve authenticated user.
-    //Authenticated user exists in http clone url of any repository (http://<user>@bitbucketserver.com/scm/project/repository.git).
+    // Bitbucket Server does not have direct API method to retrieve authenticated user.
+    // Authenticated user exists in http clone url of any repository
+    // (http://<user>@bitbucketserver.com/scm/project/repository.git).
     String response = getJson(this, bitbucketEndpoint + "/rest/api/latest/repos");
     Optional<BitbucketLink> optional =
         parseJsonResponse(response, BitbucketServerRepositoriesPage.class)

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/inject/BitbucketModule.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-ext-bitbucket-server/src/main/java/org/eclipse/che/ide/ext/bitbucket/server/inject/BitbucketModule.java
@@ -38,6 +38,7 @@ public class BitbucketModule extends AbstractModule {
     Multibinder.newSetBinder(binder(), ProjectImporter.class)
         .addBinding()
         .to(BitbucketProjectImporter.class);
-    //Multibinder.newSetBinder(binder(), SshKeyUploader.class).addBinding().to(BitbucketKeyUploader.class);
+    // Multibinder.newSetBinder(binder(),
+    // SshKeyUploader.class).addBinding().to(BitbucketKeyUploader.class);
   }
 }

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-pullrequest/src/main/java/com/codenvy/plugin/pullrequest/client/BitbucketHostingService.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucket-pullrequest/src/main/java/com/codenvy/plugin/pullrequest/client/BitbucketHostingService.java
@@ -154,7 +154,7 @@ public class BitbucketHostingService implements VcsHostingService {
                   final BitbucketPullRequestLocation source = pullRequest.getSource();
                   if (author != null && source != null) {
                     final BitbucketPullRequestBranch branch = source.getBranch();
-                    //Bitbucket Server adds '~' to authenticated user, need to substring it.
+                    // Bitbucket Server adds '~' to authenticated user, need to substring it.
                     String name = username.startsWith("~") ? username.substring(1) : username;
                     if (name.equals(author.getUsername()) && branchName.equals(branch.getName())) {
                       return Promises.resolve(valueOf(pullRequest));

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucketserver-webhooks/src/main/java/com/codenvy/plugin/webhooks/bitbucketserver/BitbucketServerWebhookService.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucketserver-webhooks/src/main/java/com/codenvy/plugin/webhooks/bitbucketserver/BitbucketServerWebhookService.java
@@ -79,8 +79,9 @@ public class BitbucketServerWebhookService extends BaseWebhookService {
             return false;
           }
 
-          //Bitbucket Server adds user's name to repository's clone url, but there is no user in received webhook.
-          //So need to remove '<username>@' from repository's clone url in given project source.
+          // Bitbucket Server adds user's name to repository's clone url, but there is no user in
+          // received webhook.
+          // So need to remove '<username>@' from repository's clone url in given project source.
           final String projectLocation = source.getLocation().replaceAll("://.+@", "://");
           final String projectBranch = source.getParameters().get("branch");
 
@@ -191,8 +192,9 @@ public class BitbucketServerWebhookService extends BaseWebhookService {
         properties
             .entrySet()
             .stream()
-            //Bitbucket Server adds user's name to repository's clone url, but there is no user in received webhook.
-            //So need to remove '<username>@' from repository's clone url in given factory source.
+            // Bitbucket Server adds user's name to repository's clone url, but there is no user in
+            // received webhook.
+            // So need to remove '<username>@' from repository's clone url in given factory source.
             .filter(entry -> repositoryUrl.equals(entry.getValue().replaceAll("://.+@", "://")))
             .map(
                 entry ->

--- a/plugins/plugin-bitbucket/codenvy-plugin-bitbucketserver-webhooks/src/test/java/com/codenvy/plugin/webhooks/bitbucketserver/BitbucketServerWebhookServiceTest.java
+++ b/plugins/plugin-bitbucket/codenvy-plugin-bitbucketserver-webhooks/src/test/java/com/codenvy/plugin/webhooks/bitbucketserver/BitbucketServerWebhookServiceTest.java
@@ -93,28 +93,28 @@ public class BitbucketServerWebhookServiceTest {
 
   @Test
   public void shouldHandlePushEvent() throws Exception {
-    //given
+    // given
     PushEvent pushEvent = createPushEvent("commit");
 
-    //when
+    // when
     service.handleWebhookEvent(pushEvent);
 
-    //then
+    // then
     verify(service).handlePushEvent(anyObject(), anyString());
   }
 
   @Test
   public void shouldChangeFactoryStartPointFromBranchToCommitWhenMergeCommitDetected()
       throws Exception {
-    //given
+    // given
     PushEvent pushEvent =
         createPushEvent(
             "Merge pull request #3 in ~projectkey/repository from testBranch to master");
 
-    //when
+    // when
     service.handleWebhookEvent(pushEvent);
 
-    //then
+    // then
     verify(service).handleMergeEvent(anyObject(), anyString());
     assertFalse(parameters.containsKey("branch"));
     assertEquals(parameters.get("commitId"), "hash commit");

--- a/plugins/plugin-google/codenvy-plugin-google-oauth2/src/main/java/org/eclipse/che/security/oauth/GoogleOAuthAuthenticator.java
+++ b/plugins/plugin-google/codenvy-plugin-google-oauth2/src/main/java/org/eclipse/che/security/oauth/GoogleOAuthAuthenticator.java
@@ -93,7 +93,8 @@ public class GoogleOAuthAuthenticator extends OAuthAuthenticator {
   public OAuthToken getToken(String userId) throws IOException {
     final OAuthToken token = super.getToken(userId);
     if (!(token == null || token.getToken() == null || token.getToken().isEmpty())) {
-      // Need to check if token which stored is valid for requests, then if it is valid - we return it to caller
+      // Need to check if token which stored is valid for requests, then if it is valid - we return
+      // it to caller
       URL tokenInfoUrl =
           new URL(
               "https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=" + token.getToken());

--- a/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/java/com/codenvy/ide/hosted/client/informers/UnstagedChangesInformer.java
+++ b/plugins/plugin-hosted/codenvy-hosted-ext-hosted/src/main/java/com/codenvy/ide/hosted/client/informers/UnstagedChangesInformer.java
@@ -27,10 +27,10 @@ public class UnstagedChangesInformer extends Action {
 
   private final AppContext appContext;
 
-  @SuppressWarnings({"unused", "FieldCanBeLocal"}) //used in native method
+  @SuppressWarnings({"unused", "FieldCanBeLocal"}) // used in native method
   private final String restContext;
 
-  @SuppressWarnings({"unused", "FieldCanBeLocal"}) //used in native method
+  @SuppressWarnings({"unused", "FieldCanBeLocal"}) // used in native method
   private final String workspaceId;
 
   @Inject

--- a/plugins/plugin-hosted/codenvy-hosted-ext-support-help/src/main/java/com/codenvy/ide/support/help/client/HelpExtension.java
+++ b/plugins/plugin-hosted/codenvy-hosted-ext-support-help/src/main/java/com/codenvy/ide/support/help/client/HelpExtension.java
@@ -69,14 +69,17 @@ public class HelpExtension {
     // TODO: fixme account
     //        final String accountId = Config.getCurrentWorkspace().getAccountId();
     //        if (accountId != null) {
-    //            subscriptionServiceClient.getSubscriptions(accountId, new AsyncRequestCallback<List<SubscriptionDescriptor>>(
-    //                    dtoUnmarshallerFactory.newListUnmarshaller(SubscriptionDescriptor.class)) {
+    //            subscriptionServiceClient.getSubscriptions(accountId, new
+    // AsyncRequestCallback<List<SubscriptionDescriptor>>(
+    //                    dtoUnmarshallerFactory.newListUnmarshaller(SubscriptionDescriptor.class))
+    // {
     //
     //                @Override
     //                protected void onSuccess(List<SubscriptionDescriptor> result) {
     //                    for (SubscriptionDescriptor subscription : result) {
     //                        if (!("Saas".equals(subscription.getServiceId()) &&
-    //                              "Community".equals(subscription.getProperties().get("Package")))) {
+    //
+    // "Community".equals(subscription.getProperties().get("Package")))) {
     //                            addPremiumSupportHelpAction();
     //                            return;
     //                        }
@@ -93,8 +96,9 @@ public class HelpExtension {
 
   private void addDefaultHelpAction() {
     // TODO change link for engineer chat channel
-    //actionManager.registerAction(localizationConstant.redirectToEngineerChatChannelAction(), redirectToEngineerChatChannelAction);
-    //helpGroup.add(redirectToEngineerChatChannelAction);
+    // actionManager.registerAction(localizationConstant.redirectToEngineerChatChannelAction(),
+    // redirectToEngineerChatChannelAction);
+    // helpGroup.add(redirectToEngineerChatChannelAction);
   }
 
   private void addPremiumSupportHelpAction() {

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedMachineProviderImpl.java
@@ -230,7 +230,8 @@ public class HostedMachineProviderImpl extends MachineProviderImpl {
       if (workDir != null) {
         FileCleaner.addFile(workDir);
       }
-      // When new image is being built it pulls base image. This operation is performed by docker build command.
+      // When new image is being built it pulls base image. This operation is performed by docker
+      // build command.
       // So, after build it is needed to cleanup base image if it is a snapshot.
       if (service.getImage().contains(MACHINE_SNAPSHOT_PREFIX)) {
         submitCleanSnapshotImageTask(service.getImage());
@@ -246,7 +247,8 @@ public class HostedMachineProviderImpl extends MachineProviderImpl {
    * @param image image to clean, e.g. 172.11.12.13:5000/machine_snapshot_abcdef1234567890:latest
    */
   private void submitCleanSnapshotImageTask(String image) {
-    // TODO replace this method by docker.removeImage(image) call after fix of the problem in pure Docker Swarm
+    // TODO replace this method by docker.removeImage(image) call after fix of the problem in pure
+    // Docker Swarm
     snapshotImagesCleanerService.schedule(
         () -> {
           try {

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedServersInstanceRuntimeInfo.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/HostedServersInstanceRuntimeInfo.java
@@ -54,7 +54,8 @@ public class HostedServersInstanceRuntimeInfo extends DockerInstanceRuntimeInfo 
 
   @Override
   public Map<String, ServerImpl> getServers() {
-    // don't use locks because value is always the same and it is ok if one thread overrides saved value
+    // don't use locks because value is always the same and it is ok if one thread overrides saved
+    // value
     if (servers == null) {
       // get servers with direct urls, transform them to use proxy if needed
       final HashMap<String, ServerImpl> servers = new HashMap<>(super.getServers());

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/UriTemplateServerProxyTransformer.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/UriTemplateServerProxyTransformer.java
@@ -78,8 +78,10 @@ public abstract class UriTemplateServerProxyTransformer implements MachineServer
       serverPath = serverPath.substring(1);
     }
 
-    // In case of external address property set, we should replace codenvy.host by this external address.
-    // for example on macOS, codenvy.host is defaulted to 192.168.65.2 which is not reachable from host machine while
+    // In case of external address property set, we should replace codenvy.host by this external
+    // address.
+    // for example on macOS, codenvy.host is defaulted to 192.168.65.2 which is not reachable from
+    // host machine while
     // it needs to use localhost (external address).
     final String externalAddress;
     if (!Strings.isNullOrEmpty(cheDockerIpExternal)) {
@@ -89,7 +91,8 @@ public abstract class UriTemplateServerProxyTransformer implements MachineServer
     }
 
     try {
-      // external URI/address will be used by the browser clients (redirect calls through externalAddress or codenvyHost if not set)
+      // external URI/address will be used by the browser clients (redirect calls through
+      // externalAddress or codenvyHost if not set)
       URI serverUriExternal =
           new URI(
               format(
@@ -103,7 +106,8 @@ public abstract class UriTemplateServerProxyTransformer implements MachineServer
           serverUriExternal.getHost()
               + (serverUriExternal.getPort() == -1 ? "" : ":" + serverUriExternal.getPort());
 
-      // internal URI/address will be used by workspace agents internals (we redirect calls to codenvyHost)
+      // internal URI/address will be used by workspace agents internals (we redirect calls to
+      // codenvyHost)
       URI serverUriInternal =
           new URI(
               format(

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/CodenvyInContainerInfrastructureProvisioner.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/agent/CodenvyInContainerInfrastructureProvisioner.java
@@ -81,7 +81,8 @@ public class CodenvyInContainerInfrastructureProvisioner extends DefaultInfrastr
     for (CheServiceImpl service : internalEnv.getServices().values()) {
       volumes = new ArrayList<>(service.getVolumes());
       volumes.addAll(
-          SNAPSHOT_EXCLUDED_DIRECTORIES); // creates volume for each directory to exclude from a snapshot
+          SNAPSHOT_EXCLUDED_DIRECTORIES); // creates volume for each directory to exclude from a
+      // snapshot
       service.setVolumes(volumes);
     }
 

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/DockerEnvironmentBackupManager.java
@@ -71,7 +71,8 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
   private static final Set<Integer> RESTORE_SUCCESS_RETURN_CODES = ImmutableSet.of(0);
   // if exit code 0 script finished successfully
   // if exit code 24 some files are gone during transfer. It may happen on scheduled backups when
-  // user performs some files operations like git checkout. So we treat this situation as successful.
+  // user performs some files operations like git checkout. So we treat this situation as
+  // successful.
   private static final Set<Integer> BACKUP_SUCCESS_RETURN_CODES = ImmutableSet.of(0, 24);
 
   private final String backupScript;
@@ -161,7 +162,8 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
     } catch (IOException e) {
       throw new ServerException(e.getLocalizedMessage(), e);
     } finally {
-      // remove lock in case exception prevent removing it in regular place to prevent resources leak
+      // remove lock in case exception prevent removing it in regular place to prevent resources
+      // leak
       // and blocking further WS start
       workspacesBackupLocks.remove(workspaceId);
       // clear user info cache
@@ -219,7 +221,8 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
       if (lock.tryLock()) {
         try {
           if (workspacesBackupLocks.get(workspaceId) == null) {
-            // It is possible to reach here, because remove lock from locks map and following unlock in
+            // It is possible to reach here, because remove lock from locks map and following unlock
+            // in
             // backup with cleanup method is not atomic operation.
             // In very rare case it may happens, but it is ok. Just ignore this backup
             // because it is called after cleanup
@@ -249,7 +252,8 @@ public class DockerEnvironmentBackupManager implements EnvironmentBackupManager 
       lock.lock();
       try {
         if (workspacesBackupLocks.get(workspaceId) == null) {
-          // it is possible to reach here if invoke this method again while previous one is in progress
+          // it is possible to reach here if invoke this method again while previous one is in
+          // progress
           LOG.error(
               "Backup with cleanup of the workspace {} was invoked several times simultaneously",
               workspaceId);

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/WorkspaceFsBackupScheduler.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/machine/backup/WorkspaceFsBackupScheduler.java
@@ -77,7 +77,8 @@ public class WorkspaceFsBackupScheduler {
     for (String workspaceId : workspaceRuntimes.getRuntimesIds()) {
 
       try {
-        // re-read workspace state to ensure that it's still active after processing of all previous workspaces
+        // re-read workspace state to ensure that it's still active after processing of all previous
+        // workspaces
         WorkspaceImpl workspace = workspaceManager.getWorkspace(workspaceId);
         // get active env from this WS instead of wsStateEntry because
         // workspace could be restarted during backup of previous WSs with another environment
@@ -109,7 +110,8 @@ public class WorkspaceFsBackupScheduler {
 
                       lastWorkspaceSynchronizationTime.put(workspaceId, System.currentTimeMillis());
                     } catch (NotFoundException ignore) {
-                      // it is ok, machine was stopped while this backup task was in the executor queue
+                      // it is ok, machine was stopped while this backup task was in the executor
+                      // queue
                     } catch (Exception e) {
                       LOG.error(e.getLocalizedMessage(), e);
                     } finally {

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/NodeSelectionStrategy.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/NodeSelectionStrategy.java
@@ -14,7 +14,7 @@ import com.codenvy.swarm.client.model.DockerNode;
 import java.io.IOException;
 import java.util.List;
 
-//TODO consider should it be DockerNode || URI || something else
+// TODO consider should it be DockerNode || URI || something else
 
 /**
  * Node selection strategy for Swarm. Used for not implemented yet in Swarm docker operations.

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/SwarmDockerConnector.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/SwarmDockerConnector.java
@@ -68,7 +68,7 @@ public class SwarmDockerConnector extends DockerConnector {
       "no resources available to schedule container";
 
   private final NodeSelectionStrategy strategy;
-  //TODO should it be done in other way?
+  // TODO should it be done in other way?
   private final String nodeDaemonScheme;
   private final int nodeDescriptionLength;
   // Map of exec ID to container ID (or name)
@@ -167,7 +167,8 @@ public class SwarmDockerConnector extends DockerConnector {
     try {
       super.startExec(params, execOutputProcessor);
     } catch (ExecNotFoundException e) {
-      // Sometimes swarm returns this error for unknown reason, see https://github.com/docker/swarm/issues/2664
+      // Sometimes swarm returns this error for unknown reason, see
+      // https://github.com/docker/swarm/issues/2664
       // Log additional info to find out if this endpoint knows about exec at exactly that time
       logMissingExecInfo(params.getExecId());
       try {
@@ -275,7 +276,7 @@ public class SwarmDockerConnector extends DockerConnector {
     return nodes;
   }
 
-  //TODO find better solution
+  // TODO find better solution
   private URI addrToUri(String addr) {
     return URI.create(nodeDaemonScheme + "://" + addr);
   }

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/model/DockerNode.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/main/java/com/codenvy/swarm/client/model/DockerNode.java
@@ -16,7 +16,7 @@ package com.codenvy.swarm.client.model;
  * @author Eugene Voevodin
  */
 public class DockerNode {
-  //TODO add ram and containers ?
+  // TODO add ram and containers ?
   private final String hostname;
   private final String addr;
 

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedDockerInstanceTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/HostedDockerInstanceTest.java
@@ -133,7 +133,7 @@ public class HostedDockerInstanceTest {
     // when
     executor.execute(() -> performCommit(repo3, TAG));
 
-    Thread.sleep(200); //to allow thread # 3 start
+    Thread.sleep(200); // to allow thread # 3 start
 
     // thread #3 is entered  method but should wait - semaphore is red
     verify(dockerInstance).commitContainer(eq(repo3), eq(TAG));

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/RemoteDockerNodeTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/RemoteDockerNodeTest.java
@@ -54,10 +54,10 @@ public class RemoteDockerNodeTest {
 
   @Test
   public void shouldRestoreWorkspaceBackupOnNodeBinding() throws Exception {
-    //when
+    // when
     remoteDockerNode.bindWorkspace();
 
-    //then
+    // then
     verify(backupManager)
         .restoreWorkspaceBackup(eq("WorkspaceId"), eq("ContainerId"), eq("127.0.0.1"));
   }
@@ -66,10 +66,10 @@ public class RemoteDockerNodeTest {
   public void shouldBackupAndCleanupWSOnNodeUnbinding() throws Exception {
     remoteDockerNode.bindWorkspace();
 
-    //when
+    // when
     remoteDockerNode.unbindWorkspace();
 
-    //then
+    // then
     verify(backupManager)
         .backupWorkspaceAndCleanup(eq("WorkspaceId"), eq("ContainerId"), eq("127.0.0.1"));
   }

--- a/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/WorkspaceFsBackupSchedulerTest.java
+++ b/plugins/plugin-hosted/codenvy-machine-hosted/src/test/java/com/codenvy/machine/backup/WorkspaceFsBackupSchedulerTest.java
@@ -169,7 +169,8 @@ public class WorkspaceFsBackupSchedulerTest {
     scheduler.scheduleBackup();
 
     // then
-    // add this verification with timeout to ensure that thread executor had enough time before verification of call
+    // add this verification with timeout to ensure that thread executor had enough time before
+    // verification of call
     verify(backupManager, timeout(2000)).backupWorkspace(WORKSPACE_ID_1);
     verify(backupManager, timeout(2000)).backupWorkspace(WORKSPACE_ID_2);
     verify(backupManager, after(2000).never()).backupWorkspace("ws3");
@@ -185,7 +186,8 @@ public class WorkspaceFsBackupSchedulerTest {
     addWorkspace("ws3");
     scheduler.scheduleBackup();
 
-    // add this verification with timeout to ensure that thread executor had enough time before verification of call
+    // add this verification with timeout to ensure that thread executor had enough time before
+    // verification of call
     verify(backupManager, timeout(2000)).backupWorkspace("ws3");
 
     // when

--- a/plugins/plugin-jenkins/codenvy-plugin-jenkins-webhooks/src/main/java/com/codenvy/plugin/jenkins/webhooks/JenkinsConnector.java
+++ b/plugins/plugin-jenkins/codenvy-plugin-jenkins-webhooks/src/main/java/com/codenvy/plugin/jenkins/webhooks/JenkinsConnector.java
@@ -155,7 +155,8 @@ public class JenkinsConnector {
   public String getCommitId(int buildId) throws IOException, ServerException {
     String requestUrl = url + "/job/" + jobName + "/" + buildId + "/api/json";
     String request = doRequest(GET, requestUrl, APPLICATION_XML, null);
-    //It is not possible to use Gson parser here because the given JSON contains objects in camel-case and upper-case at he same time.
+    // It is not possible to use Gson parser here because the given JSON contains objects in
+    // camel-case and upper-case at he same time.
     return request.substring(request.indexOf("SHA1") + 7).substring(0, 40);
   }
 

--- a/plugins/plugin-jenkins/codenvy-plugin-jenkins-webhooks/src/test/java/com/codenvy/plugin/jenkins/webhooks/JenkinsConnectorTest.java
+++ b/plugins/plugin-jenkins/codenvy-plugin-jenkins-webhooks/src/test/java/com/codenvy/plugin/jenkins/webhooks/JenkinsConnectorTest.java
@@ -46,19 +46,19 @@ public class JenkinsConnectorTest {
 
   @Test
   public void shouldUpdateConnectorWithUrlWithCredentialsFromProperties() throws Exception {
-    //when
+    // when
     JenkinsConnector jenkinsConnector = this.jenkinsConnector.updateUrlWithCredentials();
 
-    //then
+    // then
     assertEquals(jenkinsConnector.url, "http://user:password@jenkins.url");
   }
 
   @Test
   public void shouldGetRelatedFactoryIdFromProperties() throws Exception {
-    //when
+    // when
     String factoryId = jenkinsConnector.getFactoryId();
 
-    //then
+    // then
     assertEquals(factoryId, "factoryId");
   }
 }

--- a/plugins/plugin-jenkins/codenvy-plugin-jenkins-webhooks/src/test/java/com/codenvy/plugin/jenkins/webhooks/JenkinsWebhookManagerTest.java
+++ b/plugins/plugin-jenkins/codenvy-plugin-jenkins-webhooks/src/test/java/com/codenvy/plugin/jenkins/webhooks/JenkinsWebhookManagerTest.java
@@ -107,23 +107,23 @@ public class JenkinsWebhookManagerTest {
 
   @Test
   public void shouldAddFailedBuildFactoryLink() throws Exception {
-    //when
+    // when
     manager.handleFailedJobEvent(jenkinsEvent);
 
-    //then
+    // then
     verify(jenkinsConnector).addFailedBuildFactoryLink(eq("url/f?id=factoryId"));
   }
 
   @Test
   public void shouldGenerateFailedBuildFactory() throws Exception {
-    //given
+    // given
     parameters.put("branch", "branch");
     when(factory.getName()).thenReturn("name");
 
-    //when
+    // when
     manager.handleFailedJobEvent(jenkinsEvent);
 
-    //then
+    // then
     verify(factoryManager).saveFactory(factory);
     verify(factory).setName(eq("name_commitId"));
     assertNull(parameters.get("branch"));
@@ -132,13 +132,13 @@ public class JenkinsWebhookManagerTest {
 
   @Test
   public void shouldNotCreateNewFactoryIfFactoryWithCommitIdIsPresent() throws Exception {
-    //given
+    // given
     parameters.put("commitId", "commitId");
 
-    //when
+    // when
     manager.handleFailedJobEvent(jenkinsEvent);
 
-    //then
+    // then
     verify(factoryManager, never()).saveFactory(factory);
   }
 }

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/src/main/java/com/codenvy/plugin/webhooks/vsts/PullRequestUpdatedWebhook.java
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/src/main/java/com/codenvy/plugin/webhooks/vsts/PullRequestUpdatedWebhook.java
@@ -47,7 +47,8 @@ public class PullRequestUpdatedWebhook {
     this.apiVersion = apiVersion;
     this.credentials = credentials;
 
-    // No more than one webhook can be configured for a given combination of VSTS account/host/collection
+    // No more than one webhook can be configured for a given combination of VSTS
+    // account/host/collection
     this.id = account + "-" + host + "-" + collection;
 
     if (factoriesIds != null && factoriesIds.length > 0) {

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/src/main/java/com/codenvy/plugin/webhooks/vsts/VSTSConnection.java
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/src/main/java/com/codenvy/plugin/webhooks/vsts/VSTSConnection.java
@@ -142,8 +142,8 @@ public class VSTSConnection {
    */
   private String extensionStorageHttpUrl(
       final String visualStudioHost, final String account, final String collection) {
-    //https://vsts-test.visualstudio.com/DefaultCollection/_apis
-    //https://vsts-test.extmgmt.visualstudio.com/DefaultCollection/_apis
+    // https://vsts-test.visualstudio.com/DefaultCollection/_apis
+    // https://vsts-test.extmgmt.visualstudio.com/DefaultCollection/_apis
     final String host = account + ".extmgmt." + visualStudioHost + ".com";
     final String collectionPath = collection + "/_apis";
     final String extensionStoragePath =

--- a/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/src/main/java/com/codenvy/plugin/webhooks/vsts/VSTSWebhookService.java
+++ b/plugins/plugin-microsoft/codenvy-plugin-microsoft-vsts-webhooks/src/main/java/com/codenvy/plugin/webhooks/vsts/VSTSWebhookService.java
@@ -288,7 +288,8 @@ public class VSTSWebhookService extends BaseWebhookService {
           pullRequestUpdatedEvent.getResource().getLastMergeSourceCommit().getCommitId();
 
       // Get VSTS data from repository URL
-      // URL to parse: 'https://{account}.{host}.com/{collection}/_apis/git/repositories/{repositoryId}'
+      // URL to parse:
+      // 'https://{account}.{host}.com/{collection}/_apis/git/repositories/{repositoryId}'
       final String collectionUrl = repositoryIdUrl.split("/_apis/git/repositories/")[0];
       LOG.debug("collectionUrl: {}", collectionUrl);
       final String[] collectionUrlSplit = collectionUrl.split("/");

--- a/plugins/plugin-redhat/codenvy-plugin-redhat-oauth2/src/main/java/org/eclipse/che/security/oauth/RedHatUser.java
+++ b/plugins/plugin-redhat/codenvy-plugin-redhat-oauth2/src/main/java/org/eclipse/che/security/oauth/RedHatUser.java
@@ -15,6 +15,7 @@ package org.eclipse.che.security.oauth;
  *
  * @author Max Shaposhnik
  */
+
 import org.eclipse.che.security.oauth.shared.User;
 
 public class RedHatUser implements User {

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/pageobject/dashboard/organization/OrganizationPage.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/pageobject/dashboard/organization/OrganizationPage.java
@@ -58,7 +58,8 @@ public class OrganizationPage {
         "//md-content[contains(@class, 'organization-member-list')]//div[contains(@class, 'che-list-header-column')]//span";
     String MEMBERS_LIST_ITEM_XPATH =
         "//md-content[contains(@class, 'organization-member-list')]//span[text() = '%s']";
-    //        String MEMBER_CHECKBOX = "//div[contains(@class,'che-list-item-checkbox-main')]/md-checkbox[contains(@aria-label,'member')]";
+    //        String MEMBER_CHECKBOX =
+    // "//div[contains(@class,'che-list-item-checkbox-main')]/md-checkbox[contains(@aria-label,'member')]";
     String MEMBER_CHECKBOX = "//md-checkbox[contains(@aria-label,'member')]";
     // todo: //span[text()='Delete'] to get Delete button only
     String DELETE_MEMBER_WIDGET_BUTTON = "//che-popup//button";

--- a/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/util/MailReceiverUtils.java
+++ b/selenium/codenvy-selenium-test/src/main/java/com/codenvy/selenium/util/MailReceiverUtils.java
@@ -69,9 +69,9 @@ public class MailReceiverUtils {
         session.getStore("imaps"); // Get a Store object that implements the specified protocol.
     mailStore.connect(
         host, user,
-        password); //Connect to the current host using the specified username and password.
+        password); // Connect to the current host using the specified username and password.
     mailBoxFolder =
-        mailStore.getFolder("inbox"); //Create a Folder object corresponding to the given name.
+        mailStore.getFolder("inbox"); // Create a Folder object corresponding to the given name.
     mailBoxFolder.open(Folder.READ_ONLY); // Open the Folder.
     Message[] msgs = mailBoxFolder.getMessages();
     return msgs;
@@ -90,9 +90,9 @@ public class MailReceiverUtils {
         session.getStore("imaps"); // Get a Store object that implements the specified protocol.
     store.connect(
         host, user,
-        password); //Connect to the current host using the specified username and password.
+        password); // Connect to the current host using the specified username and password.
     Folder folder =
-        store.getFolder("inbox"); //Create a Folder object corresponding to the given name.
+        store.getFolder("inbox"); // Create a Folder object corresponding to the given name.
     folder.open(Folder.READ_WRITE); // Open the Folder.
     Message[] messages = folder.getMessages();
     for (int i = 0, n = messages.length; i < n; i++) {

--- a/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/ssh/LoginBySshKeyTest.java
+++ b/selenium/codenvy-selenium-test/src/test/java/com/codenvy/selenium/ssh/LoginBySshKeyTest.java
@@ -148,7 +148,8 @@ public class LoginBySshKeyTest {
         TestCommandsConstants.CUSTOM,
         ws2.getId());
 
-    //This actions for redrawing the just add commands on Toolbar widget after fixing CHE-1357 the refresh browser block should be removed
+    // This actions for redrawing the just add commands on Toolbar widget after fixing CHE-1357 the
+    // refresh browser block should be removed
     seleniumWebDriver.navigate().refresh();
     notifications.waitExpectedMessageOnProgressPanelAndClosed(
         TestWorkspaceConstants.RUNNING_WORKSPACE_MESS);

--- a/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/WsAgentModule.java
+++ b/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/WsAgentModule.java
@@ -37,7 +37,7 @@ public class WsAgentModule extends AbstractModule {
   protected void configure() {
 
     bind(PermissionChecker.class).to(HttpPermissionCheckerImpl.class);
-    //bind(TokenHandler.class).to(com.codenvy.api.permission.server.PermissionTokenHandler.class);
+    // bind(TokenHandler.class).to(com.codenvy.api.permission.server.PermissionTokenHandler.class);
     bind(TokenHandler.class)
         .annotatedWith(Names.named("delegated.handler"))
         .to(com.codenvy.auth.sso.client.NoUserInteractionTokenHandler.class);

--- a/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/WsAgentServletModule.java
+++ b/wsagent/codenvy-wsagent-core/src/main/java/com/codenvy/wsagent/server/WsAgentServletModule.java
@@ -29,15 +29,15 @@ import org.eclipse.che.inject.DynaModule;
 public class WsAgentServletModule extends ServletModule {
   @Override
   protected void configureServlets() {
-    //listeners
+    // listeners
     getServletContext().addListener(new com.codenvy.auth.sso.client.DestroySessionListener());
 
-    //filters
+    // filters
     filter("/*").through(CheCorsFilter.class);
     filter("/*")
         .through(org.eclipse.che.multiuser.machine.authentication.agent.MachineLoginFilter.class);
 
-    //servlets
+    // servlets
     install(new com.codenvy.auth.sso.client.deploy.SsoClientServletModule());
     serveRegex("/[^/]+/api((?!(/(ws|eventbus)($|/.*)))/.*)")
         .with(org.everrest.guice.servlet.GuiceEverrestServlet.class);

--- a/wsmaster/codenvy-hosted-api-admin/src/main/java/com/codenvy/api/user/server/AdminUserServicePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-admin/src/main/java/com/codenvy/api/user/server/AdminUserServicePermissionsFilter.java
@@ -37,7 +37,7 @@ public class AdminUserServicePermissionsFilter extends CheMethodInvokerFilter {
           .getSubject()
           .checkPermission(SystemDomain.DOMAIN_ID, null, MANAGE_USERS_ACTION);
     } else {
-      //unknown method
+      // unknown method
       throw new ForbiddenException("User is not authorized to perform this operation");
     }
   }

--- a/wsmaster/codenvy-hosted-api-audit/src/main/java/com/codenvy/api/audit/server/AuditManager.java
+++ b/wsmaster/codenvy-hosted-api-audit/src/main/java/com/codenvy/api/audit/server/AuditManager.java
@@ -118,14 +118,14 @@ public class AuditManager {
   private void printAllUsersInfo(Path auditReport) throws ServerException {
     Page<UserImpl> currentPage = userManager.getAll(30, 0);
     do {
-      //Print users with their workspaces from current page
+      // Print users with their workspaces from current page
       for (UserImpl user : currentPage.getItems()) {
         List<WorkspaceImpl> workspaces;
         try {
           workspaces = workspaceManager.getWorkspaces(user.getId(), false);
           Set<String> workspaceIds =
               workspaces.stream().map(WorkspaceImpl::getId).collect(Collectors.toSet());
-          //add workspaces witch are belong to user, but user doesn't have permissions for them.
+          // add workspaces witch are belong to user, but user doesn't have permissions for them.
           workspaceManager
               .getByNamespace(user.getName(), false)
               .stream()
@@ -145,7 +145,7 @@ public class AuditManager {
                 workspace.getId(),
                 permissionsManager.get(user.getId(), DOMAIN_ID, workspace.getId()));
           } catch (NotFoundException | ConflictException ignored) {
-            //User doesn't have permissions for workspace
+            // User doesn't have permissions for workspace
           }
         }
         Printer.createUserPrinter(auditReport, user, workspaces, wsPermissions).print();

--- a/wsmaster/codenvy-hosted-api-audit/src/main/java/com/codenvy/api/audit/server/AuditServicePermissionsFilter.java
+++ b/wsmaster/codenvy-hosted-api-audit/src/main/java/com/codenvy/api/audit/server/AuditServicePermissionsFilter.java
@@ -38,7 +38,7 @@ public class AuditServicePermissionsFilter extends CheMethodInvokerFilter {
           .getSubject()
           .checkPermission(SystemDomain.DOMAIN_ID, null, MANAGE_SYSTEM_ACTION);
     } else {
-      //unknown method
+      // unknown method
       throw new ForbiddenException("User is not authorized to perform this operation");
     }
   }

--- a/wsmaster/codenvy-hosted-api-audit/src/test/java/com/codenvy/api/audit/server/AuditManagerTest.java
+++ b/wsmaster/codenvy-hosted-api-audit/src/test/java/com/codenvy/api/audit/server/AuditManagerTest.java
@@ -63,7 +63,7 @@ public class AuditManagerTest {
 
     auditManager = new AuditManager(userManager, workspaceManager, permissionsManager);
 
-    //User
+    // User
     UserImpl user1 = mock(UserImpl.class);
     UserImpl user2 = mock(UserImpl.class);
     when(user1.getEmail()).thenReturn("user@email.com");
@@ -72,12 +72,12 @@ public class AuditManagerTest {
     when(user2.getId()).thenReturn("User2Id");
     when(user1.getName()).thenReturn("User1");
     when(user2.getName()).thenReturn("User2");
-    //Workspace config
+    // Workspace config
     WorkspaceConfigImpl ws1config = mock(WorkspaceConfigImpl.class);
     WorkspaceConfigImpl ws2config = mock(WorkspaceConfigImpl.class);
     when(ws1config.getName()).thenReturn("Workspace1Name");
     when(ws2config.getName()).thenReturn("Workspace2Name");
-    //Workspace
+    // Workspace
     when(workspace1.getNamespace()).thenReturn("User1");
     when(workspace2.getNamespace()).thenReturn("User2");
     when(workspace1.getId()).thenReturn("Workspace1Id");
@@ -88,7 +88,7 @@ public class AuditManagerTest {
         .thenReturn(asList(workspace1, workspace2));
     when(workspaceManager.getWorkspaces(eq("User2Id"), eq(false)))
         .thenReturn(singletonList(workspace2));
-    //Permissions
+    // Permissions
     AbstractPermissions ws1User1Permissions = mock(AbstractPermissions.class);
     AbstractPermissions ws2User1Permissions = mock(AbstractPermissions.class);
     AbstractPermissions ws2User2Permissions = mock(AbstractPermissions.class);
@@ -110,7 +110,7 @@ public class AuditManagerTest {
         .thenReturn(ws2User1Permissions);
     when(permissionsManager.get(eq("User2Id"), anyString(), eq("Workspace2Id")))
         .thenReturn(ws2User2Permissions);
-    //Page
+    // Page
     Page page = mock(Page.class);
     when(page.getItems()).thenReturn(asList(user1, user2));
     when(page.hasNextPage()).thenReturn(false);
@@ -127,10 +127,10 @@ public class AuditManagerTest {
 
   @Test
   public void shouldReturnFullAuditReport() throws Exception {
-    //when
+    // when
     auditReport = auditManager.generateAuditReport();
 
-    //then
+    // then
     assertEquals(
         readFileToString(auditReport.toFile()),
         "Number of users: 2\n"
@@ -144,7 +144,7 @@ public class AuditManagerTest {
   @Test
   public void shouldReturnFullAuditReportWithWorkspaceThatBelongsToUserButWithoutPermissionsToUser()
       throws Exception {
-    //given
+    // given
     List<WorkspaceImpl> workspaces = new ArrayList<>();
     workspaces.add(workspace2);
     when(workspace1.getNamespace()).thenReturn("User2");
@@ -153,10 +153,10 @@ public class AuditManagerTest {
     when(workspaceManager.getByNamespace(eq("User2"), eq(false)))
         .thenReturn(asList(workspace1, workspace2));
 
-    //when
+    // when
     auditReport = auditManager.generateAuditReport();
 
-    //then
+    // then
     assertEquals(
         readFileToString(auditReport.toFile()),
         "Number of users: 2\n"
@@ -171,14 +171,14 @@ public class AuditManagerTest {
   @Test
   public void shouldReturnAuditReportWithoutUserWorkspacesIfFailedToRetrieveTheListOfHisWorkspaces()
       throws Exception {
-    //given
+    // given
     when(workspaceManager.getWorkspaces(eq("User1Id"), eq(false)))
         .thenThrow(new ServerException("Failed to retrieve workspaces"));
 
-    //when
+    // when
     auditReport = auditManager.generateAuditReport();
 
-    //then
+    // then
     assertEquals(
         readFileToString(auditReport.toFile()),
         "Number of users: 2\n"

--- a/wsmaster/codenvy-hosted-api-invite/src/main/java/com/codenvy/spi/invite/jpa/JpaInviteDao.java
+++ b/wsmaster/codenvy-hosted-api-invite/src/main/java/com/codenvy/spi/invite/jpa/JpaInviteDao.java
@@ -158,7 +158,7 @@ public class JpaInviteDao implements InviteDao {
       manager.remove(invite);
       manager.flush();
     } catch (NotFoundException e) {
-      //invite is already removed
+      // invite is already removed
     }
   }
 

--- a/wsmaster/codenvy-hosted-api-invite/src/test/java/com/codenvy/api/invite/InviteServicePermissionsFilterTest.java
+++ b/wsmaster/codenvy-hosted-api-invite/src/test/java/com/codenvy/api/invite/InviteServicePermissionsFilterTest.java
@@ -84,14 +84,14 @@ public class InviteServicePermissionsFilterTest {
 
   @Test
   public void shouldTestThatAllPublicMethodsAreCoveredByPermissionsFilter() throws Exception {
-    //given
+    // given
     final List<String> collect =
         Stream.of(InviteService.class.getDeclaredMethods())
             .filter(method -> Modifier.isPublic(method.getModifiers()))
             .map(Method::getName)
             .collect(Collectors.toList());
 
-    //then
+    // then
     assertEquals(collect.size(), 3);
     assertTrue(collect.contains(InviteServicePermissionsFilter.GET_INVITES_METHOD));
     assertTrue(collect.contains(InviteServicePermissionsFilter.INVITE_METHOD));

--- a/wsmaster/codenvy-hosted-api-invite/src/test/java/com/codenvy/api/invite/InviteServiceTest.java
+++ b/wsmaster/codenvy-hosted-api-invite/src/test/java/com/codenvy/api/invite/InviteServiceTest.java
@@ -51,10 +51,10 @@ import org.testng.annotations.Test;
 public class InviteServiceTest {
   private static final String EMAIL_TO_INVITE = "userok@test.com";
 
-  @SuppressWarnings("unused") //is declared for deploying by everrest-assured
+  @SuppressWarnings("unused") // is declared for deploying by everrest-assured
   private ApiExceptionMapper mapper;
 
-  @SuppressWarnings("unused") //is declared for deploying by everrest-assured
+  @SuppressWarnings("unused") // is declared for deploying by everrest-assured
   private CheJsonProvider jsonProvider = new CheJsonProvider(new HashSet<>());
 
   @Mock private InviteManager inviteManager;

--- a/wsmaster/codenvy-hosted-events/src/main/java/com/codenvy/user/interceptor/CreateUserInterceptor.java
+++ b/wsmaster/codenvy-hosted-events/src/main/java/com/codenvy/user/interceptor/CreateUserInterceptor.java
@@ -37,7 +37,8 @@ public class CreateUserInterceptor implements MethodInterceptor {
 
   @Inject private CreationNotificationSender notificationSender;
 
-  //Do not remove ApiException. It used to tell dependency plugin that api-core is need not only for tests.
+  // Do not remove ApiException. It used to tell dependency plugin that api-core is need not only
+  // for tests.
   @Override
   public Object invoke(MethodInvocation invocation) throws Throwable, ApiException {
     Object proceed = invocation.proceed();

--- a/wsmaster/codenvy-hosted-events/src/main/java/com/codenvy/user/interceptor/UserCreatorInterceptor.java
+++ b/wsmaster/codenvy-hosted-events/src/main/java/com/codenvy/user/interceptor/UserCreatorInterceptor.java
@@ -40,18 +40,19 @@ public class UserCreatorInterceptor implements MethodInterceptor {
 
   @Inject private CreationNotificationSender notificationSender;
 
-  //Do not remove ApiException. It used to tell dependency plugin that api-core is need not only for tests.
+  // Do not remove ApiException. It used to tell dependency plugin that api-core is need not only
+  // for tests.
   @Override
   public Object invoke(MethodInvocation invocation) throws Throwable, ApiException {
-    //UserCreator should not create user if he already exists
+    // UserCreator should not create user if he already exists
     final String email = (String) invocation.getArguments()[0];
     try {
       userManager.getByEmail(email);
 
-      //user is already registered
+      // user is already registered
       return invocation.proceed();
     } catch (NotFoundException e) {
-      //user was not found and it will be created
+      // user was not found and it will be created
     }
 
     final Object proceed = invocation.proceed();

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/authentication/AuthenticationDaoImpl.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/authentication/AuthenticationDaoImpl.java
@@ -108,7 +108,7 @@ public class AuthenticationDaoImpl implements AuthenticationDao {
           ticketManager.removeTicket(accessTicket.getAccessToken());
         }
       } else {
-        //cookie is outdated, clearing
+        // cookie is outdated, clearing
         if (cookieBuilder != null) {
           cookieBuilder.clearCookies(builder, tokenAccessCookie.getValue(), secure);
         }

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/authentication/AuthenticationHandlerProvider.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/dao/authentication/AuthenticationHandlerProvider.java
@@ -10,6 +10,7 @@
  */
 package com.codenvy.api.dao.authentication;
 /** @author Sergii Kabashniuk */
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/SystemRamCheckingWorkspaceManager.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/main/java/com/codenvy/api/workspace/SystemRamCheckingWorkspaceManager.java
@@ -63,7 +63,7 @@ public class SystemRamCheckingWorkspaceManager extends LimitsCheckingWorkspaceMa
       @Named("che.workspace.auto_restore") boolean defaultAutoRestore,
       SnapshotDao snapshotDao,
       WorkspaceSharedPool sharedPool,
-      //own injects
+      // own injects
       @Named("che.limits.workspace.env.ram") String maxRamPerEnv,
       @Named("limits.workspace.start.throughput") int maxSameTimeStartWSRequests,
       SystemRamInfoProvider systemRamInfoProvider,

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/authentication/AuthenticationServiceTest.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/dao/authentication/AuthenticationServiceTest.java
@@ -89,7 +89,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldAuthenticateWithCorrectParams() throws Exception {
-    //given
+    // given
 
     when(handler.authenticate(eq(USER.getName()), eq("secret"))).thenReturn(USER.getId());
     doAnswer(
@@ -142,7 +142,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldReturnBadRequestIfLoginIsNotSet() throws Exception {
-    //given
+    // given
     // when
     given()
         .contentType(ContentType.JSON)
@@ -160,7 +160,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldReturnBadRequestIfLoginIsEmpty() throws Exception {
-    //given
+    // given
     // when
     given()
         .contentType(ContentType.JSON)
@@ -178,7 +178,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldReturnBadRequestIfPassowordIsNotSet() throws Exception {
-    //given
+    // given
     // when
     given()
         .contentType(ContentType.JSON)
@@ -196,7 +196,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldReturnBadRequestIfPasswordIsEmpty() throws Exception {
-    //given
+    // given
     // when
     given()
         .contentType(ContentType.JSON)
@@ -214,7 +214,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldReturnBadRequestIfHandlerNotAbleToAuthenticate() throws Exception {
-    //given
+    // given
     doThrow(new AuthenticationException("Not able to authenticate"))
         .when(handler)
         .authenticate(eq(USER.getName()), eq("asdfasdf"));
@@ -235,7 +235,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldLogoutFirstIfUserAlreadyLoggedIn() throws Exception {
-    //given
+    // given
     when(handler.authenticate(eq(USER.getName()), eq("secret"))).thenReturn(USER.getId());
     doAnswer(
             new Answer<Object>() {
@@ -292,7 +292,7 @@ public class AuthenticationServiceTest {
 
   @Test
   public void shouldBeAbleToLogoutByQueryParameter() throws Exception {
-    //given
+    // given
     when(ticketManager.removeTicket(eq(token2)))
         .thenReturn(new AccessTicket(token2, USER_2.getId(), "default"));
     // when
@@ -304,13 +304,13 @@ public class AuthenticationServiceTest {
         .statusCode(200)
         .when()
         .post("/auth/logout");
-    //then
+    // then
     verify(ticketManager).removeTicket(eq(token2));
   }
 
   @Test
   public void shouldBeAbleToLogoutByCookie() throws Exception {
-    //given
+    // given
     when(ticketManager.removeTicket(eq(token2)))
         .thenReturn(new AccessTicket(token2, USER_2.getId(), "default"));
     // when
@@ -322,13 +322,13 @@ public class AuthenticationServiceTest {
         .statusCode(200)
         .when()
         .post("/auth/logout");
-    //then
+    // then
     verify(ticketManager).removeTicket(eq(token2));
   }
 
   @Test
   public void shouldFailToLogoutWithoutToken() throws Exception {
-    //given
+    // given
     // when
     given()
         .contentType(ContentType.JSON)

--- a/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/SystemRamCheckingWorkspaceManagerTest.java
+++ b/wsmaster/codenvy-hosted-platform-api-impl/src/test/java/com/codenvy/api/workspace/SystemRamCheckingWorkspaceManagerTest.java
@@ -144,7 +144,7 @@ public class SystemRamCheckingWorkspaceManagerTest {
      to be able to release the throughput limit.
     */
     final CountDownLatch invokeProcessLatch = new CountDownLatch(6);
-    //Pause 5 threads after they will acquire all permits to check RAM.
+    // Pause 5 threads after they will acquire all permits to check RAM.
     doAnswer(
             invocationOnMock -> {
               invokeProcessLatch.countDown();
@@ -161,7 +161,8 @@ public class SystemRamCheckingWorkspaceManagerTest {
           } catch (Exception ignored) {
           }
         };
-    //Run 7 threads (more than number of allowed same time requests) that want to request RAM check at the same time.
+    // Run 7 threads (more than number of allowed same time requests) that want to request RAM check
+    // at the same time.
     ExecutorService executor = Executors.newFixedThreadPool(7);
     executor.submit(runnable);
     executor.submit(runnable);
@@ -171,12 +172,14 @@ public class SystemRamCheckingWorkspaceManagerTest {
     executor.submit(runnable);
     executor.submit(runnable);
 
-    //Wait for throughput limit will be reached and check that RAM check was performed only in allowed number of threads.
+    // Wait for throughput limit will be reached and check that RAM check was performed only in
+    // allowed number of threads.
     verify(manager, timeout(300).times(5)).checkSystemRamLimitAndPropagateStart(anyObject());
 
-    //Execute paused threads to release the throughput limit for other threads.
+    // Execute paused threads to release the throughput limit for other threads.
     invokeProcessLatch.countDown();
-    //Wait for throughput limit will be released and check that RAM check was performed in other threads.
+    // Wait for throughput limit will be released and check that RAM check was performed in other
+    // threads.
     verify(manager, timeout(300).times(7)).checkSystemRamLimitAndPropagateStart(anyObject());
   }
 

--- a/wsmaster/codenvy-hosted-recoverpassword/src/main/java/com/codenvy/service/password/PasswordService.java
+++ b/wsmaster/codenvy-hosted-recoverpassword/src/main/java/com/codenvy/service/password/PasswordService.java
@@ -117,7 +117,7 @@ public class PasswordService {
   public void recoverPassword(@PathParam("usermail") String mail)
       throws ServerException, NotFoundException {
     try {
-      //check if user exists
+      // check if user exists
       userManager.getByEmail(mail);
       final String masterEndpoint =
           uriInfo.getBaseUriBuilder().replacePath(null).build().toString();

--- a/wsmaster/codenvy-hosted-sso-auth-bearer/src/main/java/com/codenvy/auth/sso/server/BearerTokenAuthenticationService.java
+++ b/wsmaster/codenvy-hosted-sso-auth-bearer/src/main/java/com/codenvy/auth/sso/server/BearerTokenAuthenticationService.java
@@ -155,7 +155,7 @@ public class BearerTokenAuthenticationService {
             ticketManager.removeTicket(accessTicket.getAccessToken());
           }
         } else {
-          //cookie is outdated, clearing
+          // cookie is outdated, clearing
           cookieBuilder.clearCookies(builder, tokenAccessCookie.getValue(), isSecure);
         }
       }

--- a/wsmaster/codenvy-hosted-sso-auth-bearer/src/main/java/com/codenvy/auth/sso/server/handler/BearerTokenAuthenticationHandler.java
+++ b/wsmaster/codenvy-hosted-sso-auth-bearer/src/main/java/com/codenvy/auth/sso/server/handler/BearerTokenAuthenticationHandler.java
@@ -62,7 +62,7 @@ public class BearerTokenAuthenticationHandler {
 
   @PostConstruct
   public void startTimer() {
-    //wait 1 second and run each minute.
+    // wait 1 second and run each minute.
     timer.schedule(
         new TimerTask() {
           @Override

--- a/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/DestroySessionListener.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/DestroySessionListener.java
@@ -41,7 +41,7 @@ public class DestroySessionListener implements HttpSessionListener {
           "Unable to remove session from SSO Store. Session store is not configured in servlet context.");
     } else {
 
-      //If principal in session it means logout by session timeout.
+      // If principal in session it means logout by session timeout.
       SsoClientPrincipal principal = (SsoClientPrincipal) se.getSession().getAttribute("principal");
       if (principal != null) {
         ServerClient client = getInstance(ServerClient.class, servletContext);
@@ -51,7 +51,7 @@ public class DestroySessionListener implements HttpSessionListener {
               principal.getName(),
               principal.getClientUrl(),
               principal.getToken());
-          //notify sso server to unregistered current client
+          // notify sso server to unregistered current client
           client.unregisterClient(principal.getToken(), principal.getClientUrl());
         }
       }

--- a/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/LoginFilter.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/main/java/com/codenvy/auth/sso/client/LoginFilter.java
@@ -97,7 +97,7 @@ public class LoginFilter implements Filter {
 
       HttpSession session;
       if (token != null) {
-        //TODO thread safety
+        // TODO thread safety
         session = sessionStore.getSession(token);
         if (session == null) {
           session = httpReq.getSession();
@@ -111,9 +111,9 @@ public class LoginFilter implements Filter {
           tokenHandler.handleValidToken(httpReq, httpResp, chain, session, principal);
         }
       } else {
-        //token not exists
+        // token not exists
         if (httpReq.getParameter("cookiePresent") != null) {
-          //we know that token have to be in cookies but it's not there
+          // we know that token have to be in cookies but it's not there
           httpResp.sendRedirect(cookiesDisabledErrorPageUrl);
         } else {
           tokenHandler.handleMissingToken(httpReq, httpResp, chain);

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/LoginFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/LoginFilterTest.java
@@ -116,7 +116,7 @@ public class LoginFilterTest {
   @Test
   public void shouldRedirectToSsoServerIfSessionDoesntContainsPrincipalOnGet()
       throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/myworkspace", null, 0, "GET", null);
 
@@ -127,10 +127,10 @@ public class LoginFilterTest {
         "tokenHandler",
         new RecoverableTokenHandler(requestWrapper, clientUrlExtractor, true));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response)
         .sendRedirect(
             eq(
@@ -143,7 +143,7 @@ public class LoginFilterTest {
   @Test
   public void shouldRedirectToSsoServerAnonymousIsNotAllowed()
       throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     setFieldValue(filter, "attemptToGetNewTokenIfNotExist", true);
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/myworkspace", null, 0, "GET", null);
@@ -154,10 +154,10 @@ public class LoginFilterTest {
         "tokenHandler",
         new RecoverableTokenHandler(requestWrapper, clientUrlExtractor, false));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response)
         .sendRedirect(
             eq(
@@ -171,7 +171,7 @@ public class LoginFilterTest {
   @Test
   public void shouldRedirectToSsoServerWithCorrectRedirectAndClientUrl()
       throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest(
             "http://localhost:8080/ws/mypersonal.Workspace", null, 0, "GET", null);
@@ -182,10 +182,10 @@ public class LoginFilterTest {
         "tokenHandler",
         new RecoverableTokenHandler(requestWrapper, clientUrlExtractor, false));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response)
         .sendRedirect(
             eq(
@@ -198,7 +198,7 @@ public class LoginFilterTest {
   @Test
   public void shouldAppendQueryUrlToRedirectURLToSsoServer()
       throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest(
             "http://localhost:8080/ws/mypersonal.Workspace?myparam=myValue&param2=value2",
@@ -214,10 +214,10 @@ public class LoginFilterTest {
         "tokenHandler",
         new RecoverableTokenHandler(requestWrapper, clientUrlExtractor, false));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
 
     verify(response)
         .sendRedirect(
@@ -232,7 +232,7 @@ public class LoginFilterTest {
   @Test
   public void shouldRedirectToLoginIfPrincipalIsNotNullButQueryParameterLoginExists()
       throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest(
             "http://localhost:8080/ws/mypersonal.Workspace?myparam=myValue&param2=value2&login",
@@ -252,10 +252,10 @@ public class LoginFilterTest {
                 createSubject("user@domain")));
     filter.init(filterConfig);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response)
         .sendRedirect(
             eq(
@@ -268,7 +268,7 @@ public class LoginFilterTest {
   @Test
   public void shouldRedirectToLoginIfPrincipalIsNullButQueryParameterLoginExists()
       throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest(
             "http://localhost:8080/ws/mypersonal.Workspace?myparam=myValue&param2=value2&login",
@@ -280,10 +280,10 @@ public class LoginFilterTest {
         .thenReturn("http://localhost:8080/ws/mypersonal.Workspace");
     filter.init(filterConfig);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response)
         .sendRedirect(
             eq(
@@ -295,17 +295,17 @@ public class LoginFilterTest {
 
   @Test
   public void shouldPutPrincipalInSession() throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/ws?token=t13f", null, 0, "GET", null);
 
     when(tokenExtractor.getToken(eq(request))).thenReturn("t13f");
     when(ssoServerClient.getSubject(eq("t13f"), nullable(String.class)))
         .thenReturn(createSubject("user@domain"));
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     SsoClientPrincipal actual = (SsoClientPrincipal) request.getSession().getAttribute("principal");
     assertEquals(actual.getName(), "user@domain");
     verify(chain).doFilter(any(ServletRequest.class), eq(response));
@@ -314,7 +314,7 @@ public class LoginFilterTest {
   @Test
   public void shouldBeAbleToReplaceAnonymousWithCorrectUserPrincipal()
       throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/ws?token=t13f", null, 0, "GET", null);
 
@@ -330,10 +330,10 @@ public class LoginFilterTest {
             "t12f", "http://localhost:8080/ws/ws", createSubject("Anonymous123@domain"));
     request.getSession().setAttribute("principal", anonymous);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     ArgumentCaptor<ServletRequest> captor = ArgumentCaptor.forClass(ServletRequest.class);
     verify(chain).doFilter(captor.capture(), eq(response));
     assertEquals(
@@ -353,10 +353,10 @@ public class LoginFilterTest {
         "tokenHandler",
         new RecoverableTokenHandler(requestWrapper, clientUrlExtractor, false));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response)
         .sendRedirect(
             eq(
@@ -368,7 +368,7 @@ public class LoginFilterTest {
 
   @Test
   public void shouldWrapPrincipalInRequest() throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/ws", null, 0, "GET", null);
 
@@ -380,10 +380,10 @@ public class LoginFilterTest {
         new SsoClientPrincipal("t13f", "http://localhost:8080/ws/ws", createSubject("user@domain"));
     request.getSession().setAttribute("principal", principal);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
     verify(chain).doFilter(captor.capture(), any(ServletResponse.class));
     HttpServletRequest actual = captor.getValue();
@@ -395,7 +395,7 @@ public class LoginFilterTest {
   @Test
   public void shouldWrappedPrincipalShouldNotBeTheSameAsInRequest()
       throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/ws", null, 0, "GET", null);
     when(tokenExtractor.getToken(eq(request))).thenReturn("t13f");
@@ -406,10 +406,10 @@ public class LoginFilterTest {
         new SsoClientPrincipal("t13f", "http://localhost:8080/ws/ws", createSubject("user@domain"));
     request.getSession().setAttribute("principal", principal);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
     verify(chain).doFilter(captor.capture(), any(ServletResponse.class));
     HttpServletRequest actual = captor.getValue();
@@ -420,7 +420,7 @@ public class LoginFilterTest {
 
   @Test
   public void shouldReuseSessionAssociatedWithToken() throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         spy(
             new MockHttpServletRequest(
@@ -435,10 +435,10 @@ public class LoginFilterTest {
     when(sessionStore.getSession(eq("t13f"))).thenReturn(session1);
     request.getSession().setAttribute("principal", principal);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
     verify(chain).doFilter(captor.capture(), any(ServletResponse.class));
     HttpServletRequest actual = captor.getValue();
@@ -450,7 +450,7 @@ public class LoginFilterTest {
 
   public void shouldReplaceUpdateSessionStoreIfClientUsedSameSessionButDifferentToken()
       throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         spy(
             new MockHttpServletRequest(
@@ -466,10 +466,10 @@ public class LoginFilterTest {
     request.getSession().setAttribute("principal", principal);
     setFieldValue(filter, "tokenHandler", tokenHandler);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
 
     ArgumentCaptor<HttpSession> captor = ArgumentCaptor.forClass(HttpSession.class);
     verify(tokenHandler)
@@ -489,17 +489,17 @@ public class LoginFilterTest {
 
   @Test
   public void shouldRespond401IfPostRequestHasNoToken() throws IOException, ServletException {
-    //given
+    // given
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     PrintWriter writer = new PrintWriter(bos);
     when(response.getWriter()).thenReturn(writer);
     HttpServletRequest request =
         spy(new MockHttpServletRequest("http://localhost:8080/ws/ws", null, 0, "POST", null));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     assertEquals(
         new String(bos.toByteArray()),
@@ -508,7 +508,7 @@ public class LoginFilterTest {
 
   @Test
   public void shouldRespond401IfGetRequestHasNoToken() throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         spy(new MockHttpServletRequest("http://localhost:8080/ws/ws", null, 0, "GET", null));
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -517,10 +517,10 @@ public class LoginFilterTest {
 
     setFieldValue(filter, "tokenHandler", new NoUserInteractionTokenHandler(requestWrapper));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     assertEquals(
         new String(bos.toByteArray()),
@@ -531,16 +531,16 @@ public class LoginFilterTest {
   public void shouldRedirectToCookieErrorPageIfNotTokenInRequestButCookiesCheckRequested()
       throws IOException, ServletException {
 
-    //given
+    // given
     HttpServletRequest request =
         spy(
             new MockHttpServletRequest(
                 "http://localhost:8080/ws/ws?par=val&cookiePresent", null, 0, "GET", null));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).sendRedirect(eq("/site/cookiesDisabledErrorPageUrl"));
   }
 
@@ -557,10 +557,10 @@ public class LoginFilterTest {
     when(response.getWriter()).thenReturn(writer);
     setFieldValue(filter, "tokenHandler", new NoUserInteractionTokenHandler(requestWrapper));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
     assertEquals(new String(bos.toByteArray()), "{\"message\":\"Provided token t13f is invalid\"}");
     Assert.assertTrue(bos.size() > 0);
@@ -578,10 +578,10 @@ public class LoginFilterTest {
     when(response.getWriter()).thenReturn(writer);
     setFieldValue(filter, "tokenHandler", new NoUserInteractionTokenHandler(requestWrapper));
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
     assertEquals(new String(bos.toByteArray()), "{\"message\":\"Provided token t13f is invalid\"}");
     Assert.assertTrue(bos.size() > 0);
@@ -590,7 +590,7 @@ public class LoginFilterTest {
   @Test
   public void shouldRemoveCookiePresentParamFromValidGetRequestWithTokenAndRedirect()
       throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest(
             "http://localhost:8080/ws/ws?token=t13f&cookiePresent&cookiePresent=true",
@@ -602,24 +602,24 @@ public class LoginFilterTest {
     when(tokenExtractor.getToken(eq(request))).thenReturn("t13f");
     when(ssoServerClient.getSubject(eq("t13f"), nullable(String.class)))
         .thenReturn(createSubject("user@domain"));
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(response).sendRedirect(eq("http://localhost:8080/ws/ws?token=t13f"));
   }
 
   @Test
   public void shouldSkipRequestByFilter() throws IOException, ServletException, URISyntaxException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/ws/myworkspace", null, 0, "GET", null);
     when(requestFilter.shouldSkip(eq(request))).thenReturn(true);
 
-    //when
+    // when
     filter.doFilter(request, response, chain);
 
-    //then
+    // then
     verify(chain).doFilter(request, response);
     verifyNoMoreInteractions(sessionStore, tokenExtractor, clientUrlExtractor, ssoServerClient);
   }

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/SSOLogoutServletTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/SSOLogoutServletTest.java
@@ -41,38 +41,38 @@ public class SSOLogoutServletTest {
 
   @Test
   public void shouldFailIfTokenIsNotSet() throws ServletException, IOException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/sso/logout", null, 0, "POST", null);
-    //when
+    // when
     servlet.doPost(request, response);
-    //when                                    ,
+    // when                                    ,
     verify(response).sendError(eq(HttpServletResponse.SC_BAD_REQUEST), eq("Token is not set"));
   }
 
   @Test
   public void shouldRemoveToken() throws ServletException, IOException {
-    //given
+    // given
     MockHttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/sso/logout", null, 0, "POST", null);
     request.setParameter("authToken", "t-12312344");
-    //when
+    // when
     servlet.doPost(request, response);
-    //when
+    // when
     verify(sessionStore).removeSessionByToken("t-12312344");
     verifyZeroInteractions(response);
   }
 
   @Test
   public void shouldCleanupHttpSession() throws ServletException, IOException {
-    //given
+    // given
     MockHttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080/sso/logout", null, 0, "POST", null);
     request.setParameter("authToken", "t-12312344");
     when(sessionStore.removeSessionByToken(eq("t-12312344"))).thenReturn(session);
-    //when
+    // when
     servlet.doPost(request, response);
-    //when
+    // when
     verify(session).invalidate();
     verify(session).removeAttribute(eq("principal"));
   }

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/ConjunctionRequestFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/ConjunctionRequestFilterTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 public class ConjunctionRequestFilterTest {
   @Test(dataProvider = "skip")
   public void testShouldSkip(String requestUri, String method) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, method, null);
 
@@ -29,15 +29,15 @@ public class ConjunctionRequestFilterTest {
             new UriStartFromRequestFilter("/api/factory"),
             new NegationRequestFilter(
                 new UriStartFromAndMethodRequestFilter("POST", "/api/factory")));
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertTrue(result);
   }
 
   @Test(dataProvider = "notskip")
   public void testShouldNotSkip(String requestUri, String method) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, method, null);
 
@@ -46,9 +46,9 @@ public class ConjunctionRequestFilterTest {
             new UriStartFromRequestFilter("/api/factory"),
             new NegationRequestFilter(
                 new UriStartFromAndMethodRequestFilter("POST", "/api/factory")));
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertFalse(result);
   }
 

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/DisjunctionRequestFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/DisjunctionRequestFilterTest.java
@@ -25,26 +25,26 @@ public class DisjunctionRequestFilterTest {
   @Test(dataProvider = "skip")
   public void testShouldSkip(List<RequestFilter> requestFilters) throws Exception {
     RequestFilter[] filters = (RequestFilter[]) requestFilters.toArray();
-    //given
+    // given
     DisjunctionRequestFilter filter =
         new DisjunctionRequestFilter(
             filters[0], filters[1], Arrays.copyOfRange(filters, 2, filters.length));
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertTrue(result);
   }
 
   @Test(dataProvider = "notskip")
   public void testShouldNotSkip(List<RequestFilter> requestFilters) throws Exception {
     RequestFilter[] filters = (RequestFilter[]) requestFilters.toArray();
-    //given
+    // given
     DisjunctionRequestFilter filter =
         new DisjunctionRequestFilter(
             filters[0], filters[1], Arrays.copyOfRange(filters, 2, filters.length));
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertFalse(result);
   }
 

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/PathSegmentNumberFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/PathSegmentNumberFilterTest.java
@@ -20,27 +20,27 @@ public class PathSegmentNumberFilterTest {
 
   @Test(dataProvider = "notskip")
   public void testShouldSkip(String requestUri) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, "GET", null);
 
     PathSegmentNumberFilter filter = new PathSegmentNumberFilter(3);
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertTrue(result);
   }
 
   @Test(dataProvider = "skip")
   public void testShouldNotSkip(String requestUri) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, "GET", null);
 
     PathSegmentNumberFilter filter = new PathSegmentNumberFilter(2);
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertFalse(result);
   }
 
@@ -50,7 +50,7 @@ public class PathSegmentNumberFilterTest {
       {"/api/"},
       {"/api/organization/ojo2934kpoak"},
       {"/api/organization/ojo2934kpoak"},
-      //{"/api?user=sd"},
+      // {"/api?user=sd"},
       {"/api/user/sdf02304"},
       {"/api/account/factoryixak9964p942mikq"}
     };

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/PathSegmentValueTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/PathSegmentValueTest.java
@@ -20,27 +20,27 @@ public class PathSegmentValueTest {
 
   @Test(dataProvider = "skip")
   public void testShouldSkip(String requestUri) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, "GET", null);
 
     PathSegmentValueFilter filter = new PathSegmentValueFilter(4, "find");
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertTrue(result);
   }
 
   @Test(dataProvider = "notskip")
   public void testShouldNotSkip(String requestUri) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, "GET", null);
 
     PathSegmentValueFilter filter = new PathSegmentValueFilter(4, "organization");
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertFalse(result);
   }
 

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/RequestMethodFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/RequestMethodFilterTest.java
@@ -21,27 +21,27 @@ import org.testng.annotations.Test;
 public class RequestMethodFilterTest {
   @Test(dataProvider = "skip")
   public void testShouldSkip(String requestUri, String method) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, method, null);
 
     RequestMethodFilter filter = new RequestMethodFilter("GET");
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertTrue(result);
   }
 
   @Test(dataProvider = "notskip")
   public void testShouldNotSkip(String requestUri, String method) throws Exception {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + requestUri, null, 0, method, null);
 
     RequestMethodFilter filter = new RequestMethodFilter("POST");
-    //when
+    // when
     boolean result = filter.shouldSkip(request);
-    //then
+    // then
     Assert.assertFalse(result);
   }
 

--- a/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/UrlStartFromAndMethodRequestFilterTest.java
+++ b/wsmaster/codenvy-hosted-sso-client/src/test/java/com/codenvy/auth/sso/client/filter/UrlStartFromAndMethodRequestFilterTest.java
@@ -25,12 +25,12 @@ public class UrlStartFromAndMethodRequestFilterTest {
 
   @Test(dataProvider = "excludedPathProvider")
   public void shouldSkipRequestWithExcludedPath(String path) throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + path, null, 0, "GET", null);
 
     RegexpRequestFilter filter = new RegexpRequestFilter(filterPattern);
-    //when -then
+    // when -then
     Assert.assertTrue(filter.shouldSkip(request));
   }
 
@@ -55,11 +55,11 @@ public class UrlStartFromAndMethodRequestFilterTest {
   @Test(dataProvider = "notExcludedPathProvider")
   public void shouldNotSkipRequestWithNotExcludedPath(String path)
       throws IOException, ServletException {
-    //given
+    // given
     HttpServletRequest request =
         new MockHttpServletRequest("http://localhost:8080" + path, null, 0, "GET", null);
     RegexpRequestFilter filter = new RegexpRequestFilter(filterPattern);
-    //when -then
+    // when -then
     Assert.assertFalse(filter.shouldSkip(request));
   }
 }

--- a/wsmaster/codenvy-hosted-sso-oauth/src/main/java/com/codenvy/auth/sso/oauth/SsoOAuthAuthenticationService.java
+++ b/wsmaster/codenvy-hosted-sso-oauth/src/main/java/com/codenvy/auth/sso/oauth/SsoOAuthAuthenticationService.java
@@ -67,7 +67,7 @@ public class SsoOAuthAuthenticationService extends OAuthAuthenticationService {
       throw new OAuthAuthenticationException(e.getLocalizedMessage(), e);
     }
     final String mode = getParameter(params, "mode");
-    //federated_login left for backward compatibility
+    // federated_login left for backward compatibility
     if ("sso".equals(mode) || "federated_login".equals(mode)) {
       Map<String, String> payload = new HashMap<>();
       payload.put("provider", providerName);

--- a/wsmaster/codenvy-hosted-sso-oauth/src/test/java/com/codenvy/auth/sso/oauth/CreateUserWithCapturedProfileInfoTest.java
+++ b/wsmaster/codenvy-hosted-sso-oauth/src/test/java/com/codenvy/auth/sso/oauth/CreateUserWithCapturedProfileInfoTest.java
@@ -56,7 +56,7 @@ public class CreateUserWithCapturedProfileInfoTest {
     // oAuthLoginServlet = new OAuthLoginServlet();
     when(servletConfig.getServletContext()).thenReturn(servletContext);
 
-    //oAuthLoginServlet.init(servletConfig);
+    // oAuthLoginServlet.init(servletConfig);
   }
 
   @Test

--- a/wsmaster/codenvy-hosted-sso-server-organization/src/main/java/com/codenvy/auth/sso/server/OrgServiceUserCreator.java
+++ b/wsmaster/codenvy-hosted-sso-server-organization/src/main/java/com/codenvy/auth/sso/server/OrgServiceUserCreator.java
@@ -56,7 +56,7 @@ public class OrgServiceUserCreator implements UserCreator {
   @Override
   public User createUser(String email, String userName, String firstName, String lastName)
       throws IOException {
-    //TODO check this method should only call if user is not exists.
+    // TODO check this method should only call if user is not exists.
     try {
       return userManager.getByEmail(email);
     } catch (NotFoundException e) {

--- a/wsmaster/codenvy-hosted-sso-server/src/main/java/com/codenvy/auth/sso/server/ticket/AccessTicketInvalidator.java
+++ b/wsmaster/codenvy-hosted-sso-server/src/main/java/com/codenvy/auth/sso/server/ticket/AccessTicketInvalidator.java
@@ -56,7 +56,7 @@ public class AccessTicketInvalidator extends TimerTask {
 
   @PostConstruct
   public void startTimer() {
-    //wait 1 second and run each minute
+    // wait 1 second and run each minute
     timer.schedule(this, 1000, 60000);
   }
 

--- a/wsmaster/codenvy-hosted-sso-server/src/test/java/com/codenvy/auth/sso/server/SsoServiceTest.java
+++ b/wsmaster/codenvy-hosted-sso-server/src/test/java/com/codenvy/auth/sso/server/SsoServiceTest.java
@@ -73,7 +73,7 @@ public class SsoServiceTest {
 
   @Test
   public void shouldValidUserIfTokenIsValid() throws NotFoundException, ServerException {
-    //given
+    // given
     when(userManager.getById(eq(user.getId()))).thenReturn(user);
     AccessTicket ticket = new AccessTicket("t1", user.getId(), "default");
     SubjectDto subjectDto =
@@ -84,7 +84,7 @@ public class SsoServiceTest {
 
     when(ticketManager.getAccessTicket(eq("t1"))).thenReturn(ticket);
 
-    //when
+    // when
     final Response response =
         given()
             .pathParam("token", "t1")
@@ -94,16 +94,16 @@ public class SsoServiceTest {
             .statusCode(200)
             .when()
             .get("internal/sso/server/{token}");
-    //then
+    // then
     assertEquals(unwrapDto(response, SubjectDto.class), subjectDto);
     assertTrue(ticket.getRegisteredClients().contains("http://dev.box.com/api"));
   }
 
   @Test
   public void shouldUnregisterClientByToken() {
-    //given
+    // given
 
-    //when
+    // when
     given()
         .pathParam("token", "t1")
         .then()
@@ -111,17 +111,17 @@ public class SsoServiceTest {
         .statusCode(204)
         .when()
         .delete("internal/sso/server/{token}");
-    //then
+    // then
     verify(ticketManager).removeTicket("t1");
   }
 
   @Test
   public void shouldUnregisterClientByTokenAndUrl() {
-    //given
+    // given
     AccessTicket ticket = new AccessTicket("t1", "id-34", "default");
     ticket.registerClientUrl("http://dev.box.com/api");
     when(ticketManager.getAccessTicket(eq("t1"))).thenReturn(ticket);
-    //when
+    // when
     given()
         .pathParam("token", "t1")
         .queryParam("clienturl", "http://dev.box.com/api")
@@ -130,7 +130,7 @@ public class SsoServiceTest {
         .statusCode(204)
         .when()
         .delete("internal/sso/server/{token}");
-    //then
+    // then
     verify(ticketManager).getAccessTicket(eq("t1"));
     verifyNoMoreInteractions(ticketManager);
     assertEquals(ticket.getRegisteredClients().size(), 0);

--- a/wsmaster/codenvy-hosted-system/src/test/java/com/codenvy/service/system/SystemRamLimitMessageSenderTest.java
+++ b/wsmaster/codenvy-hosted-system/src/test/java/com/codenvy/service/system/SystemRamLimitMessageSenderTest.java
@@ -50,28 +50,28 @@ public class SystemRamLimitMessageSenderTest {
   @Test
   public void shouldSetSystemRamLimitExceedMessageSentFlagToFalseWhenRamLimitNotExceedMessageSent()
       throws Exception {
-    //given
+    // given
     systemRamLimitExceedMessageSent.set(systemRamLimitMessageSender, true);
     when(systemRamInfo.isSystemRamLimitExceeded()).thenReturn(false);
 
-    //when
+    // when
     systemRamLimitMessageSender.checkRamLimitAndSendMessageIfNeeded();
 
-    //then
+    // then
     assertFalse((boolean) systemRamLimitExceedMessageSent.get(systemRamLimitMessageSender));
   }
 
   @Test
   public void shouldSetSystemRamLimitExceedMessageSentFlagToTrueWhenRamLimitExceedMessageSent()
       throws Exception {
-    //given
+    // given
     systemRamLimitExceedMessageSent.set(systemRamLimitMessageSender, false);
     when(systemRamInfo.isSystemRamLimitExceeded()).thenReturn(true);
 
-    //when
+    // when
     systemRamLimitMessageSender.checkRamLimitAndSendMessageIfNeeded();
 
-    //then
+    // then
     assertTrue((boolean) systemRamLimitExceedMessageSent.get(systemRamLimitMessageSender));
   }
 }

--- a/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/LdapSynchronizer.java
+++ b/wsmaster/codenvy-ldap/src/main/java/com/codenvy/ldap/sync/LdapSynchronizer.java
@@ -194,7 +194,8 @@ public class LdapSynchronizer {
 
         syncFetched(entry, linkingIds, syncResult);
 
-        // Each EACH_ENTRIES_COUNT_CHECK_INTERRUPTION synchronized entries check whether thread wasn't interrupted
+        // Each EACH_ENTRIES_COUNT_CHECK_INTERRUPTION synchronized entries check whether thread
+        // wasn't interrupted
         // if it was - stop the synchronization, all the users who were not synchronized
         // will be synchronized with the next synchronization
         if (syncResult.fetched % EACH_ENTRIES_COUNT_CHECK_INTERRUPTION == 0) {


### PR DESCRIPTION
### What does this PR do?
Using formatter 2.0, we're now using v1.4 rules
https://github.com/google/google-java-format/releases/tag/google-java-format-1.4

It includes 
- 1.4 formatting level of google-format https://github.com/google/google-java-format/releases/tag/google-java-format-1.4
- display of invalid files (I've provided a pull request coveo/fmt-maven-plugin#17)
- add threadSafe flag (Provided as well as part of pull request) so there is no warning when you run the build with parallel flags.

### What issues does this PR fix or reference?
https://github.com/eclipse/che-parent/pull/33


#### Release Notes
Using new formatter rules (v1.4)
https://github.com/google/google-java-format

Plugins may require to be updated to be aligned with 1.4 rules
https://github.com/google/google-java-format/#using-the-formatter

#### Docs PR
N/A
