### PR TITLE
Remove separation of selenium tests on stable/unstable/failed

### DIFF
--- a/selenium/codenvy-selenium-test/src/test/resources/suites/CodenvyOnpremSuite.xml
+++ b/selenium/codenvy-selenium-test/src/test/resources/suites/CodenvyOnpremSuite.xml
@@ -20,165 +20,39 @@
         <classes>
             <class name="com.codenvy.selenium.assistant.CheckFindActionInCodenvyFeatureTest"/>
             <class name="org.eclipse.che.selenium.assistant.KeyBindingsTest"/>
-            <class name="org.eclipse.che.selenium.assistant.OrganizeImportsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="organizeImportsTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.assistant.OrganizeImportsTest"/>
             <class name="org.eclipse.che.selenium.languageserver.CheckMainFeatureForCSharpLanguageTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.CreateAndDeleteProjectsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="createAndDeleteProjectTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.DeleteRunningWorkspaceTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="deleteRunningWorkspaceTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.DeleteStoppingWorkspaceTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="deleteStoppingWorkspaceTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.ImportMavenProjectFromGitHubTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkAbilityImportMavenProjectTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.ImportProjectFromZipTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="importProjectFromZipTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.dashboard.RenameWorkspaceTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="renameNameWorkspaceTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.dashboard.CreateAndDeleteProjectsTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.DeleteRunningWorkspaceTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.DeleteStoppingWorkspaceTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.ImportMavenProjectFromGitHubTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.ImportProjectFromZipTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.RenameWorkspaceTest"/>
             <class name="com.codenvy.selenium.dashboard.CodenvyWorkspaceDetailsTest"/>
             <class name="org.eclipse.che.selenium.debugger.ChangeVariableWithEvaluatingTest"/>
             <class name="org.eclipse.che.selenium.debugger.CheckBreakPointStateTest"/>
-            <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4524 -->
-                    <exclude name="shouldDebugCppProject"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.debugger.DebugExternalClassTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4636 -->
-                    <exclude name="shouldDebugJreClass"/>
-
-                    <!-- unstable -->
-                    <exclude name="shouldDebugMavenArtifactClassWithSources"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.debugger.InnerClassAndLambdaDebuggingTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4211 -->
-                    <exclude name="shouldDebugInnerClass"/>
-
-                    <!-- https://github.com/eclipse/che/issues/4211 -->
-                    <exclude name="shouldDebugMethodLocalInnerClass"/>
-
-                    <!-- https://github.com/eclipse/che/issues/4211 -->
-                    <exclude name="shouldDebugStaticInnerClass"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.debugger.MultimoduleProjectDebuggingTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/5116 -->
-                    <exclude name="shouldDebugInstanceMethod"/>
-
-                    <!-- https://github.com/eclipse/che/issues/5116 -->
-                    <exclude name="shouldDebugStaticDefaultMethod"/>
-
-                    <!-- https://github.com/eclipse/che/issues/4268 -->
-                    <exclude name="shouldDebugStaticMethod"/>
-
-                    <!-- https://github.com/eclipse/che/issues/4286 -->
-                    <exclude name="shouldGoIntoConstructor"/>
-
-                    <!-- https://github.com/eclipse/che/issues/5116 -->
-                    <exclude name="shouldStopInsideConstructor"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.debugger.NodeJsDebugTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4720 -->
-                    <exclude name="debugNodeJsTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest"/>
+            <class name="org.eclipse.che.selenium.debugger.DebugExternalClassTest"/>
+            <class name="org.eclipse.che.selenium.debugger.InnerClassAndLambdaDebuggingTest"/>
+            <class name="org.eclipse.che.selenium.debugger.MultimoduleProjectDebuggingTest"/>
+            <class name="org.eclipse.che.selenium.debugger.NodeJsDebugTest"/>
             <class name="org.eclipse.che.selenium.debugger.PhpProjectDebuggingTest"/>
-            <class name="org.eclipse.che.selenium.debugger.StepIntoStepOverStepReturnWithChangeVariableTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/4292 -->
-                    <exclude name="shouldOpenDebuggingFile"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteFeaturesInEditorTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="createJavaSpringProjectAndTestEditor"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteJSFilesTest">
-                <methods>
-                    <!-- https://jira.codenvycorp.com/browse/CHE-905 -->
-                    <exclude name="checkAutocompleteJSFilesTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="shouldReflectChangesInJavaDoc"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteWithInheritTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="updateDependencyWithInheritTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.CheckAutocompleteFeaturesInTheTestFolderTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkAutocompleteFeaturesInTheTestFolderTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.debugger.StepIntoStepOverStepReturnWithChangeVariableTest"/>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteFeaturesInEditorTest"/>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteJSFilesTest"/>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteProposalJavaDocTest"/>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.AutocompleteWithInheritTest"/>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.CheckAutocompleteFeaturesInTheTestFolderTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.EditorMemberActiveLineForOpenedTabTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.EditorValidationTest"/>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.FormatterTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="formatterTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.FormatterTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.InheritClassTest"/>
-            <class name="org.eclipse.che.selenium.editor.autocomplete.JavaDocPopupTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="javaDocPopupTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.editor.autocomplete.JavaDocPopupTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.OpenDeclarationTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.QuickFixAndCodeAssistantFeaturesTest"/>
             <class name="org.eclipse.che.selenium.editor.autocomplete.ShowHintsCommandTest"/>
             <class name="org.eclipse.che.selenium.editor.CheckReplaceFeatureInEditorTest"/>
-            <class name="org.eclipse.che.selenium.editor.CheckRestoringSplitEditorTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkRestoringStateSplittedEditor"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.editor.CheckRestoringSplitEditorTest"/>
             <class name="org.eclipse.che.selenium.editor.CheckSearchFeatureInEditorTest"/>
             <class name="org.eclipse.che.selenium.editor.CheckWorkingWithTabByUsingTabListTest"/>
             <class name="org.eclipse.che.selenium.editor.CheckWorkingWithTabsByUsingContextMenuTest"/>
@@ -191,61 +65,20 @@
             <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithSpecificBranch"/>
             <class name="org.eclipse.che.selenium.factory.CheckFactoryWithPerUserCreatePolicyTest"/>
             <class name="org.eclipse.che.selenium.factory.CheckFactoryWithPerClickCreatePolicyTest"/>
-            <class name="org.eclipse.che.selenium.factory.CheckFactoryWithMultiModuleTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkFactoryProcessing"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.factory.CheckFactoryWithMultiModuleTest"/>
             <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSincePolicyTest"/>
             <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSvnCVSTest"/>
             <class name="org.eclipse.che.selenium.factory.CheckFactoryWithUntilPolicyTest"/>
-            <class name="org.eclipse.che.selenium.factory.CheckOpenFileFeatureTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkOpenFileFeatureTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.factory.CheckRunCommandFeatureTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkRunCommandFeatureTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.factory.CheckOpenFileFeatureTest"/>
+            <class name="org.eclipse.che.selenium.factory.CheckRunCommandFeatureTest"/>
             <class name="org.eclipse.che.selenium.factory.CheckWelcomePanelOnCodenvyTest"/>
-            <class name="org.eclipse.che.selenium.factory.CreateNamedFactoryFromDashBoard">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="createFactoryFromDashBoard"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.factory.CreateNamedFactoryFromDashBoard"/>
             <class name="org.eclipse.che.selenium.factory.CreateFactoryFromUiWithKeepDirTest"/>
-            <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithRootFolder">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="factoryWithDirectUrlWithKeepDirectory"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithRootFolder"/>
             <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSparseCheckoutTest"/>
             <class name="org.eclipse.che.selenium.filewatcher.EditFilesWithTabsTest"/>
-            <class name="org.eclipse.che.selenium.filewatcher.RefactoringFeatureTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkRefactorFilesFromIde"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.filewatcher.RemoveFilesWithActiveTabs">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkDeletionWithMultiOpenedTabFromIde"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkDeletionWithSingleOpenedTabFromIde"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRemovingWithoutIde"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.filewatcher.RefactoringFeatureTest"/>
+            <class name="org.eclipse.che.selenium.filewatcher.RemoveFilesWithActiveTabs"/>
             <class name="org.eclipse.che.selenium.filewatcher.UpdateFilesWithoutIDE"/>
             <class name="org.eclipse.che.selenium.filewatcher.CheckDeletingProjectByApiTest"/>
             <class name="org.eclipse.che.selenium.filewatcher.CheckFileWatcherExcludeFeatureTest"/>
@@ -262,133 +95,54 @@
             <class name="org.eclipse.che.selenium.git.SetGitCommitterTest"/>
             <class name="org.eclipse.che.selenium.gwt.CheckSimpleGwtAppTest"/>
             <class name="org.eclipse.che.selenium.intelligencecommand.MacrosCommandsEditorTest"/>
-            <class name="org.eclipse.che.selenium.intelligencecommand.AutocompleteCommandsEditorTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkAutocompleteAfterSave"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.intelligencecommand.AutocompleteCommandsEditorTest"/>
             <class name="org.eclipse.che.selenium.intelligencecommand.CheckBasicFunctionalityInCommandsExplorerTest"/>
-            <class name="org.eclipse.che.selenium.intelligencecommand.CheckIntelligenceCommandFromToolbarTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="launchClonedWepAppTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.intelligencecommand.CheckIntelligenceCommandFromToolbarTest"/>
             <class name="org.eclipse.che.selenium.intelligencecommand.CommandsEditorTest"/>
-            <class name="org.eclipse.che.selenium.intelligencecommand.CommandsPaletteTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="commandPaletteTest"/>
-
-                    <!-- unstable -->
-                    <exclude name="newCommandTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.intelligencecommand.CommandsPaletteTest"/>
             <class name="org.eclipse.che.selenium.intelligencecommand.PreviewUrlIntoCommandsEditorTest"/>
             <class name="org.eclipse.che.selenium.mavenplugin.CheckGeneratingMavenArchetypeTest"/>
-            <class name="org.eclipse.che.selenium.mavenplugin.CheckMavenPluginTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkAbilityClassAfterIncludingNodules"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.mavenplugin.CheckMavenPluginTest"/>
             <class name="org.eclipse.che.selenium.mavenplugin.GenerateEffectivePomTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.CheckCreatingProjectInEmptyWsTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.CheckMacrosFeatureTest"/>
-            <class name="org.eclipse.che.selenium.miscellaneous.CheckRestoringWorkspaceAfterStoppingWsAgentProcess">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkDialogAfterKillingProcess"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.miscellaneous.CheckRestoringWorkspaceAfterStoppingWsAgentProcess"/>
             <class name="org.eclipse.che.selenium.miscellaneous.ConvertToProjectFromConfigurationTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.ConvertToProjectWithPomFileTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.DialogAboutTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.FileStructureBaseOperationTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.FileStructureByKeyboardTest"/>
-            <class name="org.eclipse.che.selenium.miscellaneous.FileStructureCodeEditorTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkFileStructureCodeEditor"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.miscellaneous.FileStructureCodeEditorTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.FileStructureNodesTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.FindTextFeatureTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.FindUsagesBaseOperationTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.ImplementationBaseOperationsTest"/>
-            <class name="com.codenvy.selenium.miscellaneous.LoginWithMicrosoftOAuthTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="loginWithMicrosoftOAuchTest"/>
-                </methods>
-            </class>
+            <class name="com.codenvy.selenium.miscellaneous.LoginWithMicrosoftOAuthTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.NavigateToFileTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.ResolveDependencyAfterRecreateProjectTest"/>
             <class name="org.eclipse.che.selenium.miscellaneous.TerminalTypingTest"/>
-            <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithSplitPanelTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkSwitchingTabsAndPanels"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkTerminalAndBuild"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithTerminalTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="shouldEditFileIntoMCEdit"/>
-
-                    <!-- unstable -->
-                    <exclude name="shouldLaunchCommandWithBigOutput"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithSplitPanelTest"/>
+            <class name="org.eclipse.che.selenium.miscellaneous.WorkingWithTerminalTest"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0087Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0091Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0093Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0097Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0114Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0115Test"/>
-            <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0119Test">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="test0119"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0119Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0120Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0121Test"/>
             <class name="org.eclipse.che.selenium.opendeclaration.Eclipse0122Test"/>
             <class name="org.eclipse.che.selenium.plainjava.ConfigureClasspathBaseTest"/>
-            <class name="org.eclipse.che.selenium.plainjava.ConfigureSomeSourceFoldersTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkConfigureClasspathPlainJavaProject"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.plainjava.ConfigureSomeSourceFoldersTest"/>
             <class name="org.eclipse.che.selenium.plainjava.PlainJavaProjectConfigureClasspathTest"/>
             <class name="org.eclipse.che.selenium.plainjava.RunPlainJavaProjectTest"/>
             <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginJunit4Test"/>
             <class name="org.eclipse.che.selenium.testrunner.JavaTestPluginTestNgTest"/>
-            <class name="org.eclipse.che.selenium.preferences.CheckErrorsWarningsTabTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="errorsWarningTest"/>
-                </methods>
-            </class>
-            <class name="com.codenvy.selenium.preferences.EditorSettingsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="editorSettingsTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.preferences.CheckErrorsWarningsTabTest"/>
+            <class name="com.codenvy.selenium.preferences.EditorSettingsTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CheckAutoSaveForFileWhichAlreadyExistTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.CheckCollapseAllNodesProjectTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkCollapseAllBtnProjectTree"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.projectexplorer.CheckCollapseAllNodesProjectTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CheckCopyCutFeaturesForFilesTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CheckErrorMessageWhenCreationDuplicateFolderOrFileTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CheckHiddenFolderAndFileCreatedFromCommandTest"/>
@@ -407,374 +161,75 @@
             <class name="org.eclipse.che.selenium.projectexplorer.CreateNewPackageFromContextMenuTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateNewPackagesWithHelpCreationJavaClassTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreatePackagesAndFilesWithHelpIconCreateTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectInSelectedFolderTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="createProjectInSelectedFolder"/>
-                </methods>
-            </class>
-
+            <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectInSelectedFolderTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectsForArtikPluginTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="openProjectWizard"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.projectexplorer.CreateProjectTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.DeleteFilesFromContextMenuTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.DeleteFilesPackagesAndProjectWithHelpDeleteIconTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="deleteFileTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.projectexplorer.DeleteFilesPackagesAndProjectWithHelpDeleteIconTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.DeleteFilesTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.DeletePackageFromContextMenuTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.DeletePackageTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.DeletePackageWithOpenedFilesTabTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.DeleteProjectsTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.dependencies.TransitiveDependencyTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.dependencies.UpdateListOfLibraryTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkUpdateLibraryAfterChangingDependencyTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.projectexplorer.dependencies.UpdateListOfLibraryTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.FileNotExistIntoEditorAfterDeleteTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.FileOpenedAfterCreationTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.JustCreatedFileNotExistIntoEditorAfterDeleteTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="deleteFileTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.projectexplorer.JustCreatedFileNotExistIntoEditorAfterDeleteTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.NavigationByKeyboardTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.OpenFileWithHelpContextMenuTest"/>
-            <class name="org.eclipse.che.selenium.projectexplorer.PreviewHtmlFileTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkPreviewHtmlFile"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.projectexplorer.PreviewHtmlFileTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.RenamedAlreadyCreatedNotJavaFileTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.RenameJustCreatedNotJavaFileTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.RenameProjectTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.ShowFileReferenceTest"/>
             <class name="org.eclipse.che.selenium.projectexplorer.CheckDisplayingArtifactIdTest"/>
             <class name="org.eclipse.che.selenium.refactor.fields.FailNotPrivateFieldTest"/>
-            <class name="org.eclipse.che.selenium.refactor.fields.FailPrivateFieldTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="testFail0"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail4"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail6"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail7"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.refactor.fields.RenameNotPrivateFieldTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkBugFiveEightTwoOne26"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameAnnotation24"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameAnnotation25"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameDelegate28"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameEnumField31"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameGenerics32"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameGenerics33"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameGenerics36"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField0"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField1"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField10"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField2"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField3"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField4"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField5"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField6"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField7"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField8"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkRenameNotPrivateField9"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.refactor.fields.FailPrivateFieldTest"/>
+            <class name="org.eclipse.che.selenium.refactor.fields.RenameNotPrivateFieldTest"/>
             <class name="org.eclipse.che.selenium.refactor.fields.RenamePrivateFieldSmokeTest"/>
             <class name="org.eclipse.che.selenium.refactor.fields.RenamePrivateFieldTest"/>
-            <class name="org.eclipse.che.selenium.refactor.methods.RenameMethodInInterfaceTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="test0"/>
-
-                    <!-- unstable -->
-                    <exclude name="test12"/>
-
-                    <!-- unstable -->
-                    <exclude name="test20"/>
-
-                    <!-- unstable -->
-                    <exclude name="test31"/>
-
-                    <!-- unstable -->
-                    <exclude name="test44"/>
-
-                    <!-- unstable -->
-                    <exclude name="testAnnotation1"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail12"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail33"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail5"/>
-
-                    <!-- unstable -->
-                    <exclude name="testGenerics01"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.refactor.methods.RenamePrivateMethodTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="testAnon0"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail5"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.refactor.methods.RenameMethodInInterfaceTest"/>
+            <class name="org.eclipse.che.selenium.refactor.methods.RenamePrivateMethodTest"/>
             <class name="org.eclipse.che.selenium.refactor.methods.RenameStaticMethodsTest"/>
             <class name="org.eclipse.che.selenium.refactor.methods.RenameVirtualMethodsTest"/>
             <class name="org.eclipse.che.selenium.refactor.move.CodeAssistAfterMoveItemTest"/>
             <class name="org.eclipse.che.selenium.refactor.move.FailMoveItemTest"/>
-            <class name="org.eclipse.che.selenium.refactor.move.MoveItemsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkMoveItem5"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.refactor.move.MoveItemsTest"/>
             <class name="org.eclipse.che.selenium.refactor.move.MoveJavaClassToSubpackageTest"/>
-            <class name="org.eclipse.che.selenium.refactor.move.MoveJavaFileInNewSourceFolderTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkMoveJavaClassInNewSourceFolder"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageSpringTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkRenamePackageSpringApp"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageTest">
-                <methods>
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTest0"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTest1"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkTest2"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTest3"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTest4"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTest7"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTest8"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTestHierarchical9_1"/>
-
-                    <!-- https://github.com/eclipse/che/issues/1960 -->
-                    <exclude name="checkTestPackageRenameWithResource12"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.refactor.move.MoveJavaFileInNewSourceFolderTest"/>
+            <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageSpringTest"/>
+            <class name="org.eclipse.che.selenium.refactor.packages.RenamePackageTest"/>
             <class name="org.eclipse.che.selenium.refactor.parameters.FailParametersTest"/>
             <class name="org.eclipse.che.selenium.refactor.parameters.RenameParametersTest"/>
             <class name="org.eclipse.che.selenium.refactor.preview.CheckTreeInRefactorPanelTest"/>
             <class name="org.eclipse.che.selenium.refactor.preview.PreviewRefactoringTest"/>
-            <class name="org.eclipse.che.selenium.refactor.types.GenericsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="testGenerics2"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.refactor.types.GenericsTest"/>
             <class name="org.eclipse.che.selenium.refactor.types.IllegalTypeNameTest"/>
             <class name="org.eclipse.che.selenium.refactor.types.RenameTypeTest"/>
-            <class name="org.eclipse.che.selenium.refactor.types.TestAnnotationsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="testAnnotation1"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.refactor.types.TestEnumerationsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="testEnum1"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.refactor.types.TestFailTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="testFail26"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail35"/>
-
-                    <!-- unstable -->
-                    <exclude name="testFail80"/>
-                </methods>
-            </class>
-            <class name="com.codenvy.selenium.ssh.LoginBySshKeyTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="loginByShhKeyTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.refactor.types.TestAnnotationsTest"/>
+            <class name="org.eclipse.che.selenium.refactor.types.TestEnumerationsTest"/>
+            <class name="org.eclipse.che.selenium.refactor.types.TestFailTest"/>
+            <class name="com.codenvy.selenium.ssh.LoginBySshKeyTest"/>
             <class name="org.eclipse.che.selenium.subversion.CommitTest"/>
             <class name="org.eclipse.che.selenium.subversion.CopyTest"/>
             <class name="org.eclipse.che.selenium.subversion.DiffViewTest"/>
-            <class name="org.eclipse.che.selenium.subversion.LockFileTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="lockFileTest"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.subversion.LockFileTest"/>
             <class name="org.eclipse.che.selenium.subversion.PropertiesTest"/>
             <class name="org.eclipse.che.selenium.subversion.SvnUpdateTest"/>
             <class name="org.eclipse.che.selenium.subversion.UpdateToRevisionTest"/>
-            <class name="org.eclipse.che.selenium.swagger.SwaggerTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkNameProjectTest"/>
-                </methods>
-            </class>
-            <class name="com.codenvy.selenium.vsts.CheckWorkWithVSTSProviderTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="cloneProjectFromVSTS"/>
-
-                    <!-- unstable -->
-                    <exclude name="commitAndPushVSTS"/>
-
-                    <!-- unstable -->
-                    <exclude name="resetAndPullVSTS"/>
-                </methods>
-            </class>
-            <class name="com.codenvy.selenium.workspaces.CheckStoppingWsByTimeoutTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkStoppingWsByTimeoutTest"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkStoppingWsWithApi"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.CheckStopStartWsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkStopStartWorkspaceTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.CreateWorkspaceOnDashboardTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="createWorkspaceOnDashboardTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRefreshTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkRestoreStateOfProjectTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRenameWorkspaceTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkProjectAfterRenameWs"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterWorkspaceRestartTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkAviabilityPerformingCommands"/>
-
-                    <!-- unstable -->
-                    <exclude name="checkProjectAfterStopStartWs"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.SnapshotTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="snapshotTest"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.WorkingWithJavaMySqlStackTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkJavaMySqlAndRunApp"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="checkNodeJsWsAndRunApp"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest">
-                <methods>
-                    <!-- unstable -->
-                    <exclude name="ensureWorkspaceStartsFromOfficialUbuntuImage"/>
-
-                    <!-- unstable -->
-                    <exclude name="ensureWorkspaceStartsFromOfficialUbuntuImage46"/>
-                </methods>
-            </class>
+            <class name="org.eclipse.che.selenium.swagger.SwaggerTest"/>
+            <class name="com.codenvy.selenium.vsts.CheckWorkWithVSTSProviderTest"/>
+            <class name="com.codenvy.selenium.workspaces.CheckStoppingWsByTimeoutTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.CheckStopStartWsTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.CreateWorkspaceOnDashboardTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRefreshTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRenameWorkspaceTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterWorkspaceRestartTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.SnapshotTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.WorkingWithJavaMySqlStackTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest"/>
+            <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
### What does this PR do?
It removes code which aimed to separate selenium tests on three groups: stable/unstable/failed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7508