### PR TITLE
Avoid scan of classes during runtime in order to find dynamodules

### DIFF
--- a/assembly/assembly-dashboard-war/pom.xml
+++ b/assembly/assembly-dashboard-war/pom.xml
@@ -110,6 +110,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/assembly/assembly-dashboard-war/src/main/webapp/META-INF/context.xml
+++ b/assembly/assembly-dashboard-war/src/main/webapp/META-INF/context.xml
@@ -10,12 +10,11 @@
       Red Hat, Inc. - initial API and implementation
 
 -->
-<Context path="/" crossContext="false" sessionCookieName="IDESESSIONID">
-    <Valve className="org.apache.catalina.valves.rewrite.RewriteValve"/>
-    <JarScanner>
-        <JarScanFilter
-          defaultPluggabilityScan="false"
-          defaultTldScan="false"
-          pluggabilityScan=""></JarScanFilter>
-    </JarScanner>
+<Context>
+  <JarScanner>
+    <JarScanFilter
+      defaultPluggabilityScan="false"
+      defaultTldScan="false"
+      pluggabilityScan=""></JarScanFilter>
+  </JarScanner>
 </Context>

--- a/assembly/assembly-dashboard-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/assembly-dashboard-war/src/main/webapp/WEB-INF/web.xml
@@ -19,6 +19,8 @@
          metadata-complete="true">
     <display-name>User dashboard</display-name>
 
+    <absolute-ordering></absolute-ordering>
+
     <listener>
         <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>

--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -109,6 +109,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/assembly/assembly-ide-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/assembly-ide-war/src/main/webapp/WEB-INF/web.xml
@@ -19,6 +19,8 @@
          metadata-complete="true">
     <display-name>IDE</display-name>
 
+    <absolute-ordering></absolute-ordering>
+
     <context-param>
         <param-name>org.everrest.asynchronous.pool.size</param-name>
         <param-value>100</param-value>

--- a/assembly/assembly-website-war/pom.xml
+++ b/assembly/assembly-website-war/pom.xml
@@ -94,6 +94,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>

--- a/assembly/assembly-website-war/src/main/webapp/META-INF/context.xml
+++ b/assembly/assembly-website-war/src/main/webapp/META-INF/context.xml
@@ -10,12 +10,11 @@
       Red Hat, Inc. - initial API and implementation
 
 -->
-<Context path="/" crossContext="false" sessionCookieName="IDESESSIONID">
-    <Valve className="org.apache.catalina.valves.rewrite.RewriteValve"/>
-    <JarScanner>
-        <JarScanFilter
-          defaultPluggabilityScan="false"
-          defaultTldScan="false"
-          pluggabilityScan=""></JarScanFilter>
-    </JarScanner>
+<Context>
+  <JarScanner>
+    <JarScanFilter
+      defaultPluggabilityScan="false"
+      defaultTldScan="false"
+      pluggabilityScan=""></JarScanFilter>
+  </JarScanner>
 </Context>

--- a/assembly/assembly-website-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/assembly-website-war/src/main/webapp/WEB-INF/web.xml
@@ -19,6 +19,8 @@
          metadata-complete="true">
     <display-name>OnPremises-Ide site war</display-name>
 
+    <absolute-ordering></absolute-ordering>
+
     <listener>
         <listener-class>org.eclipse.che.inject.CheBootstrap</listener-class>
     </listener>

--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -70,6 +70,26 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                    <skipResources>
+                        <skipResource>.*org/eclipse/che/wsagent/server/SwaggerServletModule.class</skipResource>
+                        <skipResource>.*org/eclipse/che/wsagent/server/CheWsAgentModule.class</skipResource>
+                        <skipResource>.*org/eclipse/che/wsagent/server/CheWsAgentServletModule.class</skipResource>
+                    </skipResources>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -436,6 +436,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>

--- a/assembly/assembly-wsmaster-war/src/main/webapp/META-INF/context.xml
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/META-INF/context.xml
@@ -12,4 +12,11 @@
 -->
 <Context path="/api" docBase="api" >
     <ResourceLink global="jdbc/codenvy" name="jdbc/codenvy" type="javax.sql.DataSource"/>
+
+    <JarScanner>
+        <JarScanFilter
+          defaultPluggabilityScan="false"
+          defaultTldScan="false"
+          pluggabilityScan=""></JarScanFilter>
+    </JarScanner>
 </Context>

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/web.xml
@@ -19,6 +19,8 @@
          metadata-complete="true">
     <display-name>Platform Service Api</display-name>
 
+    <absolute-ordering></absolute-ordering>
+
     <context-param>
         <param-name>org.everrest.asynchronous</param-name>
         <param-value>false</param-value>

--- a/wsagent/codenvy-wsagent-core/src/main/webapp/WEB-INF/web.xml
+++ b/wsagent/codenvy-wsagent-core/src/main/webapp/WEB-INF/web.xml
@@ -17,6 +17,9 @@
          version="3.0"
          metadata-complete="true">
     <display-name>Codenvy Machine API</display-name>
+
+    <absolute-ordering></absolute-ordering>
+
     <context-param>
         <param-name>org.everrest.websocket.context</param-name>
         <param-value>/{var1}/api</param-value>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Pull Request Policy: https://github.com/codenvy/planning/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Use dynamodule generator plugin, to get list of dynamodules during WAR build, instead of scanning for them at runtime (Accordingly to respective changes in Che).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6283

#### Changelog
workspace master and agent : avoid scan of classes at runtime in order to find DynaModules

#### Release Notes
N / A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N /A 